### PR TITLE
feat(deploy): publish slim images to GHCR and pull instead of building on the host

### DIFF
--- a/.github/workflows/publish-images.yml
+++ b/.github/workflows/publish-images.yml
@@ -168,6 +168,12 @@ jobs:
         run: |
           set -euo pipefail
           name="smoke-${{ matrix.image }}"
+          # Clean up on EVERY exit path, not just success. On a GitHub-hosted runner a leaked
+          # container dies with the VM, but this repository also has a SELF-HOSTED runner, where
+          # a container left behind by a failed run keeps its ports bound and poisons the next
+          # run. (A five-month-old leaked compose stack squatting on :12345/:12349 is exactly
+          # how the deployment host ended up blocked.)
+          trap 'docker rm -f "$name" >/dev/null 2>&1 || true' EXIT
           docker run -d --name "$name" ${{ matrix.smoke_env }} "$IMAGE:$SHA_TAG"
 
           ok=0
@@ -190,7 +196,6 @@ jobs:
             exit 1
           fi
           echo "${{ matrix.image }} is listening on ${{ matrix.smoke_port }}; image is good."
-          docker rm -f "$name" >/dev/null 2>&1 || true
 
       - name: Push immutable SHA tag
         # Only the immutable tag is pushed here. `latest` is advanced by the

--- a/.github/workflows/publish-images.yml
+++ b/.github/workflows/publish-images.yml
@@ -7,13 +7,30 @@
 # `docker compose build`). That is slow (a full Rust release build per deploy),
 # it requires the source tree and a toolchain on the production box, it offers
 # no rollback (the previous image is simply gone), and it makes every deploy
-# hostage to that host's Docker networking. Building here instead and having the
-# host `docker compose pull` fixes all four at once.
+# hostage to that host's Docker build networking. Building here instead and
+# having the host `docker compose pull` fixes all four at once.
 #
-# Images are tagged with BOTH:
-#   * `sha-<short-sha>` - immutable. This is what makes rollback possible:
-#     `IMAGE_TAG=sha-abc1234 ./deploy.sh` redeploys an exact prior build.
-#   * `latest`          - moving pointer to the newest master build.
+# TAGGING AND THE `latest` CONTRACT
+#
+# Each image is published under an immutable `sha-<12-char-sha>` tag. That is
+# what makes rollback possible: `IMAGE_TAG=sha-abc123456789 ./deploy.sh`
+# redeploys an exact prior build. 12 characters rather than git's default 7:
+# these tags are the rollback handle, and a 7-char prefix collision would make
+# an operator's chosen tag silently ambiguous.
+#
+# `latest` is published by a SEPARATE `promote-latest` job, never by the build
+# matrix, for two reasons:
+#
+#   1. `workflow_dispatch` can be run from ANY branch. If the matrix pushed
+#      `latest` directly, a manual run from a feature branch would overwrite the
+#      tag that production pulls by default with unmerged code. `promote-latest`
+#      is gated on `refs/heads/master`.
+#   2. The matrix builds the two images as independent jobs. If `latest` were
+#      pushed per-job, a run where `server` succeeded and `internal-service`
+#      failed would leave `latest` pointing at a MISMATCHED pair, and a deploy
+#      using the default tag would pull two versions that never shipped
+#      together. `promote-latest` needs the whole matrix to succeed, so `latest`
+#      only ever advances as a complete set.
 #
 # ONE-TIME MANUAL SETUP
 #
@@ -58,8 +75,21 @@ jobs:
         include:
           - image: server
             dockerfile: ./docker/workspace-server/Dockerfile
+            # Smoke-test config. The server refuses to start without a master
+            # password, and we exercise the filesystem backend because that is
+            # what production runs.
+            smoke_port: 12349
+            smoke_env: >-
+              -e WORKSPACE_MASTER_PASSWORD=ci-smoke-test
+              -e WORKSPACE_BACKEND=filesystem
+              -e WORKSPACE_DATA_DIR=/data/server
+              -e WORKSPACE_BIND_ADDR=0.0.0.0:12349
           - image: internal-service
             dockerfile: ./docker/internal-service/Dockerfile
+            smoke_port: 12345
+            smoke_env: >-
+              -e INTERNAL_SERVICE_PORT=12345
+              -e INTERNAL_SERVICE_BIND_HOST=0.0.0.0
 
     steps:
       - uses: actions/checkout@v4
@@ -80,14 +110,16 @@ jobs:
           sudo apt-get clean
           df -h
 
+      - uses: docker/setup-buildx-action@v3
+
       - name: Compute image reference
         # Docker image references MUST be lowercase, but the org is spelled
         # `Avarok-Cybersecurity`. Passing ${{ github.repository_owner }} straight
         # into a tag produces `ghcr.io/Avarok-Cybersecurity/...`, which the daemon
-        # rejects with "repository name must be lowercase". Lowercase it here.
+        # rejects with "repository name must be lowercase".
         run: |
           echo "IMAGE=ghcr.io/${GITHUB_REPOSITORY_OWNER,,}/citadel-workspace-${{ matrix.image }}" >> "$GITHUB_ENV"
-          echo "SHA_TAG=sha-$(git rev-parse --short HEAD)" >> "$GITHUB_ENV"
+          echo "SHA_TAG=sha-${GITHUB_SHA:0:12}" >> "$GITHUB_ENV"
 
       - name: Log in to GHCR
         uses: docker/login-action@v3
@@ -96,7 +128,7 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Build and push
+      - name: Build production image (load locally, do NOT push yet)
         uses: docker/build-push-action@v6
         with:
           context: .
@@ -106,19 +138,84 @@ jobs:
           # that docker-compose.yml (which pins no target) keeps working. Omitting
           # this line would publish the 5.6 GB toolchain image.
           target: production
-          push: true
+          # Load into the local daemon instead of pushing, so the smoke test below
+          # runs against the EXACT artifact that will be published. Pushing first
+          # and testing afterwards would leave a broken image in the registry for
+          # anyone who pulled in between.
+          load: true
+          push: false
           build-args: |
             INTERNAL_SERVICE_PORT=12345
-          tags: |
-            ${{ env.IMAGE }}:latest
-            ${{ env.IMAGE }}:${{ env.SHA_TAG }}
-          # No BuildKit `gha` cache on purpose: the builder stage is ~5.6 GB and
-          # the Actions cache is capped at 10 GB, so caching these layers evicts
-          # itself and produces flaky, slow builds. This job runs once per merge to
-          # master; a clean build is the reliable choice.
+          tags: ${{ env.IMAGE }}:${{ env.SHA_TAG }}
 
-      - name: Report published tags
+      - name: Smoke test the image before publishing
+        # The runtime stages deliberately omit the toolchain, the source tree and
+        # most OS packages. A missing shared library, a missing runtime asset
+        # (kernel.toml / documents/), or a broken CMD would otherwise only surface
+        # during an actual deploy. This starts the real image and probes it with
+        # `nc -z` - the same check the compose healthchecks use - so a broken image
+        # can never reach the registry.
         run: |
-          echo "Published:"
-          echo "  ${IMAGE}:latest"
-          echo "  ${IMAGE}:${SHA_TAG}   <- pin this to roll back"
+          set -euo pipefail
+          name="smoke-${{ matrix.image }}"
+          docker run -d --name "$name" ${{ matrix.smoke_env }} "$IMAGE:$SHA_TAG"
+
+          ok=0
+          for _ in $(seq 1 45); do
+            state=$(docker inspect -f '{{.State.Status}}' "$name" 2>/dev/null || echo gone)
+            if [ "$state" != "running" ]; then
+              echo "Container is '$state' - it exited instead of serving."
+              break
+            fi
+            if docker exec "$name" nc -z 127.0.0.1 ${{ matrix.smoke_port }} 2>/dev/null; then
+              ok=1
+              break
+            fi
+            sleep 2
+          done
+
+          if [ "$ok" -ne 1 ]; then
+            echo "::error::${{ matrix.image }} production image failed its smoke test - not publishing."
+            docker logs "$name" 2>&1 | tail -50 || true
+            exit 1
+          fi
+          echo "${{ matrix.image }} is listening on ${{ matrix.smoke_port }}; image is good."
+          docker rm -f "$name" >/dev/null 2>&1 || true
+
+      - name: Push immutable SHA tag
+        # Only the immutable tag is pushed here. `latest` is advanced by the
+        # `promote-latest` job below, and only when the whole matrix succeeded on
+        # master - see the header comment.
+        run: docker push "$IMAGE:$SHA_TAG"
+
+  promote-latest:
+    name: Promote latest
+    # `needs` requires EVERY matrix job to have succeeded. Combined with the
+    # master-only guard, this is what guarantees `latest` never points at a
+    # half-published release or at unmerged code from a manual branch dispatch.
+    needs: publish
+    if: github.ref == 'refs/heads/master'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Point latest at this release
+        # `imagetools create` retags in the registry by manifest reference - it
+        # does not pull or rebuild the image, so the bits under `latest` are
+        # byte-identical to the SHA tag that just passed its smoke test.
+        run: |
+          set -euo pipefail
+          sha_tag="sha-${GITHUB_SHA:0:12}"
+          for img in server internal-service; do
+            image="ghcr.io/${GITHUB_REPOSITORY_OWNER,,}/citadel-workspace-${img}"
+            echo "Promoting ${image}:${sha_tag} -> ${image}:latest"
+            docker buildx imagetools create -t "${image}:latest" "${image}:${sha_tag}"
+          done
+          echo "Rollback handle for this release: IMAGE_TAG=${sha_tag}"

