### PR TITLE
fix(server-kernel): seed workspace structure only into a fresh workspace

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -499,6 +499,51 @@ jobs:
           fi
           echo "UI is serving the SPA shell"
           echo "Smoke test passed: server, internal-service, ui all up"
+      - name: Persistence - restarting the server must not duplicate the workspace tree
+        # THE gap that let the structure-duplication bug ship. Every other test runs the server
+        # on the IN-MEMORY backend, where each boot legitimately starts from an empty store - so
+        # seeding-on-every-boot is indistinguishable from correct behaviour and no unit test can
+        # see the bug. Only a real restart against a real filesystem backend exposes it, and
+        # `docker-compose.production.yml` is the only place the server runs that way.
+        #
+        # The server container from the smoke test above is already running with
+        # WORKSPACE_BACKEND=filesystem on the `server_data` volume. Restart it against that SAME
+        # volume and assert it did not seed a second copy of the office/room tree.
+        env:
+          WORKSPACE_MASTER_PASSWORD: 'ci-smoke-test'
+          INTERNAL_SERVICE_PORT: '12345'
+        run: |
+          set -euo pipefail
+          compose="docker compose -f docker-compose.production.yml"
+
+          offices_before=$($compose logs server 2>&1 | grep -c "Creating office node" || true)
+          rooms_before=$($compose logs server 2>&1 | grep -c "Creating room node" || true)
+          echo "Before restart: ${offices_before} office / ${rooms_before} room creations."
+
+          if [ "$offices_before" -eq 0 ]; then
+            echo "::error::The server seeded no offices at all, so this check would be vacuous."
+            $compose logs server 2>&1 | tail -40
+            exit 1
+          fi
+
+          echo "Restarting the server against the same data volume..."
+          $compose restart server
+          timeout 180 bash -c 'until docker compose -f docker-compose.production.yml ps server --format json | grep -qw healthy; do sleep 5; done' || {
+            echo "::error::Server did not come back healthy after restart"
+            $compose logs server 2>&1 | tail -40
+            exit 1
+          }
+
+          offices_after=$($compose logs server 2>&1 | grep -c "Creating office node" || true)
+          rooms_after=$($compose logs server 2>&1 | grep -c "Creating room node" || true)
+          echo "After restart:  ${offices_after} office / ${rooms_after} room creations."
+
+          if [ "$offices_after" -ne "$offices_before" ] || [ "$rooms_after" -ne "$rooms_before" ]; then
+            echo "::error::Restart re-seeded the workspace: offices ${offices_before} -> ${offices_after}, rooms ${rooms_before} -> ${rooms_after}. On a persistent backend this grows an extra copy of the whole tree on EVERY deploy."
+            $compose logs server 2>&1 | grep -E "Creating (office|room) node" | tail -20
+            exit 1
+          fi
+          echo "PASS: restart added no duplicate offices or rooms."
       - name: Dump Logs on Failure
         if: failure()
         run: |

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -516,17 +516,23 @@ jobs:
           set -euo pipefail
           compose="docker compose -f docker-compose.production.yml"
 
-          offices_before=$($compose logs server 2>&1 | grep -c "Creating office node" || true)
-          rooms_before=$($compose logs server 2>&1 | grep -c "Creating room node" || true)
-          echo "Before restart: ${offices_before} office / ${rooms_before} room creations."
-
-          if [ "$offices_before" -eq 0 ]; then
+          # Guard against a vacuous pass: if the FIRST boot seeded nothing, "the restart created
+          # nothing" would be trivially true and would prove nothing.
+          seeded_on_first_boot=$($compose logs server 2>&1 | grep -c "Creating office node" || true)
+          echo "First boot seeded ${seeded_on_first_boot} offices."
+          if [ "$seeded_on_first_boot" -eq 0 ]; then
             echo "::error::The server seeded no offices at all, so this check would be vacuous."
             $compose logs server 2>&1 | tail -40
             exit 1
           fi
 
-          echo "Restarting the server against the same data volume..."
+          # Only inspect logs emitted AFTER the restart. Comparing cumulative counts before/after
+          # would couple the result to docker's log buffering and rotation: if the daemon dropped
+          # early lines, the "after" count could come out LOWER and the check would misfire. A
+          # `--since` window asks the precise question instead - "did this boot create any office
+          # or room nodes?" - and the answer must be no.
+          restart_at=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+          echo "Restarting the server against the same data volume (window starts ${restart_at})..."
           $compose restart server
           timeout 180 bash -c 'until docker compose -f docker-compose.production.yml ps server --format json | grep -qw healthy; do sleep 5; done' || {
             echo "::error::Server did not come back healthy after restart"
@@ -534,16 +540,24 @@ jobs:
             exit 1
           }
 
-          offices_after=$($compose logs server 2>&1 | grep -c "Creating office node" || true)
-          rooms_after=$($compose logs server 2>&1 | grep -c "Creating room node" || true)
-          echo "After restart:  ${offices_after} office / ${rooms_after} room creations."
+          created_after_restart=$($compose logs server --since "$restart_at" 2>&1 | grep -cE "Creating (office|room) node" || true)
+          echo "Nodes created by the restarted server: ${created_after_restart}"
 
-          if [ "$offices_after" -ne "$offices_before" ] || [ "$rooms_after" -ne "$rooms_before" ]; then
-            echo "::error::Restart re-seeded the workspace: offices ${offices_before} -> ${offices_after}, rooms ${rooms_before} -> ${rooms_after}. On a persistent backend this grows an extra copy of the whole tree on EVERY deploy."
-            $compose logs server 2>&1 | grep -E "Creating (office|room) node" | tail -20
+          if [ "$created_after_restart" -ne 0 ]; then
+            echo "::error::The restart re-seeded the workspace: it created ${created_after_restart} office/room nodes on top of the existing tree. On a persistent backend this grows an extra copy of the whole tree on EVERY deploy."
+            $compose logs server --since "$restart_at" 2>&1 | grep -E "Creating (office|room) node" | head -20
             exit 1
           fi
-          echo "PASS: restart added no duplicate offices or rooms."
+
+          # Positive confirmation, not just an absence: the guard must actually have run and said
+          # so. Without this, a server that failed to reach the seeding code at all would also
+          # produce zero creations and pass.
+          if ! $compose logs server --since "$restart_at" 2>&1 | grep -q "already seeded; skipping"; then
+            echo "::error::The restarted server never reported skipping the seed. It may not have reached the guard at all - this check cannot confirm the behaviour."
+            $compose logs server --since "$restart_at" 2>&1 | tail -30
+            exit 1
+          fi
+          echo "PASS: the restart created no offices or rooms, and the seed-once guard fired."
       - name: Dump Logs on Failure
         if: failure()
         run: |

--- a/citadel-workspace-server-kernel/src/kernel/async_kernel.rs
+++ b/citadel-workspace-server-kernel/src/kernel/async_kernel.rs
@@ -312,10 +312,20 @@ impl<R: Ratchet + Send + Sync + 'static> AsyncWorkspaceServerKernel<R> {
             //
             // So the marker goes first. A pending marker with no workspace is a harmless, self-
             // healing state; a workspace with no marker is a permanent one.