--- a/.github/workflows/publish-images.yml
+++ b/.github/workflows/publish-images.yml
@@ -75,6 +75,11 @@ jobs:
         include:
           - image: server
             dockerfile: ./docker/workspace-server/Dockerfile
+            # The server Dockerfile declares no build args. Passing an ARG a Dockerfile does not
+            # declare is a silent no-op that Docker only warns about, so build args are scoped
+            # per-image here rather than passed globally to both.
+            build_args: ""
+
             # Smoke-test config. The server refuses to start without a master
             # password, and we exercise the filesystem backend because that is
             # what production runs.
@@ -93,6 +98,10 @@ jobs:
               -e WORKSPACE_BIND_ADDR=127.0.0.1:12349
           - image: internal-service
             dockerfile: ./docker/internal-service/Dockerfile
+            # Only this Dockerfile declares INTERNAL_SERVICE_PORT (it is baked into the image's
+            # ENV and expanded by its CMD at runtime).
+            build_args: |
+              INTERNAL_SERVICE_PORT=12345
             smoke_port: 12345
             # Loopback, for the same reason as the server above.
             smoke_env: >-
@@ -152,8 +161,7 @@ jobs:
           # anyone who pulled in between.
           load: true
           push: false
-          build-args: |
-            INTERNAL_SERVICE_PORT=12345
+          build-args: ${{ matrix.build_args }}
           tags: ${{ env.IMAGE }}:${{ env.SHA_TAG }}
           # Stamp the commit into the image itself. `latest` is a MUTABLE tag on two
           # INDEPENDENT registry repositories, and no registry offers an atomic

--- a/.github/workflows/publish-images.yml
+++ b/.github/workflows/publish-images.yml
@@ -79,17 +79,25 @@ jobs:
             # password, and we exercise the filesystem backend because that is
             # what production runs.
             smoke_port: 12349
+            # Bind to LOOPBACK, matching the production default. Nothing is published out of
+            # the container anyway (the smoke run uses no `-p` and no host networking, so the
+            # listener is confined to the container's own network namespace), and the probe
+            # runs via `docker exec` inside that namespace - so loopback costs nothing. But
+            # this repository has a self-hosted runner, and a container that binds 0.0.0.0 is
+            # one `-p` or one `network_mode: host` away from putting a server with a known
+            # password on someone's LAN. Default to the narrow thing.
             smoke_env: >-
               -e WORKSPACE_MASTER_PASSWORD=ci-smoke-test
               -e WORKSPACE_BACKEND=filesystem
               -e WORKSPACE_DATA_DIR=/data/server
-              -e WORKSPACE_BIND_ADDR=0.0.0.0:12349
+              -e WORKSPACE_BIND_ADDR=127.0.0.1:12349
           - image: internal-service
             dockerfile: ./docker/internal-service/Dockerfile
             smoke_port: 12345
+            # Loopback, for the same reason as the server above.
             smoke_env: >-
               -e INTERNAL_SERVICE_PORT=12345
-              -e INTERNAL_SERVICE_BIND_HOST=0.0.0.0
+              -e INTERNAL_SERVICE_BIND_HOST=127.0.0.1
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/publish-images.yml
+++ b/.github/workflows/publish-images.yml
@@ -1,0 +1,124 @@
+# =============================================================================
+# Publish container images to GHCR.
+#
+# WHY THIS EXISTS
+#
+# Deploys previously built images ON the production host (`deploy.sh` ran
+# `docker compose build`). That is slow (a full Rust release build per deploy),
+# it requires the source tree and a toolchain on the production box, it offers
+# no rollback (the previous image is simply gone), and it makes every deploy
+# hostage to that host's Docker networking. Building here instead and having the
+# host `docker compose pull` fixes all four at once.
+#
+# Images are tagged with BOTH:
+#   * `sha-<short-sha>` - immutable. This is what makes rollback possible:
+#     `IMAGE_TAG=sha-abc1234 ./deploy.sh` redeploys an exact prior build.
+#   * `latest`          - moving pointer to the newest master build.
+#
+# ONE-TIME MANUAL SETUP
+#
+# GHCR packages are created PRIVATE. After the first successful run, open each
+# package's settings on GitHub and set its visibility to Public, otherwise every
+# developer must `docker login ghcr.io` before they can pull. The repositories
+# themselves are already public, so there is nothing secret in these images.
+#
+# WHY `ui` IS NOT PUBLISHED HERE (yet)
+#
+# The production UI image bakes `VITE_WS_URL` at build time, and its nginx CSP
+# is `connect-src 'self'` - so a UI served on :8080 cannot reach an agent on
+# :12345. Publishing it today would ship an artifact that cannot work for the
+# local-agent deployment. It gets added once the same-origin `/ws` reverse proxy
+# (and the matching frontend change to derive the URL from `window.location`)
+# lands.
+# =============================================================================
+name: Publish Images
+
+on:
+  push:
+    branches: ["master"]
+  workflow_dispatch:
+
+# Never cancel a publish mid-push: a half-pushed manifest is worse than a slow
+# one, and unlike `validate.yml` these runs have side effects outside the runner.
+concurrency:
+  group: publish-images-${{ github.ref }}
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  publish:
+    name: Publish ${{ matrix.image }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - image: server
+            dockerfile: ./docker/workspace-server/Dockerfile
+          - image: internal-service
+            dockerfile: ./docker/internal-service/Dockerfile
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Free Disk Space
+        # The `builder` stage is ~5.6 GB (full Rust toolchain + target/). A stock
+        # GitHub runner does not have room for it alongside the preinstalled
+        # toolchains, and the failure mode is an opaque "no space left on device"
+        # deep inside a cargo build. Same step validate.yml already uses.
+        run: |
+          sudo rm -rf /usr/share/dotnet
+          sudo rm -rf /opt/ghc
+          sudo rm -rf /usr/local/share/boost
+          sudo rm -rf /usr/local/.ghcup
+          sudo rm -rf "$AGENT_TOOLSDIRECTORY"
+          sudo apt-get clean
+          df -h
+
+      - name: Compute image reference
+        # Docker image references MUST be lowercase, but the org is spelled
+        # `Avarok-Cybersecurity`. Passing ${{ github.repository_owner }} straight
+        # into a tag produces `ghcr.io/Avarok-Cybersecurity/...`, which the daemon
+        # rejects with "repository name must be lowercase". Lowercase it here.
+        run: |
+          echo "IMAGE=ghcr.io/${GITHUB_REPOSITORY_OWNER,,}/citadel-workspace-${{ matrix.image }}" >> "$GITHUB_ENV"
+          echo "SHA_TAG=sha-$(git rev-parse --short HEAD)" >> "$GITHUB_ENV"
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ${{ matrix.dockerfile }}
+          # `production` is the slim runtime stage (~145 MB). Without an explicit
+          # target, Docker builds the LAST stage - which is `dev`, deliberately, so
+          # that docker-compose.yml (which pins no target) keeps working. Omitting
+          # this line would publish the 5.6 GB toolchain image.
+          target: production
+          push: true
+          build-args: |
+            INTERNAL_SERVICE_PORT=12345
+          tags: |
+            ${{ env.IMAGE }}:latest
+            ${{ env.IMAGE }}:${{ env.SHA_TAG }}
+          # No BuildKit `gha` cache on purpose: the builder stage is ~5.6 GB and
+          # the Actions cache is capped at 10 GB, so caching these layers evicts
+          # itself and produces flaky, slow builds. This job runs once per merge to
+          # master; a clean build is the reliable choice.
+
+      - name: Report published tags
+        run: |
+          echo "Published:"
+          echo "  ${IMAGE}:latest"
+          echo "  ${IMAGE}:${SHA_TAG}   <- pin this to roll back"

--- a/.github/workflows/publish-images.yml
+++ b/.github/workflows/publish-images.yml
@@ -147,6 +147,16 @@ jobs:
           build-args: |
             INTERNAL_SERVICE_PORT=12345
           tags: ${{ env.IMAGE }}:${{ env.SHA_TAG }}
+          # Stamp the commit into the image itself. `latest` is a MUTABLE tag on two
+          # INDEPENDENT registry repositories, and no registry offers an atomic
+          # multi-repository tag update -- so a promotion that succeeds for `server` and
+          # then fails for `internal-service` would leave `latest` pointing at a mismatched
+          # pair. This label is what lets `deploy.sh` detect that and refuse to deploy the
+          # mixed set, rather than silently restarting production on two images that never
+          # shipped together. The check is the safety net; the promote job is the happy path.
+          labels: |
+            org.opencontainers.image.revision=${{ github.sha }}
+            org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}
 
       - name: Smoke test the image before publishing
         # The runtime stages deliberately omit the toolchain, the source tree and

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -434,17 +434,20 @@ jobs:
           ./scripts/verify-image-revisions.sh rev-none rev-none
           echo "PASS: unlabelled images fall back to a warning."
 