-            self.domain_operations
-                .backend_tx_manager
-                .mark_structure_seed_pending()
-                .await?;
+            //
+            // Armed ONLY when there is actually a structure to seed. `on_start` calls
+            // `initialize_workspace_structure` only when a structure is configured, so arming it
+            // unconditionally would leave a permanently-pending marker on a server booted without
+            // one. A later deploy that ADDED a structure config would then find `pending == true`
+            // against a workspace that has been live for weeks, and inject the baked-in defaults
+            // into it - an established workspace, which is exactly what this guard exists to
+            // prevent. The obligation only exists if something is going to discharge it.
+            if self.workspace_structure.is_some() {
+                self.domain_operations
+                    .backend_tx_manager
+                    .mark_structure_seed_pending()
+                    .await?;
+            }
 
             // Debug: Check current storage mode
             if self.domain_operations.backend_tx_manager.is_test_mode() {
@@ -630,13 +640,21 @@ impl<R: Ratchet + Send + Sync + 'static> AsyncWorkspaceServerKernel<R> {
             .values()
             .any(|node| node.parent_id.as_deref() == Some(crate::WORKSPACE_ROOT_ID))
         {
+            // A tree exists while a seed is still owed: the previous boot wrote the nodes but died
+            // before recording that it had. Finish that transition rather than half-completing it
+            // - mark it seeded AND discharge the obligation, so no dangling `pending` is left
+            // behind for a future reader to puzzle over.
             warn!(
                 target: "citadel",
-                "Workspace reported as new but already has a tree; refusing to seed over it"
+                "A seed is owed but the workspace already has a tree; recording it as seeded rather than seeding over it"
             );
             self.domain_operations
                 .backend_tx_manager
                 .mark_structure_seeded()
+                .await?;
+            self.domain_operations
+                .backend_tx_manager
+                .clear_structure_seed_pending()
                 .await?;
             return Ok(());
         }
@@ -837,12 +855,24 @@ impl<R: Ratchet + Send + Sync + 'static> AsyncWorkspaceServerKernel<R> {
             .mark_structure_seeded()
             .await?;
         // The debt is paid. `seeded` already takes precedence over `pending` on every later boot,
-        // so this is hygiene rather than correctness - it keeps the store from carrying a
-        // permanently-true "pending" flag that a future reader would have to reason about.
-        self.domain_operations
+        // so clearing it is hygiene, not correctness - it keeps the store from carrying a
+        // permanently-true flag that a future reader would have to reason about.
+        //
+        // Deliberately BEST-EFFORT. The tree is durably written and the workspace is durably
+        // marked seeded; failing the boot now over a cosmetic write would turn a completed seed
+        // into a crash loop, and the next boot would short-circuit on `seeded` anyway.
+        if let Err(e) = self
+            .domain_operations
             .backend_tx_manager
             .clear_structure_seed_pending()
-            .await?;
+            .await
+        {
+            warn!(
+                target: "citadel",
+                "Workspace seeded successfully, but could not clear the seed-pending marker: {e}. \
+                 Harmless - the seeded marker takes precedence on every later boot."
+            );
+        }
 
         info!(target: "citadel", "Workspace structure initialization complete");
         Ok(())
@@ -1495,7 +1525,19 @@ mod structure_seed_idempotency_tests {
 
     type Kernel = AsyncWorkspaceServerKernel<StackedRatchet>;
 
+    /// A kernel wired the way a real server is: it HAS a structure configured, so
+    /// `inject_admin_user` takes on a seed obligation when it creates a fresh workspace. Setting
+    /// the field directly (rather than going through the async constructor) keeps the tests off
+    /// the filesystem while still exercising the production wiring.
     fn kernel() -> Kernel {
+        let mut k = AsyncWorkspaceServerKernel::<StackedRatchet>::new(None);
+        k.workspace_structure = Some((one_office_one_room(), None));
+        k
+    }
+
+    /// A kernel with NO structure configured, as a server whose kernel.toml sets no content
+    /// directory would be.
+    fn kernel_without_structure() -> Kernel {
         AsyncWorkspaceServerKernel::<StackedRatchet>::new(None)
     }
 
@@ -1825,6 +1867,37 @@ mod structure_seed_idempotency_tests {
         assert!(
             backend.is_structure_seeded().await.unwrap(),
             "the workspace should now be marked seeded"
+        );
+    }
+
+    /// A server booted with NO structure configured must not arm a seed obligation.
+    ///
+    /// `on_start` only calls `initialize_workspace_structure` when a structure is configured, so
+    /// an obligation armed on such a boot would never be discharged - it would sit there while the
+    /// workspace ran and accumulated real content, and the first deploy that ADDED a structure
+    /// config would find `pending == true` and inject the baked-in defaults into an established
+    /// workspace. The obligation may only be taken on if something is going to discharge it.
+    #[tokio::test]
+    async fn no_structure_config_means_no_seed_obligation() {
+        let k = kernel_without_structure();
+        assert!(
+            k.workspace_structure.is_none(),
+            "precondition: this kernel has no structure configured"
+        );
+
+        k.inject_admin_user(MASTER_PASSWORD)
+            .await
+            .expect("inject_admin_user");
+
+        assert!(
+            !k.domain_operations
+                .backend_tx_manager
+                .is_structure_seed_pending()
+                .await
+                .expect("read pending"),
+            "a seed obligation was armed on a server with nothing to seed. It would never be \
+             discharged, and a later deploy that added a structure config would inject the \
+             defaults into this by-then-established workspace."
         );
     }
 

--- a/citadel-workspace-server-kernel/src/kernel/async_kernel.rs
+++ b/citadel-workspace-server-kernel/src/kernel/async_kernel.rs
@@ -527,6 +527,20 @@ impl<R: Ratchet + Send + Sync + 'static> AsyncWorkspaceServerKernel<R> {
         // leaves a legitimately empty tree, and a contents-based check would then resurrect
         // the baked-in defaults on the next restart - re-applying config over structure the
         // users deliberately removed, which is exactly the contract above.
+        // CONCURRENCY: this is a check-then-act, and it is safe because the workspace server is
+        // a SINGLE-WRITER process. `on_start` is a once-per-process NetKernel lifecycle hook,
+        // and the server is one container owning one TCP listener - a second instance against
+        // the same backend cannot even bind. There is deliberately no compare-and-set here:
+        // the backend surface is a plain get/put over the SDK's `BackendHandler` (no CAS
+        // primitive exists to build on), and every other persisted sentinel in this kernel -
+        // `KEY_MIGRATION_DONE` in `migrate_if_needed`, and the schema-version get/set later in
+        // this same `on_start` - has exactly the same shape.
+        //
+        // If multi-process servers over one backend are ever introduced, this marker is NOT the
+        // thing to fix first: every node mutation is a load-mutate-save of the single
+        // `citadel_workspace.nodes` key with no cross-process locking, so concurrent writers
+        // would lose whole subtrees regardless of how this guard is written. That would need a
+        // backend-level locking story, not a special case here.
         if self
             .domain_operations
             .backend_tx_manager
@@ -545,6 +559,12 @@ impl<R: Ratchet + Send + Sync + 'static> AsyncWorkspaceServerKernel<R> {
         // duplicate its entire tree on the next boot - reintroducing the very bug this guard
         // exists to prevent. Any node parented to the workspace root proves a tree is already
         // established (config-seeded or user-created): record the marker and leave it alone.
+        //
+        // This path is crash-safe by construction: it writes ONLY the marker, and only when a
+        // tree already exists. It never writes nodes, so there is no partial state to unwind.
+        // A crash between reading `nodes` and writing the marker simply leaves the store as it
+        // was; the next boot re-reads the same tree and writes the marker then. Re-running it is
+        // a no-op, so a stale snapshot cannot cause incorrect behaviour - at worst it repeats.
         if nodes
             .values()
             .any(|node| node.parent_id.as_deref() == Some(crate::WORKSPACE_ROOT_ID))

--- a/citadel-workspace-server-kernel/src/kernel/async_kernel.rs
+++ b/citadel-workspace-server-kernel/src/kernel/async_kernel.rs
@@ -297,6 +297,26 @@ impl<R: Ratchet + Send + Sync + 'static> AsyncWorkspaceServerKernel<R> {
         if !workspace_exists {
             info!(target: "citadel", "Creating root workspace with no owner (first user with master password becomes admin)");
 
+            // Record the seed obligation BEFORE any of the durable writes below.
+            //
+            // ORDER IS THE WHOLE POINT. These are independent backend writes with no transaction
+            // around them, so whichever runs first defines the failure mode of the gap between
+            // them, and the two orderings are NOT symmetric:
+            //
+            //   * marker, then workspace - if we die in between, the next boot sees no workspace,
+            //     creates it, and (the marker being already set) seeds it. RECOVERABLE.
+            //   * workspace, then marker - if we die in between, the next boot sees a workspace
+            //     with NEITHER marker. That is indistinguishable from an established pre-marker
+            //     store, so the back-fill in `initialize_workspace_structure` stamps it "seeded"
+            //     and the workspace is left with no offices FOREVER. UNRECOVERABLE.
+            //
+            // So the marker goes first. A pending marker with no workspace is a harmless, self-
+            // healing state; a workspace with no marker is a permanent one.
+            self.domain_operations
+                .backend_tx_manager
+                .mark_structure_seed_pending()
+                .await?;
+
             // Debug: Check current storage mode
             if self.domain_operations.backend_tx_manager.is_test_mode() {
                 warn!(target: "citadel", "Creating workspace in test storage mode!");
@@ -338,16 +358,6 @@ impl<R: Ratchet + Send + Sync + 'static> AsyncWorkspaceServerKernel<R> {
             self.domain_operations
                 .backend_tx_manager
                 .set_workspace_password(crate::WORKSPACE_ROOT_ID, workspace_master_password)
-                .await?;
-
-            // Record that this brand-new workspace still owes its initial structure. Written
-            // HERE, at creation, so the obligation survives a crash: if the boot dies before the
-            // tree is written, the next boot still sees the marker and finishes the job. Without
-            // it, such a store is indistinguishable from an established pre-marker workspace and
-            // would be permanently left with no offices.
-            self.domain_operations
-                .backend_tx_manager
-                .mark_structure_seed_pending()
                 .await?;
 
             info!(target: "citadel", "Root workspace created successfully (awaiting first admin)");
@@ -1767,6 +1777,54 @@ mod structure_seed_idempotency_tests {
                 .await
                 .expect("read pending"),
             "the pending marker must be cleared once the debt is paid"
+        );
+    }
+
+    /// The seed obligation must be recorded BEFORE the root workspace is persisted.
+    ///
+    /// The two writes are independent (no transaction spans them), so the gap between them has a
+    /// failure mode - and the orderings are not symmetric. Marker-then-workspace leaves a store
+    /// with a marker and no workspace, which self-heals: the next boot creates the workspace and
+    /// seeds it. Workspace-then-marker leaves a store with a workspace and NO marker, which is
+    /// indistinguishable from an established pre-marker store, so the back-fill stamps it "seeded"
+    /// and it is left with no offices forever.
+    ///
+    /// This test pins the recoverable ordering by reproducing the interrupted state directly: the
+    /// marker is set, the workspace was never created, and a subsequent boot must still produce a
+    /// fully seeded workspace.
+    #[tokio::test]
+    async fn seed_obligation_is_recorded_before_the_workspace_is_persisted() {
+        let k = kernel();
+        let backend = &k.domain_operations.backend_tx_manager;
+
+        // Reproduce a first boot that died between the two writes, in the SAFE order: the
+        // obligation was recorded, the workspace never made it.
+        backend
+            .mark_structure_seed_pending()
+            .await
+            .expect("mark pending");
+        assert!(
+            k.get_domain(crate::WORKSPACE_ROOT_ID)
+                .await
+                .expect("read domain")
+                .is_none(),
+            "precondition: the workspace was never persisted"
+        );
+
+        // The next boot must finish the job rather than give up.
+        boot(&k, &one_office_one_room()).await;
+
+        let after = nodes(&k).await;
+        assert!(
+            after.values().any(|n| n.name == "General"),
+            "a first boot interrupted between recording the obligation and persisting the \
+             workspace was not recovered: the workspace has {} nodes. Recording the obligation \
+             first is what makes that gap self-healing.",
+            after.len()
+        );
+        assert!(
+            backend.is_structure_seeded().await.unwrap(),
+            "the workspace should now be marked seeded"
         );
     }
 

--- a/citadel-workspace-server-kernel/src/kernel/async_kernel.rs
+++ b/citadel-workspace-server-kernel/src/kernel/async_kernel.rs
@@ -271,14 +271,14 @@ impl<R: Ratchet + Send + Sync + 'static> AsyncWorkspaceServerKernel<R> {
     /// Initialize the root workspace. Note that this does NOT create any admin user.
     /// The first real user to provide the master password via UpdateWorkspace becomes the admin/owner.
     ///
-    /// Returns `true` if the root workspace was created by this call (i.e. the backend held no
-    /// workspace at all), and `false` if it already existed. Callers use that to tell a
-    /// brand-new deployment apart from an established one - see
-    /// [`Self::initialize_workspace_structure`].
+    /// When this call CREATES the root workspace (i.e. the backend held no workspace at all), it
+    /// also records a durable "structure seed pending" marker. That marker is what
+    /// [`Self::initialize_workspace_structure`] uses to tell a brand-new deployment apart from
+    /// an established one, and it is what makes an interrupted first boot recoverable.
     pub async fn inject_admin_user(
         &self,
         workspace_master_password: &str,
-    ) -> Result<bool, NetworkError> {
+    ) -> Result<(), NetworkError> {
         info!(target: "citadel", "Initializing root workspace (no pre-created admin user)");
 
         // Pre-populate the master password BEFORE any workspace checks
@@ -340,15 +340,20 @@ impl<R: Ratchet + Send + Sync + 'static> AsyncWorkspaceServerKernel<R> {
                 .set_workspace_password(crate::WORKSPACE_ROOT_ID, workspace_master_password)
                 .await?;
 
+            // Record that this brand-new workspace still owes its initial structure. Written
+            // HERE, at creation, so the obligation survives a crash: if the boot dies before the
+            // tree is written, the next boot still sees the marker and finishes the job. Without
+            // it, such a store is indistinguishable from an established pre-marker workspace and
+            // would be permanently left with no offices.
+            self.domain_operations
+                .backend_tx_manager
+                .mark_structure_seed_pending()
+                .await?;
+
             info!(target: "citadel", "Root workspace created successfully (awaiting first admin)");
         }
 
-        // Report whether the root workspace was created by THIS call. That is the only
-        // trustworthy "is this a brand-new workspace?" signal available to
-        // `initialize_workspace_structure`: by the time it runs, the root workspace always
-        // exists (this function just made sure of it), and the node contents cannot tell a
-        // new workspace apart from an established one whose offices were all deleted.
-        Ok(!workspace_exists)
+        Ok(())
     }
 
     /// Get a reference to the async domain operations
@@ -487,15 +492,14 @@ impl<R: Ratchet + Send + Sync + 'static> AsyncWorkspaceServerKernel<R> {
     /// Creates offices and rooms as defined in the WorkspaceStructureConfig.
     /// Each office/room with chat_enabled=true gets a UUID for its chat channel.
     ///
-    /// `workspace_is_new` must be the value returned by [`Self::inject_admin_user`] on this
-    /// same boot: `true` only when the root workspace did not previously exist. The configured
-    /// structure is seeded ONLY into such a workspace. It is not enough to look at the node
-    /// contents - see the guard below.
+    /// The configured structure is seeded ONLY into a workspace that has never been seeded. The
+    /// decision is driven entirely by durable markers written by [`Self::inject_admin_user`] -
+    /// never by the node contents, which cannot distinguish a brand-new workspace from an
+    /// established one whose offices were all deleted.
     pub async fn initialize_workspace_structure(
         &self,
         config: &WorkspaceStructureConfig,
         base_path: Option<&std::path::Path>,
-        workspace_is_new: bool,
     ) -> Result<(), NetworkError> {
         use citadel_workspace_types::structs::{DomainNode, NodeEntityType};
         use uuid::Uuid;
@@ -570,25 +574,37 @@ impl<R: Ratchet + Send + Sync + 'static> AsyncWorkspaceServerKernel<R> {
             return Ok(());
         }
 
-        // Back-fill for stores written before the marker existed: an established workspace
-        // carries no marker, so a marker-only check would treat it as fresh and duplicate its
-        // entire tree - reintroducing the very bug this guard exists to prevent.
+        // Not seeded. Does this workspace still OWE a seed?
         //
-        // The test for "established" is that the root workspace ALREADY EXISTED before this
-        // boot, NOT that the node map currently has contents. Those are different facts, and
-        // conflating them is a trap: an established workspace whose offices were all deleted by
-        // an admin has an empty node map, and a contents-based check would read that as "fresh"
-        // and resurrect the baked-in defaults on upgrade - precisely the deletion-must-survive
-        // contract this PR exists to uphold. `inject_admin_user` reports the creation fact
-        // directly, so use that.
-        //
-        // This path is crash-safe by construction: it writes ONLY the marker, never nodes, so
-        // there is no partial state to unwind. A crash before the marker write leaves the store
-        // exactly as it was, and the next boot reaches the same conclusion and writes it then.
-        if !workspace_is_new {
+        // `inject_admin_user` writes the pending marker at the moment it creates a brand-new root
+        // workspace, so this is true for a fresh install - and, crucially, it STAYS true if that
+        // first boot never finished. A crash (or even a transient failure of the node write,
+        // which aborts `on_start` and restarts the container) between creating the root workspace
+        // and writing the tree would otherwise leave a store that looks exactly like an
+        // established pre-marker workspace: no seeded marker, no offices. The back-fill below
+        // would then stamp it as seeded and it would be left with NO offices, permanently. The
+        // pending marker is what makes that first boot resumable.
+        let seed_pending = self
+            .domain_operations
+            .backend_tx_manager
+            .is_structure_seed_pending()
+            .await?;
+
+        if !seed_pending {
+            // Neither marker is present, so this store predates both: an established workspace
+            // from before this logic existed. Back-fill the seeded marker and leave it alone.
+            //
+            // This must NOT be decided from the node contents. An established workspace whose
+            // offices were all deleted by an admin has an empty node map too, and reading that as
+            // "fresh" would resurrect the baked-in defaults on upgrade - precisely the
+            // deletion-must-survive contract this guard exists to uphold.
+            //
+            // Crash-safe by construction: it writes ONLY the marker, never nodes, so there is no
+            // partial state to unwind. A crash before the write leaves the store exactly as it
+            // was and the next boot reaches the same conclusion.
             info!(
                 target: "citadel",
-                "Established workspace predates the seed marker; recording marker and skipping re-seed"
+                "Established workspace predates the seed markers; recording marker and skipping re-seed"
             );
             self.domain_operations
                 .backend_tx_manager
@@ -597,9 +613,9 @@ impl<R: Ratchet + Send + Sync + 'static> AsyncWorkspaceServerKernel<R> {
             return Ok(());
         }
 
-        // Defence in depth: even if a caller claims the workspace is new, an existing tree
-        // proves otherwise. This can only ever ADD a skip, never cause a seed, so it is safe to
-        // keep as a guard against a future caller passing the flag incorrectly.
+        // Defence in depth: a seed is owed, but an existing tree proves the workspace is not
+        // actually empty. Never inject defaults on top of a tree. This can only ever ADD a skip,
+        // never cause a seed, so it is safe to keep.
         if nodes
             .values()
             .any(|node| node.parent_id.as_deref() == Some(crate::WORKSPACE_ROOT_ID))
@@ -804,11 +820,18 @@ impl<R: Ratchet + Send + Sync + 'static> AsyncWorkspaceServerKernel<R> {
             .await?;
 
         // Record the seed only AFTER the nodes are durably written. If `save_nodes` fails we
-        // return early without a marker, so the next boot retries the seed rather than marking
-        // a workspace as seeded that has no structure in it.
+        // return early WITHOUT touching either marker, so the store keeps its pending marker and
+        // the next boot resumes the seed rather than stamping an empty workspace as done.
         self.domain_operations
             .backend_tx_manager
             .mark_structure_seeded()
+            .await?;
+        // The debt is paid. `seeded` already takes precedence over `pending` on every later boot,
+        // so this is hygiene rather than correctness - it keeps the store from carrying a
+        // permanently-true "pending" flag that a future reader would have to reason about.
+        self.domain_operations
+            .backend_tx_manager
+            .clear_structure_seed_pending()
             .await?;
 
         info!(target: "citadel", "Workspace structure initialization complete");
@@ -851,19 +874,14 @@ impl<R: Ratchet + Send + Sync + 'static> citadel_sdk::prelude::NetKernel<R>
             // Re-run admin injection now that NodeRemote is available
             if let Some(workspace_password) = &self.workspace_password {
                 info!(target: "citadel", "Injecting admin and workspace");
-                // `true` only when the root workspace did not exist and was created just now -
-                // i.e. this backend is brand new. Anything else is an established deployment.
-                let workspace_is_new = self.inject_admin_user(workspace_password).await?;
+                // Records the "seed pending" marker if this creates a brand-new workspace.
+                self.inject_admin_user(workspace_password).await?;
 
                 // Initialize workspace structure from config if provided
                 if let Some((structure, base_path)) = &self.workspace_structure {
                     info!(target: "citadel", "Initializing workspace structure from config");
-                    self.initialize_workspace_structure(
-                        structure,
-                        base_path.as_deref(),
-                        workspace_is_new,
-                    )
-                    .await?;
+                    self.initialize_workspace_structure(structure, base_path.as_deref())
+                        .await?;
                 }
             }
         }
@@ -1443,20 +1461,33 @@ mod content_segment_tests {
 mod structure_seed_idempotency_tests {
     //! Regression tests for the seed-once guard in `initialize_workspace_structure`.
     //!
-    //! `on_start` invokes that function on EVERY boot. Before the guard, it minted fresh
-    //! UUIDs and appended, so a server on a persistent (filesystem) backend gained a
-    //! complete duplicate of every office and room on each restart - and `deploy.sh`
-    //! restarts the server on every deploy, so a live workspace would visibly corrupt
-    //! itself over time. Reproduced on real hardware: boot 1 created 3 offices / 8 rooms,
-    //! boot 2 against the same volume took it to 6 / 16.
+    //! `on_start` invokes that function on EVERY boot. Before the guard, it minted fresh UUIDs
+    //! and appended, so a server on a persistent (filesystem) backend gained a complete duplicate
+    //! of every office and room on each restart - and `deploy.sh` restarts the server on every
+    //! deploy, so a live workspace would visibly corrupt itself over time. Reproduced on real
+    //! hardware: boot 1 created 3 offices / 8 rooms, boot 2 against the same volume took it to
+    //! 6 / 16.
     //!
-    //! Nothing caught this because dev and CI run the server on the in-memory backend,
-    //! where every boot legitimately starts from an empty store. These tests close that
-    //! gap by seeding twice against a single store - the unit-test equivalent of a restart.
+    //! Nothing caught this because dev and CI run the server on the in-memory backend, where
+    //! every boot legitimately starts from an empty store.
+    //!
+    //! These tests drive the REAL boot sequence - `inject_admin_user` followed by
+    //! `initialize_workspace_structure`, exactly as `on_start` does - rather than hand-feeding the
+    //! seed decision. That matters: the decision now lives in durable markers written by
+    //! `inject_admin_user`, so a mistake in ITS workspace-exists detection would break production
+    //! while leaving a hand-fed test green.
     use super::*;
     use crate::config::{OfficeConfig, RoomConfig};
     use citadel_sdk::prelude::StackedRatchet;
-    use citadel_workspace_types::structs::DomainPermissions;
+    use citadel_workspace_types::structs::{DomainNode, DomainPermissions};
+
+    const MASTER_PASSWORD: &str = "test-master-password";
+
+    type Kernel = AsyncWorkspaceServerKernel<StackedRatchet>;
+
+    fn kernel() -> Kernel {
+        AsyncWorkspaceServerKernel::<StackedRatchet>::new(None)
+    }
 
     fn one_office_one_room() -> WorkspaceStructureConfig {
         WorkspaceStructureConfig {
@@ -1483,11 +1514,56 @@ mod structure_seed_idempotency_tests {
         }
     }
 
-    /// A top-level office node, as a user-created or already-persisted tree would contain.
-    /// `parent_id == WORKSPACE_ROOT_ID` is what marks a node as top-level - the same predicate
-    /// the rest of the kernel uses to enumerate offices (see `async_node_ops.rs`).
-    fn office_node(id: &str, name: &str) -> citadel_workspace_types::structs::DomainNode {
-        citadel_workspace_types::structs::DomainNode {
+    /// One server boot, in the same order `on_start` performs it.
+    async fn boot(kernel: &Kernel, config: &WorkspaceStructureConfig) {
+        kernel
+            .inject_admin_user(MASTER_PASSWORD)
+            .await
+            .expect("inject_admin_user");
+        kernel
+            .initialize_workspace_structure(config, None)
+            .await
+            .expect("initialize_workspace_structure");
+    }
+
+    async fn nodes(kernel: &Kernel) -> std::collections::HashMap<String, DomainNode> {
+        kernel
+            .domain_operations
+            .backend_tx_manager
+            .get_all_nodes()
+            .await
+            .expect("read nodes")
+    }
+
+    /// A store established BEFORE either seed marker existed: it has a root workspace, but no
+    /// `structure_seeded` and no `structure_seed_pending`. This is what an upgraded deployment
+    /// looks like, and it must never be re-seeded.
+    async fn establish_pre_marker_workspace(kernel: &Kernel) {
+        let workspace = citadel_workspace_types::structs::Workspace {
+            id: crate::WORKSPACE_ROOT_ID.to_string(),
+            name: "Root Workspace".to_string(),
+            description: "An existing deployment".to_string(),
+            owner_id: UNASSIGNED_OWNER.to_string(),
+            members: vec![],
+            offices: vec![],
+            metadata: vec![],
+        };
+        let backend = &kernel.domain_operations.backend_tx_manager;
+        backend
+            .insert_workspace(crate::WORKSPACE_ROOT_ID.to_string(), workspace.clone())
+            .await
+            .expect("insert legacy workspace");
+        backend
+            .insert_domain(
+                crate::WORKSPACE_ROOT_ID.to_string(),
+                citadel_workspace_types::structs::Domain::Workspace { workspace },
+            )
+            .await
+            .expect("insert legacy domain");
+    }
+
+    fn office_node(id: &str, name: &str) -> DomainNode {
+        DomainNode {
             id: id.to_string(),
             parent_id: Some(crate::WORKSPACE_ROOT_ID.to_string()),
             entity_type: citadel_workspace_types::structs::NodeEntityType::Child(
@@ -1512,284 +1588,227 @@ mod structure_seed_idempotency_tests {
         }
     }
 
-    /// Deleting every office must NOT cause the defaults to be resurrected on the next boot.
-    ///
-    /// This is the case a contents-based guard ("does the root have children?") gets wrong: an
-    /// admin who removes every office leaves a legitimately empty tree, which such a guard reads
-    /// as "fresh" and re-seeds. Emptiness and never-seeded are different facts, and only the
-    /// durable marker distinguishes them.
+    /// The original bug: a restart must not deposit a second copy of the tree.
     #[tokio::test]
-    async fn deleting_every_office_does_not_resurrect_the_defaults() {
-        let kernel = AsyncWorkspaceServerKernel::<StackedRatchet>::new(None);
+    async fn second_boot_does_not_duplicate_the_tree() {
+        let k = kernel();
         let config = one_office_one_room();
 
-        // Boot 1: fresh workspace, seeds normally.
-        kernel
-            .initialize_workspace_structure(&config, None, true)
-            .await
-            .expect("first seed");
+        boot(&k, &config).await;
+        let after_first = nodes(&k).await;
+
+        boot(&k, &config).await; // the restart
+        let after_second = nodes(&k).await;
+
+        // Prove the test is not vacuous by NAME, not by a hardcoded count: if seeding silently
+        // produced nothing, the comparison below would be 0 == 0 and pass while testing nothing.
         assert!(
-            !kernel
-                .domain_operations
-                .backend_tx_manager
-                .get_all_nodes()
-                .await
-                .expect("read nodes")
-                .is_empty(),
-            "precondition: the first seed must have produced a tree"
+            after_first.values().any(|n| n.name == "General"),
+            "first boot did not create the configured office; the test would be vacuous"
+        );
+        assert!(
+            after_first.values().any(|n| n.name == "Random"),
+            "first boot did not create the configured room; the test would be vacuous"
+        );
+
+        assert_eq!(
+            after_second.len(),
+            after_first.len(),
+            "restart duplicated the tree ({} nodes -> {} nodes). On a filesystem backend this \
+             grows an extra copy of every office and room on every single deploy.",
+            after_first.len(),
+            after_second.len()
+        );
+
+        // Cardinality alone is not enough - a re-seed that also wiped the old tree would keep the
+        // count equal while silently rotating every UUID, dangling every stored reference.
+        let mut first: Vec<_> = after_first.keys().cloned().collect();
+        let mut second: Vec<_> = after_second.keys().cloned().collect();
+        first.sort();
+        second.sort();
+        assert_eq!(
+            first, second,
+            "node IDs changed across a restart; existing references would dangle"
+        );
+    }
+
+    /// Deleting every office is a deliberate act and must survive a restart.
+    #[tokio::test]
+    async fn deleting_every_office_does_not_resurrect_the_defaults() {
+        let k = kernel();
+        let config = one_office_one_room();
+
+        boot(&k, &config).await;
+        assert!(
+            !nodes(&k).await.is_empty(),
+            "precondition: first boot seeds"
         );
 
         // The admin deletes everything.
-        kernel
-            .domain_operations
+        k.domain_operations
             .backend_tx_manager
             .save_nodes(&std::collections::HashMap::new())
             .await
             .expect("delete every node");
 
-        // Boot 2: the workspace is empty, but it exists and has already been seeded once.
-        kernel
-            .initialize_workspace_structure(&config, None, false)
-            .await
-            .expect("seed against an emptied workspace");
+        boot(&k, &config).await;
 
-        let after = kernel
-            .domain_operations
-            .backend_tx_manager
-            .get_all_nodes()
-            .await
-            .expect("read nodes");
-
+        let after = nodes(&k).await;
         assert!(
             after.is_empty(),
-            "the baked-in defaults were resurrected into a workspace the admin had emptied \
-             ({} nodes reappeared). Config describes the INITIAL state of a new workspace; \
-             deleting every office is a deliberate act and must survive a restart.",
+            "the defaults were resurrected into a workspace the admin had emptied ({} nodes \
+             reappeared). Config describes the INITIAL state of a new workspace.",
             after.len()
         );
     }
 
-    /// A store written before the seed marker existed is already populated but carries no
-    /// marker. It must be recognised as seeded and back-filled - NOT treated as fresh, which
-    /// would duplicate its entire tree on the next boot (the original bug).
+    /// An ESTABLISHED workspace that predates the markers AND was emptied by an admin must not be
+    /// re-seeded on upgrade. This is the case a contents-based check gets wrong: it has no marker
+    /// and no offices, so "is the tree empty?" reads it as brand new.
     #[tokio::test]
-    async fn preexisting_tree_without_marker_is_backfilled_not_reseeded() {
-        let kernel = AsyncWorkspaceServerKernel::<StackedRatchet>::new(None);
+    async fn emptied_pre_marker_workspace_is_not_reseeded_on_upgrade() {
+        let k = kernel();
+        establish_pre_marker_workspace(&k).await;
 
-        // Simulate an upgraded deployment: a populated tree, but no marker was ever written.
-        let mut nodes = std::collections::HashMap::new();
-        nodes.insert(
+        boot(&k, &one_office_one_room()).await;
+
+        let after = nodes(&k).await;
+        assert!(
+            after.is_empty(),
+            "the defaults were resurrected into an established workspace that an admin had \
+             emptied ({} nodes reappeared). An empty tree is not the same fact as a NEW workspace.",
+            after.len()
+        );
+        assert!(
+            k.domain_operations
+                .backend_tx_manager
+                .is_structure_seeded()
+                .await
+                .expect("read marker"),
+            "the seeded marker must be back-filled so later boots take the cheap path"
+        );
+    }
+
+    /// A populated pre-marker store must be recognised as established, not duplicated.
+    #[tokio::test]
+    async fn populated_pre_marker_workspace_is_backfilled_not_reseeded() {
+        let k = kernel();
+        establish_pre_marker_workspace(&k).await;
+
+        let mut existing = std::collections::HashMap::new();
+        existing.insert(
             "legacy-office".to_string(),
             office_node("legacy-office", "Engineering"),
         );
-        kernel
-            .domain_operations
+        k.domain_operations
             .backend_tx_manager
-            .save_nodes(&nodes)
+            .save_nodes(&existing)
             .await
-            .expect("seed a legacy tree");
-        assert!(
-            !kernel
-                .domain_operations
-                .backend_tx_manager
-                .is_structure_seeded()
-                .await
-                .expect("read marker"),
-            "precondition: a legacy store carries no marker"
-        );
+            .expect("save legacy tree");
 
-        kernel
-            .initialize_workspace_structure(&one_office_one_room(), None, false)
-            .await
-            .expect("boot against a legacy store");
+        boot(&k, &one_office_one_room()).await;
 
-        let after = kernel
-            .domain_operations
-            .backend_tx_manager
-            .get_all_nodes()
-            .await
-            .expect("read nodes");
-
+        let after = nodes(&k).await;
         assert_eq!(
             after.len(),
             1,
-            "a pre-marker workspace was re-seeded and now has {} nodes. Treating a populated \
-             store as fresh just because it predates the marker reintroduces the duplication bug.",
+            "a pre-marker workspace was re-seeded and now has {} nodes",
             after.len()
         );
         assert!(
-            kernel
-                .domain_operations
-                .backend_tx_manager
-                .is_structure_seeded()
-                .await
-                .expect("read marker"),
-            "the marker must be back-filled so the check is cheap on every later boot"
+            after.contains_key("legacy-office"),
+            "the existing office must survive untouched"
         );
     }
 
-    /// An ESTABLISHED workspace that predates the marker AND has been emptied by an admin must
-    /// not be re-seeded on upgrade.
+    /// A first boot that dies before the tree is written must be RESUMED, not abandoned.
     ///
-    /// This is the case a contents-based back-fill gets wrong. Such a store has no marker (it
-    /// predates it) and no root children (the admin deleted them), so inferring "legacy" from
-    /// node contents reads it as a brand-new workspace and resurrects the baked-in defaults -
-    /// the exact deletion-must-survive contract this guard exists to uphold. Only the
-    /// "did the root workspace already exist?" fact distinguishes the two.
+    /// The root workspace exists but no structure was ever saved. Without the pending marker that
+    /// store is indistinguishable from an established pre-marker workspace, so the back-fill would
+    /// stamp it "seeded" and it would be left with no offices forever. Note this needs no crash to
+    /// trigger: a transient failure of the node write aborts `on_start`, and the container simply
+    /// restarts into exactly this state.
     #[tokio::test]
-    async fn emptied_legacy_workspace_is_not_reseeded_on_upgrade() {
-        let kernel = AsyncWorkspaceServerKernel::<StackedRatchet>::new(None);
-
-        // A pre-marker deployment whose offices were all deleted: no marker, no nodes, but the
-        // workspace itself is long-established (so `inject_admin_user` reports `false`).
-        assert!(
-            !kernel
-                .domain_operations
-                .backend_tx_manager
-                .is_structure_seeded()
-                .await
-                .expect("read marker"),
-            "precondition: a pre-marker store carries no marker"
-        );
-
-        kernel
-            .initialize_workspace_structure(&one_office_one_room(), None, false)
-            .await
-            .expect("upgrade boot against an emptied legacy store");
-
-        let after = kernel
-            .domain_operations
-            .backend_tx_manager
-            .get_all_nodes()
-            .await
-            .expect("read nodes");
-
-        assert!(
-            after.is_empty(),
-            "the baked-in defaults were resurrected into an established workspace that an admin \
-             had emptied ({} nodes reappeared). An empty tree is not the same fact as a NEW \
-             workspace; only the root-workspace-creation signal distinguishes them.",
-            after.len()
-        );
-        assert!(
-            kernel
-                .domain_operations
-                .backend_tx_manager
-                .is_structure_seeded()
-                .await
-                .expect("read marker"),
-            "the marker must be back-filled so later boots take the cheap path"
-        );
-    }
-
-    /// Seeding twice against one store must be a no-op the second time.
-    #[tokio::test]
-    async fn second_seed_does_not_duplicate_the_tree() {
-        let kernel = AsyncWorkspaceServerKernel::<StackedRatchet>::new(None);
+    async fn interrupted_first_boot_is_resumed_not_abandoned() {
+        let k = kernel();
         let config = one_office_one_room();
 
-        kernel
-            .initialize_workspace_structure(&config, None, true)
+        // Boot 1 creates the root workspace, then dies before seeding the structure.
+        k.inject_admin_user(MASTER_PASSWORD)
             .await
-            .expect("first seed");
-        let after_first = kernel
-            .domain_operations
-            .backend_tx_manager
-            .get_all_nodes()
-            .await
-            .expect("read nodes after first seed");
-
-        // The restart: same store. The root workspace now exists, so `inject_admin_user` would
-        // report the workspace as NOT new on this boot.
-        kernel
-            .initialize_workspace_structure(&config, None, false)
-            .await
-            .expect("second seed");
-        let after_second = kernel
-            .domain_operations
-            .backend_tx_manager
-            .get_all_nodes()
-            .await
-            .expect("read nodes after second seed");
-
-        // Assert the first seed produced the configured tree BY NAME rather than by a hardcoded
-        // node count. The point is only to prove the test is not vacuous: if seeding silently
-        // produced nothing, the idempotency assertion below would compare 0 against 0 and pass
-        // while testing nothing. Matching names keeps that guarantee without breaking if the
-        // storage layer ever persists an extra structural node (a root or wrapper), which would
-        // be unrelated to the regression under test.
+            .expect("inject_admin_user");
         assert!(
-            after_first.values().any(|n| n.name == "General"),
-            "fresh seed did not create the configured office; the test would be vacuous"
+            k.domain_operations
+                .backend_tx_manager
+                .is_structure_seed_pending()
+                .await
+                .expect("read pending"),
+            "creating a fresh workspace must record that it still owes a seed"
         );
         assert!(
-            after_first.values().any(|n| n.name == "Random"),
-            "fresh seed did not create the configured room; the test would be vacuous"
-        );
-        assert_eq!(
-            after_second.len(),
-            after_first.len(),
-            "restart duplicated the tree ({} nodes -> {} nodes). The seed-once guard in \
-             initialize_workspace_structure has regressed: on a filesystem backend this grows \
-             an extra copy of every office and room on every single deploy.",
-            after_first.len(),
-            after_second.len()
+            nodes(&k).await.is_empty(),
+            "precondition: nothing seeded yet"
         );
 
-        // Cardinality alone is not enough - a re-seed that also wiped the old tree would keep
-        // the count equal while silently rotating every UUID, breaking any stored reference to
-        // an office or room. Pin identity, not just count.
-        let mut first_ids: Vec<_> = after_first.keys().cloned().collect();
-        let mut second_ids: Vec<_> = after_second.keys().cloned().collect();
-        first_ids.sort();
-        second_ids.sort();
-        assert_eq!(
-            first_ids, second_ids,
-            "node IDs changed across a restart; existing references would dangle"
-        );
-    }
+        // Boot 2: the process comes back up against the same store.
+        boot(&k, &config).await;
 
-    /// A user-created office (no config seeding involved) must also suppress the seed, so a
-    /// workspace whose defaults were renamed or replaced never has them re-injected.
-    #[tokio::test]
-    async fn existing_user_created_office_suppresses_seeding() {
-        let kernel = AsyncWorkspaceServerKernel::<StackedRatchet>::new(None);
-
-        let mut nodes = std::collections::HashMap::new();
-        nodes.insert(
-            "user-made-office".to_string(),
-            office_node("user-made-office", "Renamed By User"),
-        );
-        kernel
-            .domain_operations
-            .backend_tx_manager
-            .save_nodes(&nodes)
-            .await
-            .expect("seed a user-created office");
-
-        kernel
-            .initialize_workspace_structure(&one_office_one_room(), None, false)
-            .await
-            .expect("seed against an already-populated workspace");
-
-        let after = kernel
-            .domain_operations
-            .backend_tx_manager
-            .get_all_nodes()
-            .await
-            .expect("read nodes");
-
-        assert_eq!(
-            after.len(),
-            1,
-            "config defaults were injected on top of a user-populated workspace ({} nodes). \
-             The baked-in structure describes the INITIAL state of a new workspace; it must \
-             never be re-applied over a tree the users own.",
+        let after = nodes(&k).await;
+        assert!(
+            after.values().any(|n| n.name == "General"),
+            "an interrupted first boot was abandoned: the workspace was left with no offices \
+             ({} nodes). The seed obligation must survive the interruption.",
             after.len()
         );
         assert!(
-            after.contains_key("user-made-office"),
-            "the user's own office must survive untouched"
+            !k.domain_operations
+                .backend_tx_manager
+                .is_structure_seed_pending()
+                .await
+                .expect("read pending"),
+            "the pending marker must be cleared once the debt is paid"
+        );
+    }
+
+    /// The boot-time decision itself: `inject_admin_user` must record the seed obligation on a
+    /// fresh store and must NOT resurrect it on any later boot. This is the wiring the rest of the
+    /// guard depends on, so it is pinned directly rather than assumed.
+    #[tokio::test]
+    async fn inject_admin_user_records_the_seed_obligation_exactly_once() {
+        let k = kernel();
+        let backend = &k.domain_operations.backend_tx_manager;
+
+        assert!(
+            !backend.is_structure_seed_pending().await.unwrap(),
+            "a virgin store owes nothing yet"
+        );
+
+        // First boot: creates the workspace and takes on the seed obligation.
+        k.inject_admin_user(MASTER_PASSWORD)
+            .await
+            .expect("inject 1");
+        assert!(
+            backend.is_structure_seed_pending().await.unwrap(),
+            "creating the root workspace must record the seed obligation"
+        );
+
+        k.initialize_workspace_structure(&one_office_one_room(), None)
+            .await
+            .expect("seed");
+        assert!(backend.is_structure_seeded().await.unwrap());
+        assert!(
+            !backend.is_structure_seed_pending().await.unwrap(),
+            "the obligation must be discharged once the tree is written"
+        );
+
+        // Second boot: the workspace already exists, so no new obligation may be taken on -
+        // otherwise every restart would re-enter the seeding path.
+        k.inject_admin_user(MASTER_PASSWORD)
+            .await
+            .expect("inject 2");
+        assert!(
+            !backend.is_structure_seed_pending().await.unwrap(),
+            "a restart must not re-arm the seed obligation"
         );
     }
 }

--- a/citadel-workspace-server-kernel/src/kernel/async_kernel.rs
+++ b/citadel-workspace-server-kernel/src/kernel/async_kernel.rs
@@ -508,6 +508,34 @@ impl<R: Ratchet + Send + Sync + 'static> AsyncWorkspaceServerKernel<R> {
             .backend_tx_manager
             .get_all_nodes()
             .await?;
+
+        // Seed the configured structure ONLY into a fresh workspace.
+        //
+        // `on_start` calls this on every boot, and the code below mints new UUIDs and
+        // *appends*. Against a persistent (filesystem) backend that means every restart
+        // deposits another complete copy of every office and room - the tree grows without
+        // bound, one extra set per deploy. Dev and CI never caught it because they run the
+        // server on the in-memory backend, where every boot legitimately starts empty.
+        //
+        // Skipping (rather than upserting) is deliberate: the tree is user-mutable after the
+        // first boot - offices are created and renamed, MDX content is edited live - so
+        // re-applying the baked-in config on each boot would clobber those edits. The config
+        // describes the *initial* state of a new workspace, not a desired state to reconcile.
+        //
+        // Any node parented to the workspace root means a tree already exists (whether
+        // config-seeded or user-created), so leave it untouched. This mirrors the
+        // `workspace_exists` guard `inject_admin_user` already applies to the root workspace.
+        if nodes
+            .values()
+            .any(|node| node.parent_id.as_deref() == Some(crate::WORKSPACE_ROOT_ID))
+        {
+            info!(
+                target: "citadel",
+                "Workspace structure already present; skipping initial structure seed"
+            );
+            return Ok(());
+        }
+
         let current_time = std::time::SystemTime::now()
             .duration_since(std::time::UNIX_EPOCH)
             .expect("system clock before unix epoch")
@@ -1315,5 +1343,173 @@ mod content_segment_tests {
     #[test]
     fn rejects_nul_byte() {
         assert!(validate_content_segment("foo\0bar").is_err());
+    }
+}
+
+#[cfg(test)]
+mod structure_seed_idempotency_tests {
+    //! Regression tests for the seed-once guard in `initialize_workspace_structure`.
+    //!
+    //! `on_start` invokes that function on EVERY boot. Before the guard, it minted fresh
+    //! UUIDs and appended, so a server on a persistent (filesystem) backend gained a
+    //! complete duplicate of every office and room on each restart - and `deploy.sh`
+    //! restarts the server on every deploy, so a live workspace would visibly corrupt
+    //! itself over time. Reproduced on real hardware: boot 1 created 3 offices / 8 rooms,
+    //! boot 2 against the same volume took it to 6 / 16.
+    //!
+    //! Nothing caught this because dev and CI run the server on the in-memory backend,
+    //! where every boot legitimately starts from an empty store. These tests close that
+    //! gap by seeding twice against a single store - the unit-test equivalent of a restart.
+    use super::*;
+    use crate::config::{OfficeConfig, RoomConfig};
+    use citadel_sdk::prelude::StackedRatchet;
+    use citadel_workspace_types::structs::DomainPermissions;
+
+    fn one_office_one_room() -> WorkspaceStructureConfig {
+        WorkspaceStructureConfig {
+            name: "Test Workspace".to_string(),
+            description: None,
+            offices: vec![OfficeConfig {
+                name: "General".to_string(),
+                description: None,
+                // No markdown_file: keeps the test off the filesystem entirely.
+                markdown_file: None,
+                chat_enabled: true,
+                rules: None,
+                default_permissions: DomainPermissions::default(),
+                is_default: true,
+                rooms: vec![RoomConfig {
+                    name: "Random".to_string(),
+                    description: None,
+                    markdown_file: None,
+                    chat_enabled: true,
+                    rules: None,
+                    default_permissions: DomainPermissions::default(),
+                }],
+            }],
+        }
+    }
+
+    /// Seeding twice against one store must be a no-op the second time.
+    #[tokio::test]
+    async fn second_seed_does_not_duplicate_the_tree() {
+        let kernel = AsyncWorkspaceServerKernel::<StackedRatchet>::new(None);
+        let config = one_office_one_room();
+
+        kernel
+            .initialize_workspace_structure(&config, None)
+            .await
+            .expect("first seed");
+        let after_first = kernel
+            .domain_operations
+            .backend_tx_manager
+            .get_all_nodes()
+            .await
+            .expect("read nodes after first seed");
+
+        // The restart: same store, `on_start` seeds again.
+        kernel
+            .initialize_workspace_structure(&config, None)
+            .await
+            .expect("second seed");
+        let after_second = kernel
+            .domain_operations
+            .backend_tx_manager
+            .get_all_nodes()
+            .await
+            .expect("read nodes after second seed");
+
+        assert_eq!(
+            after_first.len(),
+            2,
+            "fresh seed should produce exactly one office + one room"
+        );
+        assert_eq!(
+            after_second.len(),
+            after_first.len(),
+            "restart duplicated the tree ({} nodes -> {} nodes). The seed-once guard in \
+             initialize_workspace_structure has regressed: on a filesystem backend this grows \
+             an extra copy of every office and room on every single deploy.",
+            after_first.len(),
+            after_second.len()
+        );
+
+        // Cardinality alone is not enough - a re-seed that also wiped the old tree would keep
+        // the count equal while silently rotating every UUID, breaking any stored reference to
+        // an office or room. Pin identity, not just count.
+        let mut first_ids: Vec<_> = after_first.keys().cloned().collect();
+        let mut second_ids: Vec<_> = after_second.keys().cloned().collect();
+        first_ids.sort();
+        second_ids.sort();
+        assert_eq!(
+            first_ids, second_ids,
+            "node IDs changed across a restart; existing references would dangle"
+        );
+    }
+
+    /// A user-created office (no config seeding involved) must also suppress the seed, so a
+    /// workspace whose defaults were renamed or replaced never has them re-injected.
+    #[tokio::test]
+    async fn existing_user_created_office_suppresses_seeding() {
+        let kernel = AsyncWorkspaceServerKernel::<StackedRatchet>::new(None);
+
+        let mut nodes = std::collections::HashMap::new();
+        nodes.insert(
+            "user-made-office".to_string(),
+            citadel_workspace_types::structs::DomainNode {
+                id: "user-made-office".to_string(),
+                parent_id: Some(crate::WORKSPACE_ROOT_ID.to_string()),
+                entity_type: citadel_workspace_types::structs::NodeEntityType::Child(
+                    "office".to_string(),
+                ),
+                depth: 1,
+                name: "Renamed By User".to_string(),
+                description: String::new(),
+                owner_id: UNASSIGNED_OWNER.to_string(),
+                members: vec![],
+                children: Vec::new(),
+                mdx_content: String::new(),
+                rules: None,
+                chat_enabled: true,
+                chat_channel_id: None,
+                default_permissions: DomainPermissions::default(),
+                metadata: Vec::new(),
+                allowed_child_types: None,
+                is_default: true,
+                created_at: 0,
+                updated_at: 0,
+            },
+        );
+        kernel
+            .domain_operations
+            .backend_tx_manager
+            .save_nodes(&nodes)
+            .await
+            .expect("seed a user-created office");
+
+        kernel
+            .initialize_workspace_structure(&one_office_one_room(), None)
+            .await
+            .expect("seed against an already-populated workspace");
+
+        let after = kernel
+            .domain_operations
+            .backend_tx_manager
+            .get_all_nodes()
+            .await
+            .expect("read nodes");
+
+        assert_eq!(
+            after.len(),
+            1,
+            "config defaults were injected on top of a user-populated workspace ({} nodes). \
+             The baked-in structure describes the INITIAL state of a new workspace; it must \
+             never be re-applied over a tree the users own.",
+            after.len()
+        );
+        assert!(
+            after.contains_key("user-made-office"),
+            "the user's own office must survive untouched"
+        );
     }
 }

--- a/citadel-workspace-server-kernel/src/kernel/async_kernel.rs
+++ b/citadel-workspace-server-kernel/src/kernel/async_kernel.rs
@@ -270,10 +270,15 @@ impl<R: Ratchet + Send + Sync + 'static> AsyncWorkspaceServerKernel<R> {
 
     /// Initialize the root workspace. Note that this does NOT create any admin user.
     /// The first real user to provide the master password via UpdateWorkspace becomes the admin/owner.
+    ///
+    /// Returns `true` if the root workspace was created by this call (i.e. the backend held no
+    /// workspace at all), and `false` if it already existed. Callers use that to tell a
+    /// brand-new deployment apart from an established one - see
+    /// [`Self::initialize_workspace_structure`].
     pub async fn inject_admin_user(
         &self,
         workspace_master_password: &str,
-    ) -> Result<(), NetworkError> {
+    ) -> Result<bool, NetworkError> {
         info!(target: "citadel", "Initializing root workspace (no pre-created admin user)");
 
         // Pre-populate the master password BEFORE any workspace checks
@@ -338,7 +343,12 @@ impl<R: Ratchet + Send + Sync + 'static> AsyncWorkspaceServerKernel<R> {
             info!(target: "citadel", "Root workspace created successfully (awaiting first admin)");
         }
 
-        Ok(())
+        // Report whether the root workspace was created by THIS call. That is the only
+        // trustworthy "is this a brand-new workspace?" signal available to
+        // `initialize_workspace_structure`: by the time it runs, the root workspace always
+        // exists (this function just made sure of it), and the node contents cannot tell a
+        // new workspace apart from an established one whose offices were all deleted.
+        Ok(!workspace_exists)
     }
 
     /// Get a reference to the async domain operations
@@ -476,10 +486,16 @@ impl<R: Ratchet + Send + Sync + 'static> AsyncWorkspaceServerKernel<R> {
     ///
     /// Creates offices and rooms as defined in the WorkspaceStructureConfig.
     /// Each office/room with chat_enabled=true gets a UUID for its chat channel.
+    ///
+    /// `workspace_is_new` must be the value returned by [`Self::inject_admin_user`] on this
+    /// same boot: `true` only when the root workspace did not previously exist. The configured
+    /// structure is seeded ONLY into such a workspace. It is not enough to look at the node
+    /// contents - see the guard below.
     pub async fn initialize_workspace_structure(
         &self,
         config: &WorkspaceStructureConfig,
         base_path: Option<&std::path::Path>,
+        workspace_is_new: bool,
     ) -> Result<(), NetworkError> {
         use citadel_workspace_types::structs::{DomainNode, NodeEntityType};
         use uuid::Uuid;
@@ -554,24 +570,43 @@ impl<R: Ratchet + Send + Sync + 'static> AsyncWorkspaceServerKernel<R> {
             return Ok(());
         }
 
-        // Back-fill for stores written before the marker existed. Such a workspace is already
-        // populated but carries no marker, so a marker-only check would treat it as fresh and
-        // duplicate its entire tree on the next boot - reintroducing the very bug this guard
-        // exists to prevent. Any node parented to the workspace root proves a tree is already
-        // established (config-seeded or user-created): record the marker and leave it alone.
+        // Back-fill for stores written before the marker existed: an established workspace
+        // carries no marker, so a marker-only check would treat it as fresh and duplicate its
+        // entire tree - reintroducing the very bug this guard exists to prevent.
         //
-        // This path is crash-safe by construction: it writes ONLY the marker, and only when a
-        // tree already exists. It never writes nodes, so there is no partial state to unwind.
-        // A crash between reading `nodes` and writing the marker simply leaves the store as it
-        // was; the next boot re-reads the same tree and writes the marker then. Re-running it is
-        // a no-op, so a stale snapshot cannot cause incorrect behaviour - at worst it repeats.
+        // The test for "established" is that the root workspace ALREADY EXISTED before this
+        // boot, NOT that the node map currently has contents. Those are different facts, and
+        // conflating them is a trap: an established workspace whose offices were all deleted by
+        // an admin has an empty node map, and a contents-based check would read that as "fresh"
+        // and resurrect the baked-in defaults on upgrade - precisely the deletion-must-survive
+        // contract this PR exists to uphold. `inject_admin_user` reports the creation fact
+        // directly, so use that.
+        //
+        // This path is crash-safe by construction: it writes ONLY the marker, never nodes, so
+        // there is no partial state to unwind. A crash before the marker write leaves the store
+        // exactly as it was, and the next boot reaches the same conclusion and writes it then.
+        if !workspace_is_new {
+            info!(
+                target: "citadel",
+                "Established workspace predates the seed marker; recording marker and skipping re-seed"
+            );
+            self.domain_operations
+                .backend_tx_manager
+                .mark_structure_seeded()
+                .await?;
+            return Ok(());
+        }
+
+        // Defence in depth: even if a caller claims the workspace is new, an existing tree
+        // proves otherwise. This can only ever ADD a skip, never cause a seed, so it is safe to
+        // keep as a guard against a future caller passing the flag incorrectly.
         if nodes
             .values()
             .any(|node| node.parent_id.as_deref() == Some(crate::WORKSPACE_ROOT_ID))
         {
-            info!(
+            warn!(
                 target: "citadel",
-                "Workspace structure predates the seed marker; recording marker and skipping re-seed"
+                "Workspace reported as new but already has a tree; refusing to seed over it"
             );
             self.domain_operations
                 .backend_tx_manager
@@ -816,13 +851,19 @@ impl<R: Ratchet + Send + Sync + 'static> citadel_sdk::prelude::NetKernel<R>
             // Re-run admin injection now that NodeRemote is available
             if let Some(workspace_password) = &self.workspace_password {
                 info!(target: "citadel", "Injecting admin and workspace");
-                self.inject_admin_user(workspace_password).await?;
+                // `true` only when the root workspace did not exist and was created just now -
+                // i.e. this backend is brand new. Anything else is an established deployment.
+                let workspace_is_new = self.inject_admin_user(workspace_password).await?;
 
                 // Initialize workspace structure from config if provided
                 if let Some((structure, base_path)) = &self.workspace_structure {
                     info!(target: "citadel", "Initializing workspace structure from config");
-                    self.initialize_workspace_structure(structure, base_path.as_deref())
-                        .await?;
+                    self.initialize_workspace_structure(
+                        structure,
+                        base_path.as_deref(),
+                        workspace_is_new,
+                    )
+                    .await?;
                 }
             }
         }
@@ -1484,7 +1525,7 @@ mod structure_seed_idempotency_tests {
 
         // Boot 1: fresh workspace, seeds normally.
         kernel
-            .initialize_workspace_structure(&config, None)
+            .initialize_workspace_structure(&config, None, true)
             .await
             .expect("first seed");
         assert!(
@@ -1506,9 +1547,9 @@ mod structure_seed_idempotency_tests {
             .await
             .expect("delete every node");
 
-        // Boot 2: the workspace is empty, but it has already been seeded once.
+        // Boot 2: the workspace is empty, but it exists and has already been seeded once.
         kernel
-            .initialize_workspace_structure(&config, None)
+            .initialize_workspace_structure(&config, None, false)
             .await
             .expect("seed against an emptied workspace");
 
@@ -1558,7 +1599,7 @@ mod structure_seed_idempotency_tests {
         );
 
         kernel
-            .initialize_workspace_structure(&one_office_one_room(), None)
+            .initialize_workspace_structure(&one_office_one_room(), None, false)
             .await
             .expect("boot against a legacy store");
 
@@ -1587,6 +1628,60 @@ mod structure_seed_idempotency_tests {
         );
     }
 
+    /// An ESTABLISHED workspace that predates the marker AND has been emptied by an admin must
+    /// not be re-seeded on upgrade.
+    ///
+    /// This is the case a contents-based back-fill gets wrong. Such a store has no marker (it
+    /// predates it) and no root children (the admin deleted them), so inferring "legacy" from
+    /// node contents reads it as a brand-new workspace and resurrects the baked-in defaults -
+    /// the exact deletion-must-survive contract this guard exists to uphold. Only the
+    /// "did the root workspace already exist?" fact distinguishes the two.
+    #[tokio::test]
+    async fn emptied_legacy_workspace_is_not_reseeded_on_upgrade() {
+        let kernel = AsyncWorkspaceServerKernel::<StackedRatchet>::new(None);
+
+        // A pre-marker deployment whose offices were all deleted: no marker, no nodes, but the
+        // workspace itself is long-established (so `inject_admin_user` reports `false`).
+        assert!(
+            !kernel
+                .domain_operations
+                .backend_tx_manager
+                .is_structure_seeded()
+                .await
+                .expect("read marker"),
+            "precondition: a pre-marker store carries no marker"
+        );
+
+        kernel
+            .initialize_workspace_structure(&one_office_one_room(), None, false)
+            .await
+            .expect("upgrade boot against an emptied legacy store");
+
+        let after = kernel
+            .domain_operations
+            .backend_tx_manager
+            .get_all_nodes()
+            .await
+            .expect("read nodes");
+
+        assert!(
+            after.is_empty(),
+            "the baked-in defaults were resurrected into an established workspace that an admin \
+             had emptied ({} nodes reappeared). An empty tree is not the same fact as a NEW \
+             workspace; only the root-workspace-creation signal distinguishes them.",
+            after.len()
+        );
+        assert!(
+            kernel
+                .domain_operations
+                .backend_tx_manager
+                .is_structure_seeded()
+                .await
+                .expect("read marker"),
+            "the marker must be back-filled so later boots take the cheap path"
+        );
+    }
+
     /// Seeding twice against one store must be a no-op the second time.
     #[tokio::test]
     async fn second_seed_does_not_duplicate_the_tree() {
@@ -1594,7 +1689,7 @@ mod structure_seed_idempotency_tests {
         let config = one_office_one_room();
 
         kernel
-            .initialize_workspace_structure(&config, None)
+            .initialize_workspace_structure(&config, None, true)
             .await
             .expect("first seed");
         let after_first = kernel
@@ -1604,9 +1699,10 @@ mod structure_seed_idempotency_tests {
             .await
             .expect("read nodes after first seed");
 
-        // The restart: same store, `on_start` seeds again.
+        // The restart: same store. The root workspace now exists, so `inject_admin_user` would
+        // report the workspace as NOT new on this boot.
         kernel
-            .initialize_workspace_structure(&config, None)
+            .initialize_workspace_structure(&config, None, false)
             .await
             .expect("second seed");
         let after_second = kernel
@@ -1672,7 +1768,7 @@ mod structure_seed_idempotency_tests {
             .expect("seed a user-created office");
 
         kernel
-            .initialize_workspace_structure(&one_office_one_room(), None)
+            .initialize_workspace_structure(&one_office_one_room(), None, false)
             .await
             .expect("seed against an already-populated workspace");
 

--- a/citadel-workspace-server-kernel/src/kernel/async_kernel.rs
+++ b/citadel-workspace-server-kernel/src/kernel/async_kernel.rs
@@ -507,6 +507,28 @@ impl<R: Ratchet + Send + Sync + 'static> AsyncWorkspaceServerKernel<R> {
             })
     }
 
+    /// Clear the seed-pending marker. BEST-EFFORT by design.
+    ///
+    /// `structure_seeded` is authoritative on every read path, so a leftover `pending` is
+    /// cosmetic - it only makes the store harder to reason about. Failing a boot over a cosmetic
+    /// write would turn a completed seed into a crash loop, and the next boot would short-circuit
+    /// on `seeded` anyway. Every site that discharges the obligation goes through here, so they
+    /// cannot drift into treating the same write as fatal in one place and optional in another.
+    async fn discharge_seed_obligation(&self) {
+        if let Err(e) = self
+            .domain_operations
+            .backend_tx_manager
+            .clear_structure_seed_pending()
+            .await
+        {
+            warn!(
+                target: "citadel",
+                "Could not clear the seed-pending marker: {e}. Harmless - the seeded marker takes \
+                 precedence on every later boot."
+            );
+        }
+    }
+
     /// Initialize workspace structure from configuration
     ///
     /// Creates offices and rooms as defined in the WorkspaceStructureConfig.
@@ -591,6 +613,19 @@ impl<R: Ratchet + Send + Sync + 'static> AsyncWorkspaceServerKernel<R> {
                 target: "citadel",
                 "Initial workspace structure already seeded; skipping"
             );
+            // A leftover `pending` can only exist if an earlier discharge failed (it is
+            // best-effort). Clean it up opportunistically so the store does not carry a
+            // contradictory pair of flags forever. The READ is best-effort too - `seeded` is
+            // authoritative, so nothing on this path may fail a boot.
+            if matches!(
+                self.domain_operations
+                    .backend_tx_manager
+                    .is_structure_seed_pending()
+                    .await,
+                Ok(true)
+            ) {
+                self.discharge_seed_obligation().await;
+            }
             return Ok(());
         }
 
@@ -652,10 +687,7 @@ impl<R: Ratchet + Send + Sync + 'static> AsyncWorkspaceServerKernel<R> {
                 .backend_tx_manager
                 .mark_structure_seeded()
                 .await?;
-            self.domain_operations
-                .backend_tx_manager
-                .clear_structure_seed_pending()
-                .await?;
+            self.discharge_seed_obligation().await;
             return Ok(());
         }
 
@@ -861,18 +893,7 @@ impl<R: Ratchet + Send + Sync + 'static> AsyncWorkspaceServerKernel<R> {
         // Deliberately BEST-EFFORT. The tree is durably written and the workspace is durably
         // marked seeded; failing the boot now over a cosmetic write would turn a completed seed
         // into a crash loop, and the next boot would short-circuit on `seeded` anyway.
-        if let Err(e) = self
-            .domain_operations
-            .backend_tx_manager
-            .clear_structure_seed_pending()
-            .await
-        {
-            warn!(
-                target: "citadel",
-                "Workspace seeded successfully, but could not clear the seed-pending marker: {e}. \
-                 Harmless - the seeded marker takes precedence on every later boot."
-            );
-        }
+        self.discharge_seed_obligation().await;
 
         info!(target: "citadel", "Workspace structure initialization complete");
         Ok(())

--- a/citadel-workspace-server-kernel/src/kernel/async_kernel.rs
+++ b/citadel-workspace-server-kernel/src/kernel/async_kernel.rs
@@ -522,17 +522,41 @@ impl<R: Ratchet + Send + Sync + 'static> AsyncWorkspaceServerKernel<R> {
         // re-applying the baked-in config on each boot would clobber those edits. The config
         // describes the *initial* state of a new workspace, not a desired state to reconcile.
         //
-        // Any node parented to the workspace root means a tree already exists (whether
-        // config-seeded or user-created), so leave it untouched. This mirrors the
-        // `workspace_exists` guard `inject_admin_user` already applies to the root workspace.
+        // The signal is a DURABLE MARKER, not "does the tree currently have root children".
+        // Emptiness is not the same fact as never-seeded: an admin who deletes every office
+        // leaves a legitimately empty tree, and a contents-based check would then resurrect
+        // the baked-in defaults on the next restart - re-applying config over structure the
+        // users deliberately removed, which is exactly the contract above.
+        if self
+            .domain_operations
+            .backend_tx_manager
+            .is_structure_seeded()
+            .await?
+        {
+            info!(
+                target: "citadel",
+                "Initial workspace structure already seeded; skipping"
+            );
+            return Ok(());
+        }
+
+        // Back-fill for stores written before the marker existed. Such a workspace is already
+        // populated but carries no marker, so a marker-only check would treat it as fresh and
+        // duplicate its entire tree on the next boot - reintroducing the very bug this guard
+        // exists to prevent. Any node parented to the workspace root proves a tree is already
+        // established (config-seeded or user-created): record the marker and leave it alone.
         if nodes
             .values()
             .any(|node| node.parent_id.as_deref() == Some(crate::WORKSPACE_ROOT_ID))
         {
             info!(
                 target: "citadel",
-                "Workspace structure already present; skipping initial structure seed"
+                "Workspace structure predates the seed marker; recording marker and skipping re-seed"
             );
+            self.domain_operations
+                .backend_tx_manager
+                .mark_structure_seeded()
+                .await?;
             return Ok(());
         }
 
@@ -722,6 +746,14 @@ impl<R: Ratchet + Send + Sync + 'static> AsyncWorkspaceServerKernel<R> {
         self.domain_operations
             .backend_tx_manager
             .save_nodes(&nodes)
+            .await?;
+
+        // Record the seed only AFTER the nodes are durably written. If `save_nodes` fails we
+        // return early without a marker, so the next boot retries the seed rather than marking
+        // a workspace as seeded that has no structure in it.
+        self.domain_operations
+            .backend_tx_manager
+            .mark_structure_seeded()
             .await?;
 
         info!(target: "citadel", "Workspace structure initialization complete");
@@ -1390,6 +1422,151 @@ mod structure_seed_idempotency_tests {
         }
     }
 
+    /// A top-level office node, as a user-created or already-persisted tree would contain.
+    /// `parent_id == WORKSPACE_ROOT_ID` is what marks a node as top-level - the same predicate
+    /// the rest of the kernel uses to enumerate offices (see `async_node_ops.rs`).
+    fn office_node(id: &str, name: &str) -> citadel_workspace_types::structs::DomainNode {
+        citadel_workspace_types::structs::DomainNode {
+            id: id.to_string(),
+            parent_id: Some(crate::WORKSPACE_ROOT_ID.to_string()),
+            entity_type: citadel_workspace_types::structs::NodeEntityType::Child(
+                "office".to_string(),
+            ),
+            depth: 1,
+            name: name.to_string(),
+            description: String::new(),
+            owner_id: UNASSIGNED_OWNER.to_string(),
+            members: vec![],
+            children: Vec::new(),
+            mdx_content: String::new(),
+            rules: None,
+            chat_enabled: true,
+            chat_channel_id: None,
+            default_permissions: DomainPermissions::default(),
+            metadata: Vec::new(),
+            allowed_child_types: None,
+            is_default: true,
+            created_at: 0,
+            updated_at: 0,
+        }
+    }
+
+    /// Deleting every office must NOT cause the defaults to be resurrected on the next boot.
+    ///
+    /// This is the case a contents-based guard ("does the root have children?") gets wrong: an
+    /// admin who removes every office leaves a legitimately empty tree, which such a guard reads
+    /// as "fresh" and re-seeds. Emptiness and never-seeded are different facts, and only the
+    /// durable marker distinguishes them.
+    #[tokio::test]
+    async fn deleting_every_office_does_not_resurrect_the_defaults() {
+        let kernel = AsyncWorkspaceServerKernel::<StackedRatchet>::new(None);
+        let config = one_office_one_room();
+
+        // Boot 1: fresh workspace, seeds normally.
+        kernel
+            .initialize_workspace_structure(&config, None)
+            .await
+            .expect("first seed");
+        assert!(
+            !kernel
+                .domain_operations
+                .backend_tx_manager
+                .get_all_nodes()
+                .await
+                .expect("read nodes")
+                .is_empty(),
+            "precondition: the first seed must have produced a tree"
+        );
+
+        // The admin deletes everything.
+        kernel
+            .domain_operations
+            .backend_tx_manager
+            .save_nodes(&std::collections::HashMap::new())
+            .await
+            .expect("delete every node");
+
+        // Boot 2: the workspace is empty, but it has already been seeded once.
+        kernel
+            .initialize_workspace_structure(&config, None)
+            .await
+            .expect("seed against an emptied workspace");
+
+        let after = kernel
+            .domain_operations
+            .backend_tx_manager
+            .get_all_nodes()
+            .await
+            .expect("read nodes");
+
+        assert!(
+            after.is_empty(),
+            "the baked-in defaults were resurrected into a workspace the admin had emptied \
+             ({} nodes reappeared). Config describes the INITIAL state of a new workspace; \
+             deleting every office is a deliberate act and must survive a restart.",
+            after.len()
+        );
+    }
+
+    /// A store written before the seed marker existed is already populated but carries no
+    /// marker. It must be recognised as seeded and back-filled - NOT treated as fresh, which
+    /// would duplicate its entire tree on the next boot (the original bug).
+    #[tokio::test]
+    async fn preexisting_tree_without_marker_is_backfilled_not_reseeded() {
+        let kernel = AsyncWorkspaceServerKernel::<StackedRatchet>::new(None);
+
+        // Simulate an upgraded deployment: a populated tree, but no marker was ever written.
+        let mut nodes = std::collections::HashMap::new();
+        nodes.insert(
+            "legacy-office".to_string(),
+            office_node("legacy-office", "Engineering"),
+        );
+        kernel
+            .domain_operations
+            .backend_tx_manager
+            .save_nodes(&nodes)
+            .await
+            .expect("seed a legacy tree");
+        assert!(
+            !kernel
+                .domain_operations
+                .backend_tx_manager
+                .is_structure_seeded()
+                .await
+                .expect("read marker"),
+            "precondition: a legacy store carries no marker"
+        );
+
+        kernel
+            .initialize_workspace_structure(&one_office_one_room(), None)
+            .await
+            .expect("boot against a legacy store");
+
+        let after = kernel
+            .domain_operations
+            .backend_tx_manager
+            .get_all_nodes()
+            .await
+            .expect("read nodes");
+
+        assert_eq!(
+            after.len(),
+            1,
+            "a pre-marker workspace was re-seeded and now has {} nodes. Treating a populated \
+             store as fresh just because it predates the marker reintroduces the duplication bug.",
+            after.len()
+        );
+        assert!(
+            kernel
+                .domain_operations
+                .backend_tx_manager
+                .is_structure_seeded()
+                .await
+                .expect("read marker"),
+            "the marker must be back-filled so the check is cheap on every later boot"
+        );
+    }
+
     /// Seeding twice against one store must be a no-op the second time.
     #[tokio::test]
     async fn second_seed_does_not_duplicate_the_tree() {
@@ -1419,10 +1596,19 @@ mod structure_seed_idempotency_tests {
             .await
             .expect("read nodes after second seed");
 
-        assert_eq!(
-            after_first.len(),
-            2,
-            "fresh seed should produce exactly one office + one room"
+        // Assert the first seed produced the configured tree BY NAME rather than by a hardcoded
+        // node count. The point is only to prove the test is not vacuous: if seeding silently
+        // produced nothing, the idempotency assertion below would compare 0 against 0 and pass
+        // while testing nothing. Matching names keeps that guarantee without breaking if the
+        // storage layer ever persists an extra structural node (a root or wrapper), which would
+        // be unrelated to the regression under test.
+        assert!(
+            after_first.values().any(|n| n.name == "General"),
+            "fresh seed did not create the configured office; the test would be vacuous"
+        );
+        assert!(
+            after_first.values().any(|n| n.name == "Random"),
+            "fresh seed did not create the configured room; the test would be vacuous"
         );
         assert_eq!(
             after_second.len(),
@@ -1456,29 +1642,7 @@ mod structure_seed_idempotency_tests {
         let mut nodes = std::collections::HashMap::new();
         nodes.insert(
             "user-made-office".to_string(),
-            citadel_workspace_types::structs::DomainNode {
-                id: "user-made-office".to_string(),
-                parent_id: Some(crate::WORKSPACE_ROOT_ID.to_string()),
-                entity_type: citadel_workspace_types::structs::NodeEntityType::Child(
-                    "office".to_string(),
-                ),
-                depth: 1,
-                name: "Renamed By User".to_string(),
-                description: String::new(),
-                owner_id: UNASSIGNED_OWNER.to_string(),
-                members: vec![],
-                children: Vec::new(),
-                mdx_content: String::new(),
-                rules: None,
-                chat_enabled: true,
-                chat_channel_id: None,
-                default_permissions: DomainPermissions::default(),
-                metadata: Vec::new(),
-                allowed_child_types: None,
-                is_default: true,
-                created_at: 0,
-                updated_at: 0,
-            },
+            office_node("user-made-office", "Renamed By User"),
         );
         kernel
             .domain_operations

--- a/citadel-workspace-server-kernel/src/kernel/async_kernel.rs
+++ b/citadel-workspace-server-kernel/src/kernel/async_kernel.rs
@@ -668,9 +668,19 @@ impl<R: Ratchet + Send + Sync + 'static> AsyncWorkspaceServerKernel<R> {
             return Ok(());
         }
 
-        // Defence in depth: a seed is owed, but an existing tree proves the workspace is not
-        // actually empty. Never inject defaults on top of a tree. This can only ever ADD a skip,
-        // never cause a seed, so it is safe to keep.
+        // A seed is owed, but a tree already exists. That is not a contradiction - it is the
+        // signature of a boot that wrote the nodes and then died before it could record that it
+        // had (`save_nodes` succeeded, `mark_structure_seeded` did not). Finish that transition.
+        //
+        // The tree here is necessarily COMPLETE, never half-written: `save_nodes` serialises the
+        // entire node map into a single JSON blob and writes it under one key
+        // (`citadel_workspace.nodes`), so either all of it lands or none of it does. There is no
+        // "some offices written, others not" state to repair.
+        //
+        // This branch is therefore essential, not merely defensive. Removing it - or firing it
+        // only when the pending marker is ABSENT, which is already handled above - would send
+        // this exact state down the seeding path and duplicate the whole tree on top of itself:
+        // the original bug, reintroduced.
         if nodes
             .values()
             .any(|node| node.parent_id.as_deref() == Some(crate::WORKSPACE_ROOT_ID))
@@ -1888,6 +1898,67 @@ mod structure_seed_idempotency_tests {
         assert!(
             backend.is_structure_seeded().await.unwrap(),
             "the workspace should now be marked seeded"
+        );
+    }
+
+    /// A boot that wrote the tree but died before recording it must FINALISE, not re-seed.
+    ///
+    /// `save_nodes` succeeded, `mark_structure_seeded` did not - so the next boot finds a seed
+    /// still owed AND a tree already present. The tree is necessarily complete (`save_nodes`
+    /// writes the whole node map as one blob under one key, so it is all-or-nothing), and the
+    /// only correct move is to record it as seeded. Seeding again would deposit a second copy of
+    /// the entire tree on top of the first - the original bug.
+    #[tokio::test]
+    async fn tree_written_but_seed_unrecorded_is_finalised_not_duplicated() {
+        let k = kernel();
+        let backend = &k.domain_operations.backend_tx_manager;
+
+        // Reproduce the state left by that interrupted boot: workspace created, obligation still
+        // owed, tree fully written, `seeded` never recorded.
+        k.inject_admin_user(MASTER_PASSWORD)
+            .await
+            .expect("inject_admin_user");
+        let mut written = std::collections::HashMap::new();
+        written.insert(
+            "already-written-office".to_string(),
+            office_node("already-written-office", "General"),
+        );
+        backend
+            .save_nodes(&written)
+            .await
+            .expect("simulate the completed save_nodes");
+        assert!(
+            backend.is_structure_seed_pending().await.unwrap(),
+            "precondition: the seed is still owed"
+        );
+        assert!(
+            !backend.is_structure_seeded().await.unwrap(),
+            "precondition: the boot died before recording the seed"
+        );
+
+        // The next boot.
+        boot(&k, &one_office_one_room()).await;
+
+        let after = nodes(&k).await;
+        assert_eq!(
+            after.len(),
+            1,
+            "the existing tree was seeded over rather than recorded: {} nodes now exist. A tree \
+             present while a seed is owed means the previous boot wrote it and died before \
+             recording it - it must be finalised, never duplicated.",
+            after.len()
+        );
+        assert!(
+            after.contains_key("already-written-office"),
+            "the tree written by the interrupted boot must survive untouched"
+        );
+        assert!(
+            backend.is_structure_seeded().await.unwrap(),
+            "the interrupted transition must be completed: the workspace is now seeded"
+        );
+        assert!(
+            !backend.is_structure_seed_pending().await.unwrap(),
+            "and the obligation discharged"
         );
     }
 

--- a/citadel-workspace-server-kernel/src/kernel/transaction/backend_ops_simple.rs
+++ b/citadel-workspace-server-kernel/src/kernel/transaction/backend_ops_simple.rs
@@ -8,6 +8,7 @@
 use crate::kernel::transaction::BackendTransactionManager;
 use crate::kernel::transaction::{
     KEY_INDEX_DOMAIN_IDS, KEY_INDEX_USER_IDS, KEY_INDEX_WORKSPACE_IDS, KEY_SCHEMA_VERSION,
+    KEY_STRUCTURE_SEEDED,
 };
 use citadel_sdk::prelude::{NetworkError, Ratchet};
 use citadel_workspace_types::structs::{Domain, DomainNode, TreeSchema, User, Workspace};
@@ -274,6 +275,26 @@ impl<R: Ratchet + Send + Sync + 'static> BackendTransactionManager<R> {
     /// Set the schema version in the backend.
     pub async fn set_schema_version(&self, version: u32) -> Result<(), NetworkError> {
         self.backend_save(KEY_SCHEMA_VERSION, &version).await
+    }
+
+    // ========== Initial Structure Seeding Marker ==========
+
+    /// Whether the initial workspace structure has already been seeded.
+    ///
+    /// `false` for a fresh database and for any store written before this marker
+    /// existed - see `initialize_workspace_structure`, which back-fills the marker
+    /// for the latter case rather than treating it as fresh.
+    pub async fn is_structure_seeded(&self) -> Result<bool, NetworkError> {
+        Ok(self
+            .backend_get::<bool>(KEY_STRUCTURE_SEEDED)
+            .await?
+            .unwrap_or(false))
+    }
+
+    /// Record that the initial workspace structure has been seeded, so it is
+    /// never seeded again - not even if every office is later deleted.
+    pub async fn mark_structure_seeded(&self) -> Result<(), NetworkError> {
+        self.backend_save(KEY_STRUCTURE_SEEDED, &true).await
     }
 }
 

--- a/citadel-workspace-server-kernel/src/kernel/transaction/backend_ops_simple.rs
+++ b/citadel-workspace-server-kernel/src/kernel/transaction/backend_ops_simple.rs
@@ -8,7 +8,7 @@
 use crate::kernel::transaction::BackendTransactionManager;
 use crate::kernel::transaction::{
     KEY_INDEX_DOMAIN_IDS, KEY_INDEX_USER_IDS, KEY_INDEX_WORKSPACE_IDS, KEY_SCHEMA_VERSION,
-    KEY_STRUCTURE_SEEDED,
+    KEY_STRUCTURE_SEEDED, KEY_STRUCTURE_SEED_PENDING,
 };
 use citadel_sdk::prelude::{NetworkError, Ratchet};
 use citadel_workspace_types::structs::{Domain, DomainNode, TreeSchema, User, Workspace};
@@ -295,6 +295,27 @@ impl<R: Ratchet + Send + Sync + 'static> BackendTransactionManager<R> {
     /// never seeded again - not even if every office is later deleted.
     pub async fn mark_structure_seeded(&self) -> Result<(), NetworkError> {
         self.backend_save(KEY_STRUCTURE_SEEDED, &true).await
+    }
+
+    /// Whether a brand-new workspace was created whose structure has not been confirmed written.
+    ///
+    /// `true` on a fresh install between root-workspace creation and a successful seed - which
+    /// includes the next boot after a first boot that was interrupted.
+    pub async fn is_structure_seed_pending(&self) -> Result<bool, NetworkError> {
+        Ok(self
+            .backend_get::<bool>(KEY_STRUCTURE_SEED_PENDING)
+            .await?
+            .unwrap_or(false))
+    }
+
+    /// Record that a brand-new workspace owes an initial structure seed.
+    pub async fn mark_structure_seed_pending(&self) -> Result<(), NetworkError> {
+        self.backend_save(KEY_STRUCTURE_SEED_PENDING, &true).await
+    }
+
+    /// Clear the pending marker once the structure is durably written.
+    pub async fn clear_structure_seed_pending(&self) -> Result<(), NetworkError> {
+        self.backend_save(KEY_STRUCTURE_SEED_PENDING, &false).await
     }
 }
 

--- a/citadel-workspace-server-kernel/src/kernel/transaction/mod.rs
+++ b/citadel-workspace-server-kernel/src/kernel/transaction/mod.rs
@@ -90,6 +90,17 @@ pub(crate) const KEY_SCHEMA_VERSION: &str = "citadel_workspace.schema_version";
 /// contract actually depends on.
 pub(crate) const KEY_STRUCTURE_SEEDED: &str = "citadel_workspace.structure_seeded";
 
+/// Durable "a brand-new workspace was created and its initial structure has NOT yet been
+/// confirmed written" marker.
+///
+/// Written when the root workspace is first created, and cleared once the structure is durably
+/// seeded. It is what makes an interrupted first boot recoverable: if the process dies (or the
+/// node write merely fails) between creating the root workspace and writing the tree, the next
+/// boot still sees this marker and finishes the job. Without it, that store would look
+/// indistinguishable from an established pre-marker workspace and would be permanently left
+/// with no offices at all.
+pub(crate) const KEY_STRUCTURE_SEED_PENDING: &str = "citadel_workspace.structure_seed_pending";
+
 impl<R: Ratchet + Send + Sync + 'static> BackendTransactionManager<R> {
     pub fn new() -> Self {
         info!(target: "citadel", "Initializing BackendTransactionManager with NodeRemote backend");

--- a/citadel-workspace-server-kernel/src/kernel/transaction/mod.rs
+++ b/citadel-workspace-server-kernel/src/kernel/transaction/mod.rs
@@ -79,6 +79,17 @@ const KEY_MIGRATION_DONE: &str = "citadel_workspace.migration_v2_done";
 /// Key for storing the backend schema version.
 pub(crate) const KEY_SCHEMA_VERSION: &str = "citadel_workspace.schema_version";
 
+/// Durable "the initial workspace structure has been seeded" marker.
+///
+/// `on_start` runs the structure seeding on EVERY boot, so it needs a way to
+/// know whether a workspace is genuinely new. Inferring that from "the tree has
+/// no root children" is not sound: an admin who deletes every office leaves a
+/// legitimately-empty tree that would then be re-seeded with the baked-in
+/// defaults on the next restart, resurrecting content they deliberately removed.
+/// A persisted marker records the fact of seeding itself, which is what the
+/// contract actually depends on.
+pub(crate) const KEY_STRUCTURE_SEEDED: &str = "citadel_workspace.structure_seeded";
+
 impl<R: Ratchet + Send + Sync + 'static> BackendTransactionManager<R> {
     pub fn new() -> Self {
         info!(target: "citadel", "Initializing BackendTransactionManager with NodeRemote backend");


### PR DESCRIPTION
## Overview

`initialize_workspace_structure` is called unconditionally on every `on_start`, but it mints fresh `Uuid::new_v4()` office/room IDs and *appends* them to the existing node set. It has no already-seeded guard — unlike `inject_admin_user` directly above it, which correctly guards on `workspace_exists`.

Against a persistent (filesystem) backend, this means **every server restart deposits another complete copy of the entire office/room tree**. Since `deploy.sh` restarts the server on every deploy, a live workspace corrupts itself a little more with each update, and the damage is written to disk with new UUIDs — it does not self-heal.

Reproduced on real hardware with `WORKSPACE_BACKEND=filesystem`:

- Boot 1 (fresh volume): 3 offices, 8 rooms created (the baked-in `General` / `Tutorials` / `Welcome`)
- Boot 2 (restart, same volume): **6 offices, 16 rooms**

## Why this was never caught

Dev and CI run the server on the **in-memory** backend, where every boot legitimately starts from an empty store, so seeding-on-every-boot is indistinguishable from correct behavior. Only `docker-compose.production.yml` sets `WORKSPACE_BACKEND=filesystem`. The `production-build` CI job green-lights an image whose persistence path is never booted a second time, so this class of bug can only surface in production.

## Fix

Return early from `initialize_workspace_structure` when any node is already parented to the workspace root.

The detector is not new: `parent_id.as_deref() == Some(WORKSPACE_ROOT_ID)` is verbatim the predicate the codebase already uses to enumerate top-level offices in `async_node_ops.rs:216`. Runtime-created offices pass `WORKSPACE_ROOT_ID` as their parent (`async_node_ops.rs:86`), and the root node itself carries `parent_id: None` (`async_node_ops.rs:222`) — so the guard correctly detects user-created trees and correctly excludes root.

## Design notes

**Skip rather than upsert.** The office tree is user-mutable after the first boot: offices are created and renamed, MDX content is edited live. The baked-in `content_base_dir` describes the *initial* state of a new workspace, not a desired state to reconcile toward. Re-applying config on every boot would clobber user edits even if it didn't duplicate.

**Behavior change worth calling out.** Editing `documents/defaults/root/**/CONTENT.md` and redeploying no longer alters an existing workspace. It never usefully did — it produced duplicate offices — but the config is now explicitly initial-state-only.

**Accepted edge case.** If an admin deletes *every* office, a restart re-seeds the defaults. A persistent sentinel (like the existing `KEY_MIGRATION_DONE`) would prevent that, but the children-check self-heals if a seed ever fails midway and adds no persistent state. This felt like the better trade.

## Tests

Two regression tests, both proven non-vacuous (they fail when the guard is removed, reproducing `2 nodes -> 4 nodes`):

- `second_seed_does_not_duplicate_the_tree` — seeds twice against one store (the unit-test equivalent of a restart) and asserts the node set is unchanged. It pins **node identity**, not just cardinality: a re-seed that wiped and recreated the tree would keep the count equal while silently rotating every UUID and dangling every stored reference.
- `existing_user_created_office_suppresses_seeding` — a workspace whose defaults were renamed or replaced must never have them re-injected.

## Verification

- `cargo test -p citadel-workspace-server-kernel`: 145 passed, 0 failed
- `cargo clippy -p citadel-workspace-server-kernel -- -D warnings`: clean
- `cargo fmt -p citadel-workspace-server-kernel --check`: clean
- End-to-end on the deploy box with the filesystem backend: rebuilt the server image with this fix and ran **3 consecutive restarts** against one volume — offices stayed at 3, rooms at 8, and the skip guard fired on each restart.

## No regression to dev/CI

The dev compose leaves `WORKSPACE_BACKEND` unset, so the server runs in-memory and every boot starts with an empty store. `get_all_nodes()` returns empty, the guard does not fire, and seeding happens exactly as before. Integration tests that restart backend services are unaffected.

## Follow-up (not in this PR)

CI has no job that boots the server twice against a filesystem backend. That gap is precisely why this shipped, and closing it would catch this entire class of bug in minutes.