-      - name: Missing image is refused, not silently passed
-        # `docker image inspect` fails for an image that was never pulled. That must NOT be
-        # mistaken for "no label, carry on".
+      - name: A MISSING image is refused, not treated as unlabelled
+        # `docker image inspect` fails outright for an image that was never pulled. That must NOT
+        # be conflated with "inspected fine, but carries no label" - an image we cannot see is an
+        # image we cannot verify, so it has to fail the gate rather than slip through the
+        # warn-and-continue path. Asserting the FAILURE here is the point: an earlier version of
+        # this step passed whichever way the script behaved, which pinned the bypass instead of
+        # catching it.
         run: |
           set -euo pipefail
           if ./scripts/verify-image-revisions.sh rev-a definitely-not-pulled:latest 2>/dev/null; then
-            echo "WARNING: a missing image was treated as unlabelled (warn-and-continue)."
-            echo "That is the documented fallback, but note the deploy would then rely on"
-            echo "'docker compose up' failing on the missing image instead."
+            echo "::error::The gate ALLOWED an image it could not even inspect. A partially completed 'docker compose pull' would sail straight through the release-consistency check."
+            exit 1
           fi
-          echo "PASS: behaviour is pinned."
+          echo "PASS: an un-inspectable image is refused."
 
       - name: deploy.sh parses
         run: bash -n deploy.sh && bash -n scripts/verify-image-revisions.sh

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -386,6 +386,69 @@ jobs:
           name: screenshots-${{ matrix.artifact }}
           path: citadel-workspaces/integration-tests/screenshots/
 
+  deploy-gate-tests:
+    # Regression coverage for the release-consistency gate that stands between a `docker
+    # compose pull` and a production restart. It is the mechanism that stops a partially
+    # promoted `latest` from restarting production on two backend images that never shipped
+    # together - so it must not be the one piece of the deploy path that nothing exercises.
+    #
+    # Runs against REAL images with real labels (cheap: a few `FROM busybox` layers), so it
+    # tests `docker image inspect` behaviour rather than a mock of it - including the
+    # `<no value>` string docker prints for an absent label, which is exactly the sort of
+    # detail a stub would paper over.
+    name: Deploy Gate - image revision check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Build fixture images
+        run: |
+          set -euo pipefail
+          printf 'FROM busybox\nLABEL org.opencontainers.image.revision=aaaaaaaaaaaa\n' | docker build -q -t rev-a - >/dev/null
+          printf 'FROM busybox\nLABEL org.opencontainers.image.revision=aaaaaaaaaaaa\n' | docker build -q -t rev-a-copy - >/dev/null
+          printf 'FROM busybox\nLABEL org.opencontainers.image.revision=bbbbbbbbbbbb\n' | docker build -q -t rev-b - >/dev/null
+          printf 'FROM busybox\n' | docker build -q -t rev-none - >/dev/null
+
+      - name: Matching revisions are allowed through
+        run: |
+          set -euo pipefail
+          ./scripts/verify-image-revisions.sh rev-a rev-a-copy
+          echo "PASS: images from the same commit deploy."
+
+      - name: MISMATCHED revisions abort the deploy
+        run: |
+          set -euo pipefail
+          if ./scripts/verify-image-revisions.sh rev-a rev-b; then
+            echo "::error::The gate allowed images from DIFFERENT commits through. A partial 'latest' promotion would restart production on a mismatched pair."
+            exit 1
+          fi
+          echo "PASS: mismatched images are refused."
+
+      - name: Unlabelled images warn but do not block
+        # Locally-built and pre-label images carry no revision. Blocking them would strand
+        # anyone deploying an older or locally built image, so the documented behaviour is to
+        # warn and continue - pinned here so it cannot silently become a hard failure.
+        run: |
+          set -euo pipefail
+          ./scripts/verify-image-revisions.sh rev-a rev-none
+          ./scripts/verify-image-revisions.sh rev-none rev-none
+          echo "PASS: unlabelled images fall back to a warning."
+
+      - name: Missing image is refused, not silently passed
+        # `docker image inspect` fails for an image that was never pulled. That must NOT be
+        # mistaken for "no label, carry on".
+        run: |
+          set -euo pipefail
+          if ./scripts/verify-image-revisions.sh rev-a definitely-not-pulled:latest 2>/dev/null; then
+            echo "WARNING: a missing image was treated as unlabelled (warn-and-continue)."
+            echo "That is the documented fallback, but note the deploy would then rely on"
+            echo "'docker compose up' failing on the missing image instead."
+          fi
+          echo "PASS: behaviour is pinned."
+
+      - name: deploy.sh parses
+        run: bash -n deploy.sh && bash -n scripts/verify-image-revisions.sh
+
   production-build:
     name: Production Docker Build
     runs-on: ubuntu-latest

--- a/deploy.sh
+++ b/deploy.sh
@@ -345,7 +345,12 @@ echo "  Internal service is up."
 
 # UI last (lightweight, fast restart)
 echo "  Restarting ui..."
-docker compose -f "$COMPOSE_FILE" "${PROFILE_ARGS[@]}" up -d --no-deps --build ui
+# No `--build`: the ui image was already built in step 2, BEFORE anything was restarted.
+# Rebuilding it here would reopen the exact window step 2 exists to close - a build failure at
+# this point (cache invalidation, disk pressure, a transient npm error) would land AFTER the
+# server and internal-service have already been swapped to their new images, leaving production
+# on a new backend with the old UI. Build everything first, restart afterwards.
+docker compose -f "$COMPOSE_FILE" "${PROFILE_ARGS[@]}" up -d --no-deps ui
 # Wait for nginx to actually serve (the ui healthcheck does a wget --spider
 # on :8080). Without this the deploy reports success even if nginx failed to
 # start (bad config, missing dist/) — the cloudflared step would then start

--- a/deploy.sh
+++ b/deploy.sh
@@ -170,9 +170,33 @@ else
     echo ""
 fi
 
-# Step 2: Rebuild images (only changed layers are rebuilt due to Docker cache)
-echo "[2/4] Building images..."
-docker compose -f "$COMPOSE_FILE" "${PROFILE_ARGS[@]}" build
+# Step 2: Pull prebuilt images from GHCR.
+#
+# This used to run `docker compose build`, compiling Rust on the production
+# host. That was slow (a full release build per deploy), it required the source
+# tree and a toolchain on the box, it left no way back to the previous image,
+# and it made every deploy depend on the host's Docker build networking being
+# healthy -- which on at least one deployment host it is not (a k3s/Docker
+# iptables conflict leaves the default bridge with no egress, so any build
+# needing `apt-get` or `npm` fails).
+#
+# CI now builds and publishes the images (.github/workflows/publish-images.yml)
+# and the host simply pulls them. Set IMAGE_TAG to a `sha-<short>` tag to deploy
+# or roll back to an exact prior build:
+#
+#     IMAGE_TAG=sha-abc1234 ./deploy.sh --no-pull
+#
+echo "[2/4] Pulling images (tag: ${IMAGE_TAG:-latest})..."
+docker compose -f "$COMPOSE_FILE" "${PROFILE_ARGS[@]}" pull server internal-service
+
+# The `ui` service is not published to GHCR yet -- its production image bakes
+# VITE_WS_URL at build time and its CSP cannot reach an off-origin agent, so a
+# published artifact would not actually work until the same-origin `/ws` proxy
+# lands. Until then it is still built locally, and only when it is being run.
+if docker compose -f "$COMPOSE_FILE" "${PROFILE_ARGS[@]}" config --services | grep -qx "ui"; then
+    echo "  Building ui locally (not yet published to GHCR)..."
+    docker compose -f "$COMPOSE_FILE" "${PROFILE_ARGS[@]}" build ui
+fi
 echo ""
 
 # Step 3: Rolling restart - update services one at a time
@@ -232,16 +256,19 @@ wait_for_port() {
     exit 1
 }
 
-# Server first (other services depend on it)
+# Server first (other services depend on it).
+#
+# No `--build`: the image was pulled in step 2. Leaving `--build` here would
+# silently re-compile on the host and defeat the whole point of the registry.
 echo "  Restarting server..."
-docker compose -f "$COMPOSE_FILE" "${PROFILE_ARGS[@]}" up -d --no-deps --build server
+docker compose -f "$COMPOSE_FILE" "${PROFILE_ARGS[@]}" up -d --no-deps server
 echo "  Waiting for server to be healthy..."
 wait_for_port server 12349
 echo "  Server is up."
 
 # Internal service next
 echo "  Restarting internal-service..."
-docker compose -f "$COMPOSE_FILE" "${PROFILE_ARGS[@]}" up -d --no-deps --build internal-service
+docker compose -f "$COMPOSE_FILE" "${PROFILE_ARGS[@]}" up -d --no-deps internal-service
 echo "  Waiting for internal-service to be healthy..."
 wait_for_port internal-service "${INTERNAL_SERVICE_PORT:-12345}"
 echo "  Internal service is up."

--- a/deploy.sh
+++ b/deploy.sh
@@ -220,38 +220,22 @@ fi
 # time with `org.opencontainers.image.revision` (the commit it was built from). If the
 # two disagree, abort BEFORE anything is restarted. This catches a partial promotion,
 # a hand-edited tag, or an interrupted deploy alike.
+#
+# The comparison itself lives in scripts/verify-image-revisions.sh rather than inline
+# here, because it is the safety gate and an untested safety gate is a liability. As a
+# standalone script that takes images as arguments it is exercised directly in CI
+# (validate.yml -> deploy-gate-tests) against real images with matching, mismatched and
+# absent labels. Inline in this script - wedged between an image pull and a production
+# restart - none of those paths could be tested at all.
 echo "  Verifying both images came from the same commit..."
 srv_img=$(docker compose -f "$COMPOSE_FILE" config --format json | jq -r '.services.server.image')
 is_img=$(docker compose -f "$COMPOSE_FILE" config --format json | jq -r '.services["internal-service"].image')
 
-image_revision() {
-    docker image inspect --format '{{ index .Config.Labels "org.opencontainers.image.revision" }}' "$1" 2>/dev/null || true
-}
-srv_rev=$(image_revision "$srv_img")
-is_rev=$(image_revision "$is_img")
-
-if [ -z "$srv_rev" ] || [ -z "$is_rev" ] || [ "$srv_rev" = "<no value>" ] || [ "$is_rev" = "<no value>" ]; then
-    # Images built before the label existed (or built locally). Warn rather than block:
-    # refusing to deploy an unlabelled image would strand anyone on an older build.
-    echo "  WARNING: one or both images carry no revision label; skipping the consistency check." >&2
-    echo "           (Images published by CI always carry it. Locally-built images do not.)" >&2
-elif [ "$srv_rev" != "$is_rev" ]; then
-    echo "" >&2
-    echo "ERROR: the pulled images come from DIFFERENT commits. Refusing to deploy." >&2
-    echo "  server           : $srv_img" >&2
-    echo "                     revision $srv_rev" >&2
-    echo "  internal-service : $is_img" >&2
-    echo "                     revision $is_rev" >&2
-    echo "" >&2
-    echo "  This usually means a 'latest' promotion only partially completed. Deploy an" >&2
-    echo "  explicit, immutable tag instead, which is consistent by construction:" >&2
-    echo "    IMAGE_TAG=sha-<12-char-sha> ./deploy.sh" >&2
-    echo "  Available tags: https://github.com/orgs/Avarok-Cybersecurity/packages" >&2
+if ! ./scripts/verify-image-revisions.sh "$srv_img" "$is_img"; then
     echo "" >&2
     echo "  Nothing was restarted; the running stack is untouched." >&2
     exit 1
 fi
-echo "  Both images are from commit ${srv_rev}."
 
 # The `ui` service is not published to GHCR yet -- its production image bakes
 # VITE_WS_URL at build time and its CSP cannot reach an off-origin agent, so a

--- a/deploy.sh
+++ b/deploy.sh
@@ -207,6 +207,52 @@ if ! docker compose -f "$COMPOSE_FILE" "${PROFILE_ARGS[@]}" pull server internal
     exit 1
 fi
 
+# Release-consistency gate: the two backend images MUST come from the same commit.
+#
+# `latest` is a mutable tag on two INDEPENDENT registry repositories, and no registry
+# offers an atomic multi-repository tag update. CI advances both in a `promote-latest`
+# job that only runs when every image built and passed its smoke test, but a promotion
+# that succeeds for `server` and then fails partway (transient registry/auth error)
+# would still leave `latest` pointing at a MISMATCHED pair -- and a plain `./deploy.sh`
+# would then restart production on two backend versions that never shipped together.
+#
+# Rather than trusting the tag, verify the artifacts: each image is stamped at build
+# time with `org.opencontainers.image.revision` (the commit it was built from). If the
+# two disagree, abort BEFORE anything is restarted. This catches a partial promotion,
+# a hand-edited tag, or an interrupted deploy alike.
+echo "  Verifying both images came from the same commit..."
+srv_img=$(docker compose -f "$COMPOSE_FILE" config --format json | jq -r '.services.server.image')
+is_img=$(docker compose -f "$COMPOSE_FILE" config --format json | jq -r '.services["internal-service"].image')
+
+image_revision() {
+    docker image inspect --format '{{ index .Config.Labels "org.opencontainers.image.revision" }}' "$1" 2>/dev/null || true
+}
+srv_rev=$(image_revision "$srv_img")
+is_rev=$(image_revision "$is_img")
+
+if [ -z "$srv_rev" ] || [ -z "$is_rev" ] || [ "$srv_rev" = "<no value>" ] || [ "$is_rev" = "<no value>" ]; then
+    # Images built before the label existed (or built locally). Warn rather than block:
+    # refusing to deploy an unlabelled image would strand anyone on an older build.
+    echo "  WARNING: one or both images carry no revision label; skipping the consistency check." >&2
+    echo "           (Images published by CI always carry it. Locally-built images do not.)" >&2
+elif [ "$srv_rev" != "$is_rev" ]; then
+    echo "" >&2
+    echo "ERROR: the pulled images come from DIFFERENT commits. Refusing to deploy." >&2
+    echo "  server           : $srv_img" >&2
+    echo "                     revision $srv_rev" >&2
+    echo "  internal-service : $is_img" >&2
+    echo "                     revision $is_rev" >&2
+    echo "" >&2
+    echo "  This usually means a 'latest' promotion only partially completed. Deploy an" >&2
+    echo "  explicit, immutable tag instead, which is consistent by construction:" >&2
+    echo "    IMAGE_TAG=sha-<12-char-sha> ./deploy.sh" >&2
+    echo "  Available tags: https://github.com/orgs/Avarok-Cybersecurity/packages" >&2
+    echo "" >&2
+    echo "  Nothing was restarted; the running stack is untouched." >&2
+    exit 1
+fi
+echo "  Both images are from commit ${srv_rev}."
+
 # The `ui` service is not published to GHCR yet -- its production image bakes
 # VITE_WS_URL at build time and its CSP cannot reach an off-origin agent, so a
 # published artifact would not actually work until the same-origin `/ws` proxy

--- a/deploy.sh
+++ b/deploy.sh
@@ -181,13 +181,31 @@ fi
 # needing `apt-get` or `npm` fails).
 #
 # CI now builds and publishes the images (.github/workflows/publish-images.yml)
-# and the host simply pulls them. Set IMAGE_TAG to a `sha-<short>` tag to deploy
-# or roll back to an exact prior build:
+# and the host simply pulls them. Set IMAGE_TAG to a `sha-<12-char>` tag to
+# deploy or roll back to an exact prior build:
 #
-#     IMAGE_TAG=sha-abc1234 ./deploy.sh --no-pull
+#     IMAGE_TAG=sha-abc123456789 ./deploy.sh --no-pull
 #
+# `set -euo pipefail` (top of this file) already aborts the deploy if either of
+# the commands below fails, so a failed pull can never fall through to the
+# restart step. The explicit checks exist for the OPERATOR, not for control
+# flow: a bare `set -e` abort prints nothing, and by far the most likely failure
+# here is a 403 because the GHCR packages are still Private (they are created
+# that way and must be flipped to Public once). Naming that cause up front turns
+# a cryptic mid-deploy exit into a one-line fix.
 echo "[2/4] Pulling images (tag: ${IMAGE_TAG:-latest})..."
-docker compose -f "$COMPOSE_FILE" "${PROFILE_ARGS[@]}" pull server internal-service
+if ! docker compose -f "$COMPOSE_FILE" "${PROFILE_ARGS[@]}" pull server internal-service; then
+    echo "" >&2
+    echo "ERROR: failed to pull images (tag: ${IMAGE_TAG:-latest})." >&2
+    echo "  Common causes:" >&2
+    echo "   * The GHCR packages are still Private. They are created Private;" >&2
+    echo "     set each package's visibility to Public, or run 'docker login ghcr.io'." >&2
+    echo "   * IMAGE_TAG names a tag that was never published. List them at" >&2
+    echo "     https://github.com/orgs/Avarok-Cybersecurity/packages" >&2
+    echo "   * The publish workflow has not run yet for this commit." >&2
+    echo "  Nothing was restarted; the running stack is untouched." >&2
+    exit 1
+fi
 
 # The `ui` service is not published to GHCR yet -- its production image bakes
 # VITE_WS_URL at build time and its CSP cannot reach an off-origin agent, so a
@@ -195,9 +213,31 @@ docker compose -f "$COMPOSE_FILE" "${PROFILE_ARGS[@]}" pull server internal-serv
 # lands. Until then it is still built locally, and only when it is being run.
 if docker compose -f "$COMPOSE_FILE" "${PROFILE_ARGS[@]}" config --services | grep -qx "ui"; then
     echo "  Building ui locally (not yet published to GHCR)..."
-    docker compose -f "$COMPOSE_FILE" "${PROFILE_ARGS[@]}" build ui
+    if ! docker compose -f "$COMPOSE_FILE" "${PROFILE_ARGS[@]}" build ui; then
+        echo "" >&2
+        echo "ERROR: failed to build the ui image." >&2
+        echo "  Aborting BEFORE restarting anything, so the backend is not left on new" >&2
+        echo "  images while the ui stays on its old one." >&2
+        exit 1
+    fi
 fi
 echo ""
+
+# NOTE on the removed `target_cache` volume: the production images no longer
+# contain cargo, source or a target/ directory, so the build-cache volume was
+# dropped from the compose file. A host that ran an older revision may still
+# have the named volume lying around, wasting disk.
+#
+# It is deliberately NOT removed automatically here. Volume names are scoped by
+# compose PROJECT name, so the orphan's name depends on the directory the stack
+# was deployed from -- and on a shared host that name can collide with a live
+# volume owned by an unrelated project (on the current deployment box, a
+# `citadel-workspace_target_cache` volume belongs to the CI runner's stack). A
+# blind `docker volume rm` in a deploy script could therefore destroy someone
+# else's build cache. Remove it by hand, after checking what owns it:
+#
+#     docker volume ls | grep target_cache
+#     docker volume rm <project>_target_cache
 
 # Step 3: Rolling restart - update services one at a time
 # Data volumes are attached to containers, NOT images. Rebuilding an image

--- a/docker-compose.production.yml
+++ b/docker-compose.production.yml
@@ -46,8 +46,14 @@ services:
   # ---------------------------------------------------------------------------
   server:
     # Pull a prebuilt image from GHCR rather than compiling on the production
-    # host. `IMAGE_TAG` defaults to `latest`; pin it to a `sha-<short>` tag to
-    # roll back to an exact prior build (see .github/workflows/publish-images.yml).
+    # host. `IMAGE_TAG` defaults to `latest`; pin it to a `sha-<12-char-sha>` tag
+    # to roll back to an exact prior build (see .github/workflows/publish-images.yml).
+    #
+    # `latest` is safe as a default because CI only advances it via a `promote-latest`
+    # job that requires EVERY image in the release to have built AND passed its smoke
+    # test, and only on master -- so it can never point at a half-published release or
+    # at a manually-dispatched branch build. Pin an explicit SHA tag for a deploy you
+    # need to be able to reproduce exactly.
     image: ghcr.io/avarok-cybersecurity/citadel-workspace-server:${IMAGE_TAG:-latest}
     build:
       context: .

--- a/docker-compose.production.yml
+++ b/docker-compose.production.yml
@@ -45,12 +45,20 @@ services:
   # Data persisted to server_data volume
   # ---------------------------------------------------------------------------
   server:
+    # Pull a prebuilt image from GHCR rather than compiling on the production
+    # host. `IMAGE_TAG` defaults to `latest`; pin it to a `sha-<short>` tag to
+    # roll back to an exact prior build (see .github/workflows/publish-images.yml).
+    image: ghcr.io/avarok-cybersecurity/citadel-workspace-server:${IMAGE_TAG:-latest}
     build:
       context: .
       dockerfile: ./docker/workspace-server/Dockerfile
+      # REQUIRED. `dev` is the last stage in that Dockerfile (so that the dev
+      # compose file, which pins no target, keeps its toolchain image). Without
+      # this line a local `docker compose build` would produce the 5.6 GB
+      # toolchain image instead of the 142 MB runtime one.
+      target: production
     volumes:
       - server_data:/data/server
-      - target_cache:/usr/src/app/target
     environment:
       - RUST_LOG=citadel=info
       - WORKSPACE_MASTER_PASSWORD=${WORKSPACE_MASTER_PASSWORD}
@@ -60,12 +68,20 @@ services:
       # workspace state on the `server_data` volume defined above.
       - WORKSPACE_BACKEND=filesystem
       - WORKSPACE_DATA_DIR=/data/server
-      # With network_mode: host, bind the Citadel listener to loopback so it
-      # is reachable only by the co-located cloudflared (the protocol is E2E
-      # encrypted, but a 0.0.0.0 bind would still expose it on the host's
-      # public interfaces). Override if a remote peer must reach this server
-      # directly, and add a host firewall in that case.
-      - WORKSPACE_BIND_ADDR=127.0.0.1:12349
+      # Which interface the Citadel listener binds to.
+      #
+      # Defaults to loopback, which is correct for the co-located-cloudflared
+      # topology: the tunnel reaches the server over the host loopback, and a
+      # 0.0.0.0 bind would additionally expose it on the host's public
+      # interfaces, bypassing the Cloudflare boundary.
+      #
+      # It is now overridable because the local-agent topology needs the
+      # opposite: each user runs their own agent on their own machine and dials
+      # this server DIRECTLY over the internet, so it must bind 0.0.0.0. Set
+      # `WORKSPACE_BIND_ADDR=0.0.0.0:12349` in .env for that deployment, and put
+      # a host firewall in front of the port. The Citadel protocol is E2E
+      # encrypted, so a public bind is by design in that mode.
+      - WORKSPACE_BIND_ADDR=${WORKSPACE_BIND_ADDR:-127.0.0.1:12349}
     deploy:
       resources:
         limits:
@@ -92,14 +108,19 @@ services:
   # same address the user specified.
   # ---------------------------------------------------------------------------
   internal-service:
+    # Prebuilt image from GHCR; see the `server` service above for the IMAGE_TAG
+    # pinning / rollback contract.
+    image: ghcr.io/avarok-cybersecurity/citadel-workspace-internal-service:${IMAGE_TAG:-latest}
     build:
       context: .
       dockerfile: ./docker/internal-service/Dockerfile
+      # REQUIRED - see the `server` service. Without it a local build produces
+      # the 4.5 GB toolchain image rather than the 145 MB runtime one.
+      target: production
       args:
         - INTERNAL_SERVICE_PORT=${INTERNAL_SERVICE_PORT:-12345}
     volumes:
       - internal_service_data:/data/internal-service
-      - target_cache:/usr/src/app/target
     environment:
       - RUST_LOG=citadel=info
       - DOCKER_CONTAINER=1
@@ -262,5 +283,8 @@ volumes:
   # Application data (NEVER delete these unless you want to lose all data)
   server_data:
   internal_service_data:
-  # Build cache (safe to delete, just makes rebuilds slower)
-  target_cache:
+  # NOTE: the `target_cache` build-cache volume is gone. The production images
+  # are now slim runtime stages that contain no cargo, no source and no
+  # `target/` directory, so there was nothing left for it to cache -- it only
+  # existed to speed up in-container rebuilds of the old 5.6 GB toolchain image.
+  # The dev compose file still has its own, which is where it belongs.

--- a/docker/internal-service/Dockerfile
+++ b/docker/internal-service/Dockerfile
@@ -1,10 +1,29 @@
 # syntax=docker.io/docker/dockerfile:1.7-labs
-# Base image with Rust
-FROM rust:1.92.0
+# =============================================================================
+# Internal Service (the "citadel agent") image.
+#
+# Stages:
+#   builder     - full Rust toolchain; compiles the release binary
+#   production  - slim runtime: the ~29 MB binary + its shared libs, nothing else
+#   dev         - LAST stage, and therefore the DEFAULT build target
+#
+# STAGE ORDER IS LOAD-BEARING. `docker build` with no `--target` builds the LAST
+# stage, and `docker-compose.yml` (dev / tilt / CI integration tests) does NOT
+# pin a target for this service. If `production` were last, dev and CI would
+# silently get a toolchain-less image. `dev` therefore stays last and is
+# equivalent to the previous single-stage image.
+#
+# The slim stage matters most for THIS image: end users run the agent locally,
+# so they would otherwise each pull 4.43 GB just to launch the app. `ldd` on the
+# binary reports the same seven libs as the workspace server, and notably NO
+# GTK/GDK linkage despite the `rfd` dependency -- so no desktop stack is needed.
+# The slim stage lands at roughly 150 MB.
+# =============================================================================
+
+FROM rust:1.92.0 AS builder
 
 WORKDIR /usr/src/app
-ARG INTERNAL_SERVICE_PORT
-ENV INTERNAL_SERVICE_PORT=${INTERNAL_SERVICE_PORT}
+
 # Skip WASM build in Docker environment
 ENV SKIP_WASM_BUILD=1
 ENV DOCKER_CONTAINER=1
@@ -21,22 +40,100 @@ COPY ./citadel-workspace-internal-service /usr/src/app/citadel-workspace-interna
 COPY ./citadel-workspace-types /usr/src/app/citadel-workspace-types
 COPY ./citadel-internal-service /usr/src/app/citadel-internal-service
 
-# Dynamically expose the port from the build argument
-EXPOSE ${INTERNAL_SERVICE_PORT}
-
 # Build release binary during docker build (not at container startup).
 #
-# `deadlock-detection` was previously enabled here, but it spawns a
-# background thread that sweeps every parking_lot mutex every 5
-# seconds — pure runtime overhead in production where deadlocks should
-# be diagnosed via stack traces, not by paying the constant
-# bookkeeping cost. The feature stays available for local debugging
-# (enable explicitly when reproducing a hang) and is OFF for the
-# image that actually ships.
+# `deadlock-detection` was previously enabled here, but it spawns a background
+# thread that sweeps every parking_lot mutex every 5 seconds -- pure runtime
+# overhead in production where deadlocks should be diagnosed via stack traces,
+# not by paying the constant bookkeeping cost. The feature stays available for
+# local debugging and is OFF for the image that actually ships.
 RUN cargo build --release --bin citadel-workspace-internal-service
 
-# Copy binary to /usr/local/bin to avoid being shadowed by target_cache volume mount
+# Copy binary to /usr/local/bin so it is not shadowed by the target_cache volume
+# mount the dev compose file attaches at /usr/src/app/target.
 RUN cp ./target/release/citadel-workspace-internal-service /usr/local/bin/
+
+# =============================================================================
+# Production runtime: binary only. No toolchain, no source, no target/.
+# Selected explicitly with `target: production`; never the default (see above).
+# =============================================================================
+FROM debian:trixie-slim AS production
+
+# Runtime dependencies only, derived from `ldd` against the built binary:
+#   libssl3  - provides BOTH libssl.so.3 and libcrypto.so.3
+#   libzstd1 - libzstd.so.1
+#   zlib1g   - libz.so.1
+# (libc, libm and libgcc_s already ship in the slim base.)
+#
+# Verified NOT needed: GTK/GDK/glib. The `rfd` crate (native file dialogs) does
+# not pull a desktop stack into this binary -- `ldd` shows zero GTK linkage --
+# so there is no reason to bloat the runtime with one.
+#
+# `netcat-openbsd` is NOT optional: the compose healthchecks probe the listener
+# with `nc -z`. Without it the container sits permanently "unhealthy" and
+# deploy.sh aborts waiting on a probe that can never pass.
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+        ca-certificates \
+        libssl3 \
+        libzstd1 \
+        zlib1g \
+        netcat-openbsd && \
+    rm -rf /var/lib/apt/lists/*
+
+WORKDIR /usr/src/app
+
+# The port is baked in as an ENV because the CMD below expands it at runtime.
+# ARGs do not cross stage boundaries, so it must be re-declared here.
+ARG INTERNAL_SERVICE_PORT
+ENV INTERNAL_SERVICE_PORT=${INTERNAL_SERVICE_PORT}
+
+COPY --from=builder /usr/local/bin/citadel-workspace-internal-service /usr/local/bin/citadel-workspace-internal-service
+
+# NOTE: kernel.toml is deliberately NOT copied here. It is an input to the
+# workspace *server*; the internal service takes all of its configuration from
+# CLI flags and env vars (see the CMD below and `select_backend_type` in
+# citadel-workspace-internal-service/src/main.rs) and never reads a config file.
+
+# Data directory for the filesystem backend (a volume is mounted here)
+RUN mkdir -p /data/internal-service
+
+# Run as non-root. Same uid (1000) as the dev stage so a data volume written by
+# one stage stays writable by the other.
+RUN useradd -m -u 1000 appuser && \
+    chown appuser /usr/local/bin/citadel-workspace-internal-service && \
+    chown -R appuser /data/internal-service
+USER appuser
+
+EXPOSE ${INTERNAL_SERVICE_PORT}
+
+# Persistence is opt-in via env vars so dev (`tilt`) keeps the documented
+# ephemeral behaviour from CLAUDE.md. Production sets both vars in the compose
+# file; dev leaves them unset and the binary falls through to its in-memory
+# default.
+#
+# The shell-only `${VAR:+ --flag "$VAR"}` form expands to nothing when the env
+# var is unset, so dev gets a clean `--bind` invocation. The `$VAR` references
+# are double-quoted so a path containing whitespace survives word-splitting and
+# reaches structopt as a single argument.
+#
+# The bind host is `INTERNAL_SERVICE_BIND_HOST` (default `0.0.0.0`).
+CMD ["sh", "-c", "/usr/local/bin/citadel-workspace-internal-service --bind ${INTERNAL_SERVICE_BIND_HOST:-0.0.0.0}:${INTERNAL_SERVICE_PORT}${INTERNAL_SERVICE_BACKEND:+ --backend \"$INTERNAL_SERVICE_BACKEND\"}${INTERNAL_SERVICE_DATA_DIR:+ --data-dir \"$INTERNAL_SERVICE_DATA_DIR\"}"]
+
+# =============================================================================
+# Dev runtime: equivalent to the previous single-stage image. Retains the
+# toolchain, source and target/ for the tilt rebuild loop.
+#
+# MUST REMAIN THE LAST STAGE -- it is the default target for docker-compose.yml,
+# which pins no target for this service.
+# =============================================================================
+FROM builder AS dev
+
+ARG INTERNAL_SERVICE_PORT
+ENV INTERNAL_SERVICE_PORT=${INTERNAL_SERVICE_PORT}
+
+# Dynamically expose the port from the build argument
+EXPOSE ${INTERNAL_SERVICE_PORT}
 
 # Create data directory for persistent storage
 RUN mkdir -p /data/internal-service
@@ -47,26 +144,4 @@ RUN chown appuser /usr/local/bin/citadel-workspace-internal-service
 RUN chown -R appuser /data/internal-service
 USER appuser
 
-# Run the pre-built internal service binary.
-#
-# Persistence is opt-in via env vars so dev (`tilt`) keeps the
-# documented ephemeral behaviour from CLAUDE.md ("any accounts created
-# on one will be lost on reload"). Production sets both vars in
-# docker-compose.production.yml; dev leaves them unset and the binary
-# falls through to its in-memory default.
-#
-# The shell-only `${VAR:+ --flag "$VAR"}` form expands to nothing when
-# the env var is unset, so dev gets a clean `--bind` invocation. The
-# `$VAR` references are double-quoted so a path containing whitespace
-# (e.g. `INTERNAL_SERVICE_DATA_DIR=/my data`) survives shell
-# word-splitting and reaches structopt as a single CLI argument
-# instead of being split into "/my" and "data".
-#
-# The bind host is `INTERNAL_SERVICE_BIND_HOST` (default `0.0.0.0`). Dev
-# (bridge networking) leaves it unset so other containers can reach the
-# service. Production uses `network_mode: host` and sets it to `127.0.0.1`
-# so the WebSocket control plane is reachable only by the co-located
-# cloudflared/nginx over loopback and is NOT exposed on the host's public
-# interfaces (which `0.0.0.0` + host networking would do, bypassing the
-# Cloudflare TLS/Access boundary).
 CMD ["sh", "-c", "/usr/local/bin/citadel-workspace-internal-service --bind ${INTERNAL_SERVICE_BIND_HOST:-0.0.0.0}:${INTERNAL_SERVICE_PORT}${INTERNAL_SERVICE_BACKEND:+ --backend \"$INTERNAL_SERVICE_BACKEND\"}${INTERNAL_SERVICE_DATA_DIR:+ --data-dir \"$INTERNAL_SERVICE_DATA_DIR\"}"]

--- a/docker/internal-service/Dockerfile
+++ b/docker/internal-service/Dockerfile
@@ -60,7 +60,11 @@ RUN cp ./target/release/citadel-workspace-internal-service /usr/local/bin/
 FROM debian:trixie-slim AS production
 
 # Runtime dependencies only, derived from `ldd` against the built binary:
-#   libssl3  - provides BOTH libssl.so.3 and libcrypto.so.3
+#   libssl3t64 - provides BOTH libssl.so.3 and libcrypto.so.3. Named `libssl3t64`, not
+#                `libssl3`: on Debian trixie the 64-bit time_t transition renamed the real
+#                package, and `libssl3` survives only as a virtual Provides: alias. Installing
+#                via the alias works today (verified), but naming the real package is explicit
+#                and does not depend on an alias that a future point release may drop.
 #   libzstd1 - libzstd.so.1
 #   zlib1g   - libz.so.1
 # (libc, libm and libgcc_s already ship in the slim base.)
@@ -75,7 +79,7 @@ FROM debian:trixie-slim AS production
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
         ca-certificates \
-        libssl3 \
+        libssl3t64 \
         libzstd1 \
         zlib1g \
         netcat-openbsd && \

--- a/docker/workspace-server/Dockerfile
+++ b/docker/workspace-server/Dockerfile
@@ -67,7 +67,11 @@ RUN cp ./target/release/citadel-workspace-server-kernel /usr/local/bin/
 FROM debian:trixie-slim AS production
 
 # Runtime dependencies only, derived from `ldd` against the built binary:
-#   libssl3  - provides BOTH libssl.so.3 and libcrypto.so.3
+#   libssl3t64 - provides BOTH libssl.so.3 and libcrypto.so.3. Named `libssl3t64`, not
+#                `libssl3`: on Debian trixie the 64-bit time_t transition renamed the real
+#                package, and `libssl3` survives only as a virtual Provides: alias. Installing
+#                via the alias works today (verified), but naming the real package is explicit
+#                and does not depend on an alias that a future point release may drop.
 #   libzstd1 - libzstd.so.1
 #   zlib1g   - libz.so.1
 # (libc, libm and libgcc_s already ship in the slim base.)
@@ -81,7 +85,7 @@ FROM debian:trixie-slim AS production
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
         ca-certificates \
-        libssl3 \
+        libssl3t64 \
         libzstd1 \
         zlib1g \
         netcat-openbsd && \

--- a/docker/workspace-server/Dockerfile
+++ b/docker/workspace-server/Dockerfile
@@ -1,6 +1,29 @@
 # syntax=docker.io/docker/dockerfile:1.7-labs
-# Base image with Rust
-FROM rust:1.92.0
+# =============================================================================
+# Workspace Server image.
+#
+# Stages:
+#   builder     - full Rust toolchain; compiles the release binary
+#   production  - slim runtime: the ~29 MB binary + its shared libs, nothing else
+#   dev         - LAST stage, and therefore the DEFAULT build target
+#
+# STAGE ORDER IS LOAD-BEARING. `docker build` with no `--target` builds the
+# LAST stage, and `docker-compose.yml` (dev / tilt / CI integration tests) does
+# NOT pin a target for this service -- unlike `ui`, which pins `target: dev`.
+# If `production` were last, every dev and CI build would silently receive a
+# toolchain-less image and the `target_cache`-backed rebuild loop would break.
+# So `dev` is kept last and is equivalent to the previous single-stage image;
+# production opts in explicitly via `target: production`.
+#
+# Why a slim runtime stage exists at all: the single-stage image was 5.65 GB,
+# because it shipped the Rust toolchain, the full source tree and `target/` to
+# production. The binary is 29 MB, and `ldd` reports it needs only libssl3 /
+# libcrypto3, libzstd1 and libz on top of what the base already carries (libc,
+# libgcc, libm). Publishing 5.65 GB to a registry -- and making every developer
+# pull it -- is untenable; the slim stage lands at roughly 150 MB instead.
+# =============================================================================
+
+FROM rust:1.92.0 AS builder
 
 WORKDIR /usr/src/app
 
@@ -22,8 +45,6 @@ COPY ./docker/workspace-server/citadel-workspace-server-kernel.Cargo.docker.toml
 COPY ./citadel-workspace-internal-service /usr/src/app/citadel-workspace-internal-service
 COPY ./citadel-workspace-types /usr/src/app/citadel-workspace-types
 COPY ./citadel-internal-service /usr/src/app/citadel-internal-service
-# Expose port if server listens on one (replace 12349 with actual port if needed)
-EXPOSE 12349
 
 # Set environment variables for build - skips WASM build in Docker
 ENV SKIP_WASM_BUILD=1
@@ -35,10 +56,74 @@ RUN cargo clippy --bin citadel-workspace-server-kernel
 # Build release binary to avoid dev-dependency features leaking through
 RUN cargo build --release --bin citadel-workspace-server-kernel
 
-# Copy binary to /usr/local/bin to avoid being shadowed by target_cache volume mount
-# The docker-compose.yml mounts a volume at /usr/src/app/target for cargo caching,
-# which would hide the binary built in the image. This copy ensures the binary is available.
+# Copy binary to /usr/local/bin so it is not shadowed by the target_cache volume
+# mount the dev compose file attaches at /usr/src/app/target.
 RUN cp ./target/release/citadel-workspace-server-kernel /usr/local/bin/
+
+# =============================================================================
+# Production runtime: binary + assets only. No toolchain, no source, no target/.
+# Selected explicitly with `target: production`; never the default (see above).
+# =============================================================================
+FROM debian:trixie-slim AS production
+
+# Runtime dependencies only, derived from `ldd` against the built binary:
+#   libssl3  - provides BOTH libssl.so.3 and libcrypto.so.3
+#   libzstd1 - libzstd.so.1
+#   zlib1g   - libz.so.1
+# (libc, libm and libgcc_s already ship in the slim base.)
+#
+# `netcat-openbsd` is NOT optional: the compose healthchecks probe the listener
+# with `nc -z 127.0.0.1 12349`. Without it the container would sit permanently
+# "unhealthy" and deploy.sh would abort every deploy waiting on a probe that
+# can never pass.
+#
+# `ca-certificates` is required for outbound TLS verification.
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+        ca-certificates \
+        libssl3 \
+        libzstd1 \
+        zlib1g \
+        netcat-openbsd && \
+    rm -rf /var/lib/apt/lists/*
+
+WORKDIR /usr/src/app
+
+COPY --from=builder /usr/local/bin/citadel-workspace-server-kernel /usr/local/bin/citadel-workspace-server-kernel
+
+# kernel.toml and documents/ are RUNTIME assets, not build inputs: `content_base_dir`
+# in kernel.toml points at documents/defaults/root, which the server reads on first
+# boot to seed the initial workspace structure. Omitting them would leave the server
+# unable to start.
+COPY ./docker/workspace-server/kernel.toml /usr/src/app/kernel.toml
+COPY ./docker/workspace-server/documents /usr/src/app/documents
+
+# Data directory for the filesystem backend (a volume is mounted here in production)
+RUN mkdir -p /data/server
+
+# Run as non-root. Same uid (1000) as the dev stage so a data volume written by
+# one stage stays writable by the other.
+RUN useradd -m -u 1000 appuser && \
+    chown appuser /usr/local/bin/citadel-workspace-server-kernel && \
+    chown appuser /usr/src/app/kernel.toml && \
+    chown -R appuser /usr/src/app/documents && \
+    chown -R appuser /data/server
+USER appuser
+
+EXPOSE 12349
+
+CMD ["/usr/local/bin/citadel-workspace-server-kernel", "--config", "/usr/src/app/kernel.toml"]
+
+# =============================================================================
+# Dev runtime: equivalent to the previous single-stage image. Retains the
+# toolchain, source and target/ for the tilt rebuild loop.
+#
+# MUST REMAIN THE LAST STAGE -- it is the default target for docker-compose.yml,
+# which pins no target for this service.
+# =============================================================================
+FROM builder AS dev
+
+EXPOSE 12349
 
 # Create data directory for persistent storage
 RUN mkdir -p /data/server

--- a/scripts/verify-image-revisions.sh
+++ b/scripts/verify-image-revisions.sh
@@ -37,11 +37,21 @@ fi
 
 REVISION_LABEL="org.opencontainers.image.revision"
 
+# Print the image's revision label on stdout.
+#
+# Exit 0  = the image was inspected successfully (the label may still be empty).
+# Exit 1  = the image could NOT be inspected at all.
+#
+# Those two must NOT be conflated. Swallowing an inspect failure as "no label" would let a
+# MISSING image - a half-completed `docker compose pull`, a typo'd tag, a dead daemon - slip
+# through the warn-and-continue path and bypass the gate entirely, which is exactly the
+# outcome this script exists to prevent.
 image_revision() {
-    # `docker image inspect` prints the literal string `<no value>` when the label
-    # is absent, so normalise that to an empty string.
     local rev
-    rev=$(docker image inspect --format "{{ index .Config.Labels \"$REVISION_LABEL\" }}" "$1" 2>/dev/null || true)
+    if ! rev=$(docker image inspect --format "{{ index .Config.Labels \"$REVISION_LABEL\" }}" "$1" 2>/dev/null); then
+        return 1
+    fi
+    # `docker image inspect` prints the literal string `<no value>` when the label is absent.
     if [ "$rev" = "<no value>" ]; then
         rev=""
     fi
@@ -53,7 +63,15 @@ reference_img=""
 unlabelled=0
 
 for img in "$@"; do
-    rev=$(image_revision "$img")
+    if ! rev=$(image_revision "$img"); then
+        echo "" >&2
+        echo "ERROR: cannot inspect ${img}. Refusing to deploy." >&2
+        echo "  The image is not present locally. Most likely the pull did not complete," >&2
+        echo "  or the tag does not exist in the registry." >&2
+        echo "  This is NOT the same as an image without a revision label: an image we cannot" >&2
+        echo "  see is an image we cannot verify, so the release-consistency gate cannot pass." >&2
+        exit 1
+    fi
 
     if [ -z "$rev" ]; then
         # Images built before the label existed, or built locally, carry no revision.

--- a/scripts/verify-image-revisions.sh
+++ b/scripts/verify-image-revisions.sh
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+# =============================================================================
+# Verify that a set of container images were all built from the SAME commit.
+#
+# WHY THIS IS A SEPARATE, TESTABLE SCRIPT
+#
+# `latest` is a mutable tag on INDEPENDENT registry repositories, and no registry
+# offers an atomic multi-repository tag update. CI advances the tags in a
+# `promote-latest` job that only runs once every image has built and passed its
+# smoke test, but a promotion that succeeds for one image and then fails partway
+# (transient registry / auth error) would still leave `latest` pointing at a
+# MISMATCHED pair. A plain `./deploy.sh` would then restart production on two
+# backend versions that never shipped together.
+#
+# So rather than trusting the tag, we verify the artifacts: CI stamps every image
+# with `org.opencontainers.image.revision` (the commit it was built from), and
+# this script refuses the deploy if they disagree.
+#
+# It lives outside deploy.sh because it is the SAFETY GATE - an untested safety
+# gate is a liability. Pulled out here it takes images as arguments, touches no
+# global state, and is exercised directly by CI
+# (.github/workflows/validate.yml -> deploy-gate-tests) against real images with
+# matching, mismatched, and absent labels.
+#
+# Usage:   verify-image-revisions.sh <image> [<image> ...]
+# Exit 0:  all images carry the same revision, OR one or more carry no label at
+#          all (a warning - locally-built and pre-label images are not blocked).
+# Exit 1:  two images carry DIFFERENT revisions.
+# =============================================================================
+
+set -euo pipefail
+
+if [ "$#" -lt 2 ]; then
+    echo "usage: $0 <image> <image> [<image> ...]" >&2
+    exit 2
+fi
+
+REVISION_LABEL="org.opencontainers.image.revision"
+
+image_revision() {
+    # `docker image inspect` prints the literal string `<no value>` when the label
+    # is absent, so normalise that to an empty string.
+    local rev
+    rev=$(docker image inspect --format "{{ index .Config.Labels \"$REVISION_LABEL\" }}" "$1" 2>/dev/null || true)
+    if [ "$rev" = "<no value>" ]; then
+        rev=""
+    fi
+    printf '%s' "$rev"
+}
+
+reference_rev=""
+reference_img=""
+unlabelled=0
+
+for img in "$@"; do
+    rev=$(image_revision "$img")
+
+    if [ -z "$rev" ]; then
+        # Images built before the label existed, or built locally, carry no revision.
+        # Warn but do not block: refusing to deploy an unlabelled image would strand
+        # anyone on an older build or a local build.
+        echo "WARNING: ${img} carries no ${REVISION_LABEL} label; cannot verify it." >&2
+        unlabelled=1
+        continue
+    fi
+
+    if [ -z "$reference_rev" ]; then
+        reference_rev="$rev"
+        reference_img="$img"
+        continue
+    fi
+
+    if [ "$rev" != "$reference_rev" ]; then
+        echo "" >&2
+        echo "ERROR: these images were built from DIFFERENT commits. Refusing to deploy." >&2
+        echo "  ${reference_img}" >&2
+        echo "    revision ${reference_rev}" >&2
+        echo "  ${img}" >&2
+        echo "    revision ${rev}" >&2
+        echo "" >&2
+        echo "  This usually means a 'latest' promotion only partially completed. Deploy an" >&2
+        echo "  explicit, immutable tag instead, which is consistent by construction:" >&2
+        echo "    IMAGE_TAG=sha-<12-char-sha> ./deploy.sh" >&2
+        echo "  Available tags: https://github.com/orgs/Avarok-Cybersecurity/packages" >&2
+        exit 1
+    fi
+done
+
+if [ "$unlabelled" -eq 1 ]; then
+    echo "Revision check skipped: at least one image carries no revision label."
+    exit 0
+fi
+
+echo "All images are from commit ${reference_rev}."


### PR DESCRIPTION
## Overview

Deploys currently build images **on the production host** (`deploy.sh` runs `docker compose build`). That has four separate problems:

1. **The images are enormous.** The Rust Dockerfiles are single-stage (`FROM rust:1.92.0`, full stop), so the final images ship the entire Rust toolchain, the full source tree and `target/` to production: **server 5.65 GB, internal-service 4.43 GB**. The server binary is **29 MB**.
2. **Every deploy is a full Rust release build** on the box — many minutes of compile for what should be a file copy.
3. **No rollback.** The previous image is simply gone once rebuilt.
4. **Every deploy depends on the host's Docker build networking.** On the current deployment host it is broken: k3s/kube-router owns the iptables `FORWARD` chain (policy `DROP`), and Docker's bridge ACCEPT rule sits at position 13,274 having passed **zero packets ever**. The default bridge therefore has **no outbound connectivity at all** — not just DNS — so any `apt-get`/`npm` in a Dockerfile fails. Building on the host is hostage to that.

## Fix

Build images in CI, publish them to GHCR, and have the host **pull** instead of build. The host stops building entirely, which makes problem 4 irrelevant rather than working around it.

### 1. Slim multi-stage runtime images

Both Rust Dockerfiles gain a `production` target: a `rust:1.92.0` builder stage, then a `debian:trixie-slim` runtime stage carrying only the binary, its runtime assets and its shared libraries. The dependency list is derived from `ldd` against the built binaries (`libssl3`, `libzstd1`, `zlib1g` on top of what the slim base already has), plus `netcat-openbsd` — which is **not** optional, because the compose healthchecks probe the listener with `nc -z` and would otherwise never pass.

| Image | Before | After |
|---|---|---|
| workspace-server | 5.65 GB | **142 MB** |
| internal-service | 4.43 GB | **145 MB** |

This mirrors a pattern already in the repo — `docker/ui/Dockerfile` is already `dev` → `build` → `production`.

**Stage order is load-bearing.** `docker build` with no `--target` builds the *last* stage, and `docker-compose.yml` (dev / tilt / CI integration tests) pins **no target** for these two services, unlike `ui` which pins `target: dev`. So `dev` is deliberately kept as the **last** stage and remains equivalent to the previous single-stage image; production opts in explicitly with `target: production`. Putting `production` last would have silently handed every dev and CI build a toolchain-less image.

Also verified: despite the `rfd` dependency (native file dialogs), the internal-service binary has **zero GTK/GDK linkage**, so no desktop stack has to be dragged into its runtime.

### 2. Publish workflow

`.github/workflows/publish-images.yml` builds and pushes on merge to `master` (plus `workflow_dispatch`), tagging each image with both `latest` and an immutable `sha-<short>`.

### 3. Host pulls instead of builds

`docker-compose.production.yml` gains `image: ghcr.io/...:${IMAGE_TAG:-latest}` and `target: production`; `deploy.sh` pulls rather than builds. Rollback becomes:

```
IMAGE_TAG=sha-abc1234 ./deploy.sh --no-pull
```

`WORKSPACE_BIND_ADDR` is now overridable (still defaulting to loopback). The loopback default is correct for the co-located-cloudflared topology, but the local-agent topology needs the opposite: each user runs their own agent and dials the server directly, so it must bind `0.0.0.0`. The Citadel protocol is E2E encrypted, so a public bind is by design in that mode.

The now-orphaned `target_cache` volume is dropped from the production compose — the runtime images contain no cargo, no source and no `target/`, so there is nothing left for it to cache. The dev compose keeps its own.

## Why `ui` is not published here

The production UI image bakes `VITE_WS_URL` at build time and its nginx CSP is `connect-src 'self'` — so a UI served on `:8080` cannot reach an agent on `:12345`. Publishing it today would ship an artifact that **cannot work** for the local-agent deployment. It joins the workflow once the same-origin `/ws` reverse proxy (and the matching frontend change to derive the URL from `window.location`) lands. `deploy.sh` still builds `ui` locally in the meantime.

## Verification (on the real deployment host)

- Both `production` targets build and were **functionally tested**, not just sized: the slim server boots, engages the filesystem backend, seeds the workspace from `documents/`, listens, and passes an actual `nc -z` probe with **zero errors/panics**. The slim agent builds, runs and listens.
- The **default** target of both Dockerfiles still contains `cargo` — confirming the dev/Tilt/CI flow is unaffected.
- `docker compose config` validates; `IMAGE_TAG=sha-abc1234` and `WORKSPACE_BIND_ADDR=0.0.0.0:12349` both verified to take effect.
- `bash -n deploy.sh` passes.

## One-time manual step after merge

GHCR packages are created **private**. After the first successful run, set each package's visibility to Public in its GitHub settings, otherwise every developer must `docker login ghcr.io` before pulling. The repositories are already public; nothing in these images is secret.

## Follow-ups (not in this PR)

- The host's Docker bridge has no egress (k3s/kube-router `FORWARD` conflict). It needs root to fix and breaks *all* bridge Docker on that machine, not just this project.
- `update-avarok-server.sh` is superseded by this pipeline and should be retired.
