### PR TITLE
feat(ui): proxy the agent websocket at a same-origin /ws path

### DIFF
--- a/.github/workflows/publish-images.yml
+++ b/.github/workflows/publish-images.yml
@@ -96,6 +96,17 @@ jobs:
               -e WORKSPACE_BACKEND=filesystem
               -e WORKSPACE_DATA_DIR=/data/server
               -e WORKSPACE_BIND_ADDR=127.0.0.1:12349
+          - image: ui
+            dockerfile: ./docker/ui/Dockerfile
+            # nginx serves the SPA and proxies /ws to the agent. Nothing to configure at build
+            # time: the socket URL is derived from window.location at runtime and the agent's
+            # address is the AGENT_UPSTREAM env var, so ONE image serves every topology.
+            # Deliberately NO VITE_WS_URL build-arg - setting it would bake an absolute URL back
+            # in and re-break the thing this image exists to fix.
+            build_args: ""
+            needs_wasm: true
+            smoke_port: 8080
+            smoke_env: ""
           - image: internal-service
             dockerfile: ./docker/internal-service/Dockerfile
             # Only this Dockerfile declares INTERNAL_SERVICE_PORT (it is baked into the image's
@@ -126,6 +137,18 @@ jobs:
           sudo rm -rf "$AGENT_TOOLSDIRECTORY"
           sudo apt-get clean
           df -h
+
+      - name: Generate WASM artifacts (UI build needs them)
+        # The UI bundle imports the wasm-pack output (`citadel_internal_service_wasm_client.js`
+        # and its .wasm). Those are NOT git-tracked - they are produced into
+        # citadel-internal-service/typescript-client by the `sync-wasm-client` one-shot container.
+        # Without this the Vite production build fails to resolve the import. Same step
+        # validate.yml's production-build already relies on.
+        if: matrix.needs_wasm
+        env:
+          WORKSPACE_MASTER_PASSWORD: 'ci-prod-build'
+          INTERNAL_SERVICE_PORT: '12345'
+        run: docker compose up --build sync-wasm-client
 
       - uses: docker/setup-buildx-action@v3
 
@@ -213,6 +236,23 @@ jobs:
           fi
           echo "${{ matrix.image }} is listening on ${{ matrix.smoke_port }}; image is good."
 
+          # The UI is a static server, so "the port is bound" is a weak signal - nginx binds even
+          # when it is serving nothing. Assert it serves the SPA shell AND that the /ws proxy made
+          # it into the rendered config (a broken envsubst would drop it silently and the app
+          # would ship unable to reach the agent at all).
+          if [ "${{ matrix.image }}" = "ui" ]; then
+            if ! docker exec "$name" wget -qO- http://127.0.0.1:8080/ | grep -q '<div id="root"'; then
+              echo "::error::ui served a response that is not the SPA shell."
+              exit 1
+            fi
+            if ! docker exec "$name" grep -q 'location /ws' /etc/nginx/conf.d/default.conf; then
+              echo "::error::the /ws proxy is missing from the rendered nginx config - the app would be unable to reach the agent."
+              docker exec "$name" cat /etc/nginx/conf.d/default.conf | head -30
+              exit 1
+            fi
+            echo "ui serves the SPA shell and the /ws proxy is configured."
+          fi
+
       - name: Push immutable SHA tag
         # Only the immutable tag is pushed here. `latest` is advanced by the
         # `promote-latest` job below, and only when the whole matrix succeeded on
@@ -244,7 +284,7 @@ jobs:
         run: |
           set -euo pipefail
           sha_tag="sha-${GITHUB_SHA:0:12}"
-          for img in server internal-service; do
+          for img in server internal-service ui; do
             image="ghcr.io/${GITHUB_REPOSITORY_OWNER,,}/citadel-workspace-${img}"
             echo "Promoting ${image}:${sha_tag} -> ${image}:latest"
             docker buildx imagetools create -t "${image}:latest" "${image}:${sha_tag}"

--- a/.github/workflows/publish-images.yml
+++ b/.github/workflows/publish-images.yml
@@ -98,7 +98,10 @@ jobs:
             build_args: ""
             needs_wasm: true
             smoke_port: 8080
-            smoke_env: ""
+            # The image FAILS CLOSED (WS_PROXY_ENABLED=0), so the proxy checks below must opt in
+            # explicitly - exactly as a real deployment does. The fail-closed default itself is
+            # then proven by a second container that passes no env at all.
+            smoke_env: "-e WS_PROXY_ENABLED=1"
           - image: internal-service
             dockerfile: ./docker/internal-service/Dockerfile
             # Only this Dockerfile declares INTERNAL_SERVICE_PORT (it is baked into the image's
@@ -288,17 +291,19 @@ jobs:
             # unauthenticated agent to the internet.
             off="smoke-ui-wsoff"
             docker rm -f "$off" >/dev/null 2>&1 || true
-            docker run -d --name "$off" -e WS_PROXY_ENABLED=0 "$IMAGE:$SHA_TAG" >/dev/null
+            # NO -e flag: this is the image's DEFAULT posture. Anyone who runs this image without
+            # thinking about it must get no agent proxy at all.
+            docker run -d --name "$off" "$IMAGE:$SHA_TAG" >/dev/null
             for _ in $(seq 1 20); do docker exec "$off" nc -z 127.0.0.1 8080 2>/dev/null && break; sleep 1; done
             offip=$(docker inspect -f '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' "$off")
             disabled=$(curl -s -o /dev/null -w '%{http_code}' -H "Origin: http://$offip:8080" "http://$offip:8080/ws")
             spa=$(curl -s -o /dev/null -w '%{http_code}' "http://$offip:8080/")
             docker rm -f "$off" >/dev/null 2>&1 || true
             if [ "$disabled" != "404" ] || [ "$spa" != "200" ]; then
-              echo "::error::WS_PROXY_ENABLED=0 did not disable /ws (got $disabled, want 404) or broke the SPA (got $spa, want 200). A publicly-served UI would expose the agent."
+              echo "::error::the image does not fail closed: with no WS_PROXY_ENABLED set, /ws returned $disabled (want 404) and the SPA $spa (want 200). Any unanticipated topology would republish the unauthenticated agent."
               exit 1
             fi
-            echo "ui: WS_PROXY_ENABLED=0 disables /ws (404) while still serving the SPA."
+            echo "ui: fails closed by default - /ws is 404 unless a deployment opts in, and the SPA still serves."
           fi
 
       - name: Push immutable SHA tag

--- a/.github/workflows/publish-images.yml
+++ b/.github/workflows/publish-images.yml
@@ -25,7 +25,7 @@
 #      `latest` directly, a manual run from a feature branch would overwrite the
 #      tag that production pulls by default with unmerged code. `promote-latest`
 #      is gated on `refs/heads/master`.
-#   2. The matrix builds the two images as independent jobs. If `latest` were
+#   2. The matrix builds the three images as independent jobs. If `latest` were
 #      pushed per-job, a run where `server` succeeded and `internal-service`
 #      failed would leave `latest` pointing at a MISMATCHED pair, and a deploy
 #      using the default tag would pull two versions that never shipped
@@ -34,19 +34,11 @@
 #
 # ONE-TIME MANUAL SETUP
 #
-# GHCR packages are created PRIVATE. After the first successful run, open each
-# package's settings on GitHub and set its visibility to Public, otherwise every
-# developer must `docker login ghcr.io` before they can pull. The repositories
-# themselves are already public, so there is nothing secret in these images.
-#
-# WHY `ui` IS NOT PUBLISHED HERE (yet)
-#
-# The production UI image bakes `VITE_WS_URL` at build time, and its nginx CSP
-# is `connect-src 'self'` - so a UI served on :8080 cannot reach an agent on
-# :12345. Publishing it today would ship an artifact that cannot work for the
-# local-agent deployment. It gets added once the same-origin `/ws` reverse proxy
-# (and the matching frontend change to derive the URL from `window.location`)
-# lands.
+# GHCR packages are created PRIVATE and stay that way. Pulling them therefore
+# needs `docker login ghcr.io` with a token carrying `read:packages` - a one-time
+# step for anyone deploying or running the local client. (Public would remove that
+# step, but these images are an internal artifact and there is no reason to publish
+# the org's build output to the world for the sake of one login.)
 # =============================================================================
 name: Publish Images
 
@@ -237,20 +229,76 @@ jobs:
           echo "${{ matrix.image }} is listening on ${{ matrix.smoke_port }}; image is good."
 
           # The UI is a static server, so "the port is bound" is a weak signal - nginx binds even
-          # when it is serving nothing. Assert it serves the SPA shell AND that the /ws proxy made
-          # it into the rendered config (a broken envsubst would drop it silently and the app
-          # would ship unable to reach the agent at all).
+          # when it is serving nothing. Assert the things that actually have to hold, including the
+          # two security controls on /ws: a regression in either would ship an unauthenticated
+          # control plane to whoever can reach the page.
           if [ "${{ matrix.image }}" = "ui" ]; then
-            if ! docker exec "$name" wget -qO- http://127.0.0.1:8080/ | grep -q '<div id="root"'; then
-              echo "::error::ui served a response that is not the SPA shell."
+            # Drive these from the RUNNER with curl, against the container's bridge IP - NOT with
+            # `docker exec ... wget`. busybox wget prints no headers for a non-2xx response, so a
+            # status/header assertion made with it silently reads as empty and proves nothing.
+            ip=$(docker inspect -f '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' "$name")
+            code() { curl -s -o /dev/null -w '%{http_code}' ${2:+-H "Origin: $2"} "http://$ip:8080$1"; }
+
+            if ! curl -sf "http://$ip:8080/" | grep -q '<div id="root"'; then
+              echo "::error::ui served a response that is not the SPA shell."; exit 1
+            fi
+
+            # envsubst must substitute OUR vars and leave nginx's own alone. If the filter breaks,
+            # $http_upgrade renders empty, the Upgrade header is dropped, and every websocket dies
+            # while the container still looks perfectly healthy.
+            if ! docker exec "$name" grep -q 'location = /ws' /etc/nginx/conf.d/default.conf \
+               || ! docker exec "$name" grep -q 'proxy_set_header Upgrade \$http_upgrade' /etc/nginx/conf.d/default.conf; then
+              echo "::error::rendered nginx config is missing '/ws' or had \$http_upgrade clobbered by envsubst."
+              docker exec "$name" cat /etc/nginx/conf.d/default.conf; exit 1
+            fi
+
+            # CONTROL 1 - same-origin. The agent's socket is an unauthenticated control plane, so a
+            # page on another origin must not be able to drive it through the user's browser
+            # (cross-site WebSocket hijacking), and nor must a client that sends no Origin at all.
+            foreign=$(code /ws "http://evil.example"); none=$(code /ws "")
+            if [ "$foreign" != "403" ] || [ "$none" != "403" ]; then
+              echo "::error::/ws accepted a cross-origin ($foreign) or origin-less ($none) request; both must be 403. This is a cross-site WebSocket hijacking hole."
               exit 1
             fi
-            if ! docker exec "$name" grep -q 'location /ws' /etc/nginx/conf.d/default.conf; then
-              echo "::error::the /ws proxy is missing from the rendered nginx config - the app would be unable to reach the agent."
-              docker exec "$name" cat /etc/nginx/conf.d/default.conf | head -30
+            # ...and it must still accept ITS OWN origin, or the gate is uselessly strict and the app
+            # can never connect. No agent runs in this container, so a 502 is the proof that the
+            # request passed the Origin gate and nginx went looking for the upstream.
+            same=$(code /ws "http://$ip:8080")
+            if [ "$same" != "502" ]; then
+              echo "::error::/ws returned $same for a same-origin request; expected 502 (gate passed, no agent present). A 403 here means the app could never connect."
               exit 1
             fi
-            echo "ui serves the SPA shell and the /ws proxy is configured."
+            # Error pages must still carry the CSP. This holds only because the /ws block declares
+            # no add_header of its own and therefore inherits the server-level set; adding one there
+            # would silently replace them all.
+            if ! curl -s -D - -o /dev/null -H "Origin: http://evil.example" "http://$ip:8080/ws" \
+                 | grep -qi '^content-security-policy'; then
+              echo "::error::/ws error responses lost the Content-Security-Policy header (an add_header in that block would do this)."
+              exit 1
+            fi
+            # Exact-match location: a prefix match would forward /wsfoo to the agent too.
+            if [ "$(code /wsfoo "http://$ip:8080")" != "200" ]; then
+              echo "::error::/wsfoo was not served by the SPA - the /ws location is matching as a prefix."
+              exit 1
+            fi
+            echo "ui: SPA served; /ws is same-origin-only (403 cross-origin, 403 no-origin, proxies same-origin), keeps its CSP, and does not prefix-match."
+
+            # CONTROL 2 - the kill switch that any publicly-served UI relies on
+            # (docker-compose.production.yml). If this regresses, that deployment quietly proxies an
+            # unauthenticated agent to the internet.
+            off="smoke-ui-wsoff"
+            docker rm -f "$off" >/dev/null 2>&1 || true
+            docker run -d --name "$off" -e WS_PROXY_ENABLED=0 "$IMAGE:$SHA_TAG" >/dev/null
+            for _ in $(seq 1 20); do docker exec "$off" nc -z 127.0.0.1 8080 2>/dev/null && break; sleep 1; done
+            offip=$(docker inspect -f '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' "$off")
+            disabled=$(curl -s -o /dev/null -w '%{http_code}' -H "Origin: http://$offip:8080" "http://$offip:8080/ws")
+            spa=$(curl -s -o /dev/null -w '%{http_code}' "http://$offip:8080/")
+            docker rm -f "$off" >/dev/null 2>&1 || true
+            if [ "$disabled" != "404" ] || [ "$spa" != "200" ]; then
+              echo "::error::WS_PROXY_ENABLED=0 did not disable /ws (got $disabled, want 404) or broke the SPA (got $spa, want 200). A publicly-served UI would expose the agent."
+              exit 1
+            fi
+            echo "ui: WS_PROXY_ENABLED=0 disables /ws (404) while still serving the SPA."
           fi
 
       - name: Push immutable SHA tag

--- a/.github/workflows/publish-images.yml
+++ b/.github/workflows/publish-images.yml
@@ -101,7 +101,9 @@ jobs:
             # The image FAILS CLOSED (WS_PROXY_ENABLED=0), so the proxy checks below must opt in
             # explicitly - exactly as a real deployment does. The fail-closed default itself is
             # then proven by a second container that passes no env at all.
-            smoke_env: "-e WS_PROXY_ENABLED=1"
+            # -p on LOOPBACK: /ws requires a loopback Host (the DNS-rebinding defence), so the
+            # checks must arrive over 127.0.0.1 exactly as a real user's browser does.
+            smoke_env: "-e WS_PROXY_ENABLED=1 -p 127.0.0.1:18080:8080"
           - image: internal-service
             dockerfile: ./docker/internal-service/Dockerfile
             # Only this Dockerfile declares INTERNAL_SERVICE_PORT (it is baked into the image's
@@ -239,10 +241,13 @@ jobs:
             # Drive these from the RUNNER with curl, against the container's bridge IP - NOT with
             # `docker exec ... wget`. busybox wget prints no headers for a non-2xx response, so a
             # status/header assertion made with it silently reads as empty and proves nothing.
-            ip=$(docker inspect -f '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' "$name")
-            code() { curl -s -o /dev/null -w '%{http_code}' ${2:+-H "Origin: $2"} "http://$ip:8080$1"; }
+            # Reach it over LOOPBACK, not the container's bridge IP. /ws now requires a loopback
+            # Host (the DNS-rebinding defence), so 172.17.x.x would be refused - and a real user
+            # arrives on 127.0.0.1 anyway. The container was started with -p by the step above.
+            base="http://127.0.0.1:18080"
+            code() { curl -s -o /dev/null -w '%{http_code}' ${2:+-H "Origin: $2"} "$base$1"; }
 
-            if ! curl -sf "http://$ip:8080/" | grep -q '<div id="root"'; then
+            if ! curl -sf "$base/" | grep -q '<div id="root"'; then
               echo "::error::ui served a response that is not the SPA shell."; exit 1
             fi
 
@@ -266,25 +271,37 @@ jobs:
             # ...and it must still accept ITS OWN origin, or the gate is uselessly strict and the app
             # can never connect. No agent runs in this container, so a 502 is the proof that the
             # request passed the Origin gate and nginx went looking for the upstream.
-            same=$(code /ws "http://$ip:8080")
+            same=$(code /ws "$base")
             if [ "$same" != "502" ]; then
               echo "::error::/ws returned $same for a same-origin request; expected 502 (gate passed, no agent present). A 403 here means the app could never connect."
               exit 1
             fi
+            # DNS REBINDING. The attack the same-origin check cannot see: a rebound `evil.example`
+            # resolves to 127.0.0.1, so Host AND Origin both read evil.example - they match, and a
+            # same-origin check alone waves it through while the attacker's JS drives the agent.
+            # Only the loopback Host allowlist catches this. Simulated exactly: a matching
+            # Host/Origin pair for a name we do not serve under.
+            rebound=$(curl -s -o /dev/null -w '%{http_code}' \
+              -H "Host: evil.example:18080" -H "Origin: http://evil.example:18080" "$base/ws")
+            if [ "$rebound" != "403" ]; then
+              echo "::error::/ws accepted a DNS-rebinding handshake (Host=Origin=evil.example) with $rebound; expected 403. A malicious site could drive the local agent."
+              exit 1
+            fi
+
             # Error pages must still carry the CSP. This holds only because the /ws block declares
             # no add_header of its own and therefore inherits the server-level set; adding one there
             # would silently replace them all.
-            if ! curl -s -D - -o /dev/null -H "Origin: http://evil.example" "http://$ip:8080/ws" \
+            if ! curl -s -D - -o /dev/null -H "Origin: http://evil.example" "$base/ws" \
                  | grep -qi '^content-security-policy'; then
               echo "::error::/ws error responses lost the Content-Security-Policy header (an add_header in that block would do this)."
               exit 1
             fi
             # Exact-match location: a prefix match would forward /wsfoo to the agent too.
-            if [ "$(code /wsfoo "http://$ip:8080")" != "200" ]; then
+            if [ "$(code /wsfoo "$base")" != "200" ]; then
               echo "::error::/wsfoo was not served by the SPA - the /ws location is matching as a prefix."
               exit 1
             fi
-            echo "ui: SPA served; /ws is same-origin-only (403 cross-origin, 403 no-origin, proxies same-origin), keeps its CSP, and does not prefix-match."
+            echo "ui: SPA served; /ws requires a loopback Host (403 on DNS-rebinding) AND a same-origin Origin (403 cross-origin, 403 no-origin), proxies same-origin, keeps its CSP, and does not prefix-match."
 
             # CONTROL 2 - the kill switch that any publicly-served UI relies on
             # (docker-compose.production.yml). If this regresses, that deployment quietly proxies an
@@ -293,11 +310,17 @@ jobs:
             docker rm -f "$off" >/dev/null 2>&1 || true
             # NO -e flag: this is the image's DEFAULT posture. Anyone who runs this image without
             # thinking about it must get no agent proxy at all.
-            docker run -d --name "$off" "$IMAGE:$SHA_TAG" >/dev/null
+            docker run -d --name "$off" -p 127.0.0.1:18081:8080 "$IMAGE:$SHA_TAG" >/dev/null
             for _ in $(seq 1 20); do docker exec "$off" nc -z 127.0.0.1 8080 2>/dev/null && break; sleep 1; done
-            offip=$(docker inspect -f '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' "$off")
-            disabled=$(curl -s -o /dev/null -w '%{http_code}' -H "Origin: http://$offip:8080" "http://$offip:8080/ws")
-            spa=$(curl -s -o /dev/null -w '%{http_code}' "http://$offip:8080/")
+            # Prove it actually STARTED. A container that crashed on boot refuses every connection,
+            # which would sail through the assertions below as a "404" and read as a security PASS.
+            if ! docker exec "$off" nc -z 127.0.0.1 8080 2>/dev/null; then
+              echo "::error::the fail-closed smoke container never became ready - the assertions below would be meaningless."
+              docker logs "$off"; docker rm -f "$off" >/dev/null 2>&1 || true; exit 1
+            fi
+            offbase="http://127.0.0.1:18081"
+            disabled=$(curl -s -o /dev/null -w '%{http_code}' -H "Origin: $offbase" "$offbase/ws")
+            spa=$(curl -s -o /dev/null -w '%{http_code}' "$offbase/")
             docker rm -f "$off" >/dev/null 2>&1 || true
             if [ "$disabled" != "404" ] || [ "$spa" != "200" ]; then
               echo "::error::the image does not fail closed: with no WS_PROXY_ENABLED set, /ws returned $disabled (want 404) and the SPA $spa (want 200). Any unanticipated topology would republish the unauthenticated agent."

--- a/.github/workflows/publish-images.yml
+++ b/.github/workflows/publish-images.yml
@@ -288,6 +288,16 @@ jobs:
               exit 1
             fi
 
+            # The allowlist contains an IP literal (0.0.0.0, because LISTEN_ADDR defaults to it), so
+            # pin that it did NOT become "any IP". A LAN address must stay refused - serving /ws to
+            # the local network would hand the agent to every machine on it.
+            lan=$(curl -s -o /dev/null -w '%{http_code}' \
+              -H "Host: 192.168.1.50:18080" -H "Origin: http://192.168.1.50:18080" "$base/ws")
+            if [ "$lan" != "403" ]; then
+              echo "::error::/ws accepted a LAN Host (192.168.1.50) with $lan; expected 403. The loopback allowlist has been widened too far."
+              exit 1
+            fi
+
             # Error pages must still carry the CSP. This holds only because the /ws block declares
             # no add_header of its own and therefore inherits the server-level set; adding one there
             # would silently replace them all.

--- a/.github/workflows/publish-images.yml
+++ b/.github/workflows/publish-images.yml
@@ -98,12 +98,12 @@ jobs:
             build_args: ""
             needs_wasm: true
             smoke_port: 8080
-            # The image FAILS CLOSED (WS_PROXY_ENABLED=0), so the proxy checks below must opt in
-            # explicitly - exactly as a real deployment does. The fail-closed default itself is
-            # then proven by a second container that passes no env at all.
-            # -p on LOOPBACK: /ws requires a loopback Host (the DNS-rebinding defence), so the
-            # checks must arrive over 127.0.0.1 exactly as a real user's browser does.
-            smoke_env: "-e WS_PROXY_ENABLED=1 -p 127.0.0.1:18080:8080"
+            # Deliberately NO published port. The generic liveness probe below runs
+            # `docker exec ... nc`, so it does not need one - and the shared /ws smoke script
+            # binds 127.0.0.1:18080 for its own containers, which would collide. The proxy is
+            # opted in (the image fails closed) so the probe exercises a realistic config; the
+            # fail-closed default and every security control are asserted inside the script.
+            smoke_env: "-e WS_PROXY_ENABLED=1"
           - image: internal-service
             dockerfile: ./docker/internal-service/Dockerfile
             # Only this Dockerfile declares INTERNAL_SERVICE_PORT (it is baked into the image's
@@ -233,129 +233,12 @@ jobs:
           fi
           echo "${{ matrix.image }} is listening on ${{ matrix.smoke_port }}; image is good."
 
-          # The UI is a static server, so "the port is bound" is a weak signal - nginx binds even
-          # when it is serving nothing. Assert the things that actually have to hold, including the
-          # two security controls on /ws: a regression in either would ship an unauthenticated
-          # control plane to whoever can reach the page.
+          # "The port is bound" is a weak signal for a static server - nginx binds even when it is
+          # serving nothing, and says nothing at all about the /ws security controls.
           if [ "${{ matrix.image }}" = "ui" ]; then
-            # Drive these from the RUNNER with curl, against the container's bridge IP - NOT with
-            # `docker exec ... wget`. busybox wget prints no headers for a non-2xx response, so a
-            # status/header assertion made with it silently reads as empty and proves nothing.
-            # Reach it over LOOPBACK, not the container's bridge IP. /ws now requires a loopback
-            # Host (the DNS-rebinding defence), so 172.17.x.x would be refused - and a real user
-            # arrives on 127.0.0.1 anyway. The container was started with -p by the step above.
-            base="http://127.0.0.1:18080"
-            code() { curl -s -o /dev/null -w '%{http_code}' ${2:+-H "Origin: $2"} "$base$1"; }
-
-            if ! curl -sf "$base/" | grep -q '<div id="root"'; then
-              echo "::error::ui served a response that is not the SPA shell."; exit 1
-            fi
-
-            # envsubst must substitute OUR vars and leave nginx's own alone. If the filter breaks,
-            # $http_upgrade renders empty, the Upgrade header is dropped, and every websocket dies
-            # while the container still looks perfectly healthy.
-            if ! docker exec "$name" grep -q 'location = /ws' /etc/nginx/conf.d/default.conf \
-               || ! docker exec "$name" grep -q 'proxy_set_header Upgrade \$http_upgrade' /etc/nginx/conf.d/default.conf; then
-              echo "::error::rendered nginx config is missing '/ws' or had \$http_upgrade clobbered by envsubst."
-              docker exec "$name" cat /etc/nginx/conf.d/default.conf; exit 1
-            fi
-
-            # CONTROL 1 - same-origin. The agent's socket is an unauthenticated control plane, so a
-            # page on another origin must not be able to drive it through the user's browser
-            # (cross-site WebSocket hijacking), and nor must a client that sends no Origin at all.
-            foreign=$(code /ws "http://evil.example"); none=$(code /ws "")
-            if [ "$foreign" != "403" ] || [ "$none" != "403" ]; then
-              echo "::error::/ws accepted a cross-origin ($foreign) or origin-less ($none) request; both must be 403. This is a cross-site WebSocket hijacking hole."
-              exit 1
-            fi
-            # ...and it must still accept ITS OWN origin, or the gate is uselessly strict and the app
-            # can never connect. No agent runs in this container, so a 502 is the proof that the
-            # request passed the Origin gate and nginx went looking for the upstream.
-            same=$(code /ws "$base")
-            if [ "$same" != "502" ]; then
-              echo "::error::/ws returned $same for a same-origin request; expected 502 (gate passed, no agent present). A 403 here means the app could never connect."
-              exit 1
-            fi
-            # DNS REBINDING. The attack the same-origin check cannot see: a rebound `evil.example`
-            # resolves to 127.0.0.1, so Host AND Origin both read evil.example - they match, and a
-            # same-origin check alone waves it through while the attacker's JS drives the agent.
-            # Only the loopback Host allowlist catches this. Simulated exactly: a matching
-            # Host/Origin pair for a name we do not serve under.
-            rebound=$(curl -s -o /dev/null -w '%{http_code}' \
-              -H "Host: evil.example:18080" -H "Origin: http://evil.example:18080" "$base/ws")
-            if [ "$rebound" != "403" ]; then
-              echo "::error::/ws accepted a DNS-rebinding handshake (Host=Origin=evil.example) with $rebound; expected 403. A malicious site could drive the local agent."
-              exit 1
-            fi
-
-            # The allowlist contains an IP literal (0.0.0.0, because LISTEN_ADDR defaults to it), so
-            # pin that it did NOT become "any IP". A LAN address must stay refused - serving /ws to
-            # the local network would hand the agent to every machine on it.
-            lan=$(curl -s -o /dev/null -w '%{http_code}' \
-              -H "Host: 192.168.1.50:18080" -H "Origin: http://192.168.1.50:18080" "$base/ws")
-            if [ "$lan" != "403" ]; then
-              echo "::error::/ws accepted a LAN Host (192.168.1.50) with $lan; expected 403. The loopback allowlist has been widened too far."
-              exit 1
-            fi
-
-            # Error pages must still carry the CSP. This holds only because the /ws block declares
-            # no add_header of its own and therefore inherits the server-level set; adding one there
-            # would silently replace them all.
-            if ! curl -s -D - -o /dev/null -H "Origin: http://evil.example" "$base/ws" \
-                 | grep -qi '^content-security-policy'; then
-              echo "::error::/ws error responses lost the Content-Security-Policy header (an add_header in that block would do this)."
-              exit 1
-            fi
-            # Exact-match location: a prefix match would forward /wsfoo to the agent too.
-            if [ "$(code /wsfoo "$base")" != "200" ]; then
-              echo "::error::/wsfoo was not served by the SPA - the /ws location is matching as a prefix."
-              exit 1
-            fi
-            echo "ui: SPA served; /ws requires a loopback Host (403 on DNS-rebinding) AND a same-origin Origin (403 cross-origin, 403 no-origin), proxies same-origin, keeps its CSP, and does not prefix-match."
-
-            # CONTROL 2 - the kill switch that any publicly-served UI relies on
-            # (docker-compose.production.yml). If this regresses, that deployment quietly proxies an
-            # unauthenticated agent to the internet.
-            off="smoke-ui-wsoff"
-            docker rm -f "$off" >/dev/null 2>&1 || true
-            # NO -e flag: this is the image's DEFAULT posture. Anyone who runs this image without
-            # thinking about it must get no agent proxy at all.
-            docker run -d --name "$off" -p 127.0.0.1:18081:8080 "$IMAGE:$SHA_TAG" >/dev/null
-            for _ in $(seq 1 20); do docker exec "$off" nc -z 127.0.0.1 8080 2>/dev/null && break; sleep 1; done
-            # Prove it actually STARTED. A container that crashed on boot refuses every connection,
-            # which would sail through the assertions below as a "404" and read as a security PASS.
-            if ! docker exec "$off" nc -z 127.0.0.1 8080 2>/dev/null; then
-              echo "::error::the fail-closed smoke container never became ready - the assertions below would be meaningless."
-              docker logs "$off"; docker rm -f "$off" >/dev/null 2>&1 || true; exit 1
-            fi
-            offbase="http://127.0.0.1:18081"
-            disabled=$(curl -s -o /dev/null -w '%{http_code}' -H "Origin: $offbase" "$offbase/ws")
-            spa=$(curl -s -o /dev/null -w '%{http_code}' "$offbase/")
-            docker rm -f "$off" >/dev/null 2>&1 || true
-            if [ "$disabled" != "404" ] || [ "$spa" != "200" ]; then
-              echo "::error::the image does not fail closed: with no WS_PROXY_ENABLED set, /ws returned $disabled (want 404) and the SPA $spa (want 200). Any unanticipated topology would republish the unauthenticated agent."
-              exit 1
-            fi
-            echo "ui: fails closed by default - /ws is 404 unless a deployment opts in, and the SPA still serves."
-
-            # The switch is opt-IN: only the literal "1" may enable the proxy. Tested with the
-            # values an operator would plausibly reach for to turn it OFF. The obvious spelling of
-            # the guard (`if $flag = "0"`) fails OPEN for every one of these, so someone writing
-            # WS_PROXY_ENABLED=false would have been silently EXPOSING the unauthenticated agent
-            # while believing they had disabled it.
-            for val in "" "false" "off" "no" "0"; do
-              vc="smoke-ui-val"
-              docker rm -f "$vc" >/dev/null 2>&1 || true
-              docker run -d --name "$vc" -e WS_PROXY_ENABLED="$val" -p 127.0.0.1:18082:8080 "$IMAGE:$SHA_TAG" >/dev/null
-              for _ in $(seq 1 20); do docker exec "$vc" nc -z 127.0.0.1 8080 2>/dev/null && break; sleep 1; done
-              got=$(curl -s -o /dev/null -w '%{http_code}' -H "Origin: http://127.0.0.1:18082" "http://127.0.0.1:18082/ws")
-              docker rm -f "$vc" >/dev/null 2>&1 || true
-              if [ "$got" != "404" ]; then
-                echo "::error::WS_PROXY_ENABLED='$val' left /ws ENABLED (got $got, want 404). The switch must be opt-in: anything but the literal 1 has to disable the proxy, or an operator turning it 'off' would expose the agent."
-                exit 1
-              fi
-            done
-            echo "ui: only the literal WS_PROXY_ENABLED=1 enables the proxy; '', false, off, no and 0 all disable it."
+            # Same assertions the PR gate runs (validate.yml), from one shared script - so the
+            # release gate can never end up testing less than the pull-request gate did.
+            ./scripts/smoke-ui-ws.sh "$IMAGE:$SHA_TAG" 18080
           fi
 
       - name: Push immutable SHA tag

--- a/.github/workflows/publish-images.yml
+++ b/.github/workflows/publish-images.yml
@@ -337,6 +337,25 @@ jobs:
               exit 1
             fi
             echo "ui: fails closed by default - /ws is 404 unless a deployment opts in, and the SPA still serves."
+
+            # The switch is opt-IN: only the literal "1" may enable the proxy. Tested with the
+            # values an operator would plausibly reach for to turn it OFF. The obvious spelling of
+            # the guard (`if $flag = "0"`) fails OPEN for every one of these, so someone writing
+            # WS_PROXY_ENABLED=false would have been silently EXPOSING the unauthenticated agent
+            # while believing they had disabled it.
+            for val in "" "false" "off" "no" "0"; do
+              vc="smoke-ui-val"
+              docker rm -f "$vc" >/dev/null 2>&1 || true
+              docker run -d --name "$vc" -e WS_PROXY_ENABLED="$val" -p 127.0.0.1:18082:8080 "$IMAGE:$SHA_TAG" >/dev/null
+              for _ in $(seq 1 20); do docker exec "$vc" nc -z 127.0.0.1 8080 2>/dev/null && break; sleep 1; done
+              got=$(curl -s -o /dev/null -w '%{http_code}' -H "Origin: http://127.0.0.1:18082" "http://127.0.0.1:18082/ws")
+              docker rm -f "$vc" >/dev/null 2>&1 || true
+              if [ "$got" != "404" ]; then
+                echo "::error::WS_PROXY_ENABLED='$val' left /ws ENABLED (got $got, want 404). The switch must be opt-in: anything but the literal 1 has to disable the proxy, or an operator turning it 'off' would expose the agent."
+                exit 1
+              fi
+            done
+            echo "ui: only the literal WS_PROXY_ENABLED=1 enables the proxy; '', false, off, no and 0 all disable it."
           fi
 
       - name: Push immutable SHA tag

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -556,6 +556,17 @@ jobs:
             exit 1
           fi
           echo "Production images built successfully"
+      - name: Smoke Test - /ws proxy security controls
+        # The PR GATE for the agent proxy. These assertions used to live only in
+        # publish-images.yml, which runs on master pushes - i.e. AFTER the merge decision.
+        # A PR that regressed the fail-closed switch or the envsubst pinning would have gone
+        # green here and only been caught at promotion time, or shipped if publish were
+        # bypassed. The controls guard an unauthenticated control plane, so they have to be
+        # asserted on the change that could break them.
+        #
+        # Shared with publish-images.yml so the two gates cannot drift into testing
+        # different things.
+        run: ./scripts/smoke-ui-ws.sh ghcr.io/avarok-cybersecurity/citadel-workspace-ui:latest 18080
       - name: Smoke Test - Services Start
         env:
           WORKSPACE_MASTER_PASSWORD: 'ci-smoke-test'

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -424,6 +424,23 @@ jobs:
           fi
           echo "PASS: mismatched images are refused."
 
+      - name: THREE images are all checked, not just the first two
+        # deploy.sh now passes three images (server, internal-service, ui). The script iterates
+        # over "$@", so this works - but nothing pinned it, and the failure mode of a hardcoded
+        # $1/$2 would be silent: the third image's revision simply never compared, so a UI built
+        # from a different commit would deploy against mismatched backends and the gate would
+        # report success. Assert both directions, with the odd one out LAST so a gate that only
+        # looks at the first two arguments fails this test.
+        run: |
+          set -euo pipefail
+          ./scripts/verify-image-revisions.sh rev-a rev-a-copy rev-a
+          echo "PASS: three images from the same commit deploy."
+          if ./scripts/verify-image-revisions.sh rev-a rev-a-copy rev-b; then
+            echo "::error::The gate ignored the THIRD image. A UI built from a different commit than the backends would deploy unnoticed."
+            exit 1
+          fi
+          echo "PASS: a mismatched third image is refused."
+
       - name: Unlabelled images warn but do not block
         # Locally-built and pre-label images carry no revision. Blocking them would strand
         # anyone deploying an older or locally built image, so the documented behaviour is to

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -484,27 +484,58 @@ jobs:
         run: docker compose up --build sync-wasm-client
       - name: Build Production Images (server + internal-service + ui)
         run: |
-          # The UI image has its own multi-stage `production` target with
-          # a hand-written nginx config (printf'd from the Dockerfile), a
-          # non-root user setup, and a security-header block. None of that
-          # is exercised by the dev `target: dev` build, so a syntax error
-          # in the printf, a wrong `COPY --from=build` path, or a missing
-          # `target: production` would previously only surface during an
-          # actual production deploy. Building it in CI catches those.
-          docker compose -f docker-compose.production.yml build server internal-service ui
+          # The UI image has its own multi-stage `production` target with a
+          # templated nginx config, a non-root user setup, a security-header
+          # block and the /ws proxy. None of that is exercised by the dev
+          # `target: dev` build, so a broken template, a wrong
+          # `COPY --from=build` path, or a missing `target: production` would
+          # otherwise only surface during an actual production deploy.
+          docker compose -f docker-compose.production.yml build server internal-service
+
+          # The `ui` service is intentionally build-less in the production
+          # compose file: production PULLS a published image, and carrying a
+          # `build:` next to `image:` would make Compose build locally and
+          # silently bypass the published artifact the release gate verified.
+          #
+          # That means Compose cannot build it for us here - `compose build ui`
+          # prints "No services to build" and exits 0, so CI would sail past a
+          # completely unbuilt image and only fail later, opaquely, when `up`
+          # tried to PULL a tag that does not exist yet on a PR branch.
+          #
+          # So build it straight from the Dockerfile and tag it with the exact
+          # reference the compose file resolves to. Compose's default
+          # pull_policy is `missing`, so a locally-present tag is used as-is and
+          # nothing is pulled. This also keeps CI honest: it validates the image
+          # built from THIS commit's source, not whatever `latest` happens to be.
+          docker build \
+            -f docker/ui/Dockerfile \
+            --target production \
+            -t ghcr.io/avarok-cybersecurity/citadel-workspace-ui:latest \
+            .
       - name: Verify Images Were Built
         run: |
           echo "Checking for built images..."
-          # docker compose build tags images as <project>-<service>
           docker images
-          # Verify all three images exist and are non-empty
-          SERVER_IMAGE=$(docker compose -f docker-compose.production.yml images server --format json | head -1)
-          IS_IMAGE=$(docker compose -f docker-compose.production.yml images internal-service --format json | head -1)
-          UI_IMAGE=$(docker compose -f docker-compose.production.yml images ui --format json | head -1)
-          # Fail if ANY image is missing. Listing each one explicitly keeps
-          # the failure message specific about which build silently dropped.
-          if [ -z "$SERVER_IMAGE" ] || [ -z "$IS_IMAGE" ] || [ -z "$UI_IMAGE" ]; then
-            echo "ERROR: Production images were not built (server='$SERVER_IMAGE', internal-service='$IS_IMAGE', ui='$UI_IMAGE')"
+          # Assert against the DAEMON, by the exact tag the compose file resolves
+          # to. The previous check asked `docker compose images <svc>`, which
+          # reports a row for a declared service whether or not the image was
+          # ever built - so it returned non-empty for an image that did not
+          # exist, and the "verification" passed while the build had silently
+          # dropped the UI entirely. `docker image inspect` cannot do that.
+          missing=0
+          for img in \
+            ghcr.io/avarok-cybersecurity/citadel-workspace-server:latest \
+            ghcr.io/avarok-cybersecurity/citadel-workspace-internal-service:latest \
+            ghcr.io/avarok-cybersecurity/citadel-workspace-ui:latest; do
+            if docker image inspect "$img" >/dev/null 2>&1; then
+              echo "  present: $img"
+            else
+              echo "  MISSING: $img"
+              missing=1
+            fi
+          done
+          if [ "$missing" -ne 0 ]; then
+            echo "ERROR: at least one production image was not built (see MISSING above)."
             exit 1
           fi
           echo "Production images built successfully"

--- a/deploy.sh
+++ b/deploy.sh
@@ -194,7 +194,7 @@ fi
 # that way and must be flipped to Public once). Naming that cause up front turns
 # a cryptic mid-deploy exit into a one-line fix.
 echo "[2/4] Pulling images (tag: ${IMAGE_TAG:-latest})..."
-if ! docker compose -f "$COMPOSE_FILE" "${PROFILE_ARGS[@]}" pull server internal-service; then
+if ! docker compose -f "$COMPOSE_FILE" "${PROFILE_ARGS[@]}" pull server internal-service ui; then
     echo "" >&2
     echo "ERROR: failed to pull images (tag: ${IMAGE_TAG:-latest})." >&2
     echo "  Common causes:" >&2
@@ -227,30 +227,23 @@ fi
 # (validate.yml -> deploy-gate-tests) against real images with matching, mismatched and
 # absent labels. Inline in this script - wedged between an image pull and a production
 # restart - none of those paths could be tested at all.
-echo "  Verifying both images came from the same commit..."
+echo "  Verifying all images came from the same commit..."
 srv_img=$(docker compose -f "$COMPOSE_FILE" config --format json | jq -r '.services.server.image')
 is_img=$(docker compose -f "$COMPOSE_FILE" config --format json | jq -r '.services["internal-service"].image')
+# The ui is pulled from the same release now, so it is subject to the same consistency rule: a
+# partially completed `latest` promotion could otherwise pair a new backend with an old UI, which
+# is exactly the mixed-version deploy this gate exists to prevent.
+ui_img=$(docker compose -f "$COMPOSE_FILE" config --format json | jq -r '.services.ui.image')
 
-if ! ./scripts/verify-image-revisions.sh "$srv_img" "$is_img"; then
+if ! ./scripts/verify-image-revisions.sh "$srv_img" "$is_img" "$ui_img"; then
     echo "" >&2
     echo "  Nothing was restarted; the running stack is untouched." >&2
     exit 1
 fi
 
-# The `ui` service is not published to GHCR yet -- its production image bakes
-# VITE_WS_URL at build time and its CSP cannot reach an off-origin agent, so a
-# published artifact would not actually work until the same-origin `/ws` proxy
-# lands. Until then it is still built locally, and only when it is being run.
-if docker compose -f "$COMPOSE_FILE" "${PROFILE_ARGS[@]}" config --services | grep -qx "ui"; then
-    echo "  Building ui locally (not yet published to GHCR)..."
-    if ! docker compose -f "$COMPOSE_FILE" "${PROFILE_ARGS[@]}" build ui; then
-        echo "" >&2
-        echo "ERROR: failed to build the ui image." >&2
-        echo "  Aborting BEFORE restarting anything, so the backend is not left on new" >&2
-        echo "  images while the ui stays on its old one." >&2
-        exit 1
-    fi
-fi
+# All three images are published now, so this host builds NOTHING. The ui used to be built here
+# (it baked VITE_WS_URL at build time, so a published image could not have worked); the app now
+# derives its socket URL at runtime, so one published ui image serves every deployment.
 echo ""
 
 # NOTE on the removed `target_cache` volume: the production images no longer

--- a/deploy.sh
+++ b/deploy.sh
@@ -194,7 +194,26 @@ fi
 # that way and must be flipped to Public once). Naming that cause up front turns
 # a cryptic mid-deploy exit into a one-line fix.
 echo "[2/4] Pulling images (tag: ${IMAGE_TAG:-latest})..."
-if ! docker compose -f "$COMPOSE_FILE" "${PROFILE_ARGS[@]}" pull server internal-service ui; then
+
+# Pull whichever of the three services this compose file actually declares, rather than a
+# hardcoded list. docker-compose.production.yml documents that `ui` and `internal-service` are
+# droppable for a server-only deployment, and an operator who takes that option would otherwise
+# hit `no such service: ui` here - a deploy broken by following our own documentation. `server`
+# is the one service that is genuinely required.
+declared_services=$(docker compose -f "$COMPOSE_FILE" config --services)
+PULL_SERVICES=()
+for svc in server internal-service ui; do
+    if printf '%s\n' "$declared_services" | grep -qx "$svc"; then
+        PULL_SERVICES+=("$svc")
+    fi
+done
+if ! printf '%s\n' "${PULL_SERVICES[@]}" | grep -qx server; then
+    echo "ERROR: '$COMPOSE_FILE' declares no 'server' service; there is nothing to deploy." >&2
+    exit 1
+fi
+echo "  Services in this compose file: ${PULL_SERVICES[*]}"
+
+if ! docker compose -f "$COMPOSE_FILE" "${PROFILE_ARGS[@]}" pull "${PULL_SERVICES[@]}"; then
     echo "" >&2
     echo "ERROR: failed to pull images (tag: ${IMAGE_TAG:-latest})." >&2
     echo "  Common causes:" >&2
@@ -228,14 +247,25 @@ fi
 # absent labels. Inline in this script - wedged between an image pull and a production
 # restart - none of those paths could be tested at all.
 echo "  Verifying all images came from the same commit..."
-srv_img=$(docker compose -f "$COMPOSE_FILE" config --format json | jq -r '.services.server.image')
-is_img=$(docker compose -f "$COMPOSE_FILE" config --format json | jq -r '.services["internal-service"].image')
-# The ui is pulled from the same release now, so it is subject to the same consistency rule: a
-# partially completed `latest` promotion could otherwise pair a new backend with an old UI, which
-# is exactly the mixed-version deploy this gate exists to prevent.
-ui_img=$(docker compose -f "$COMPOSE_FILE" config --format json | jq -r '.services.ui.image')
+# Verify exactly the services that were pulled. Every image in the deployment is subject to the
+# same consistency rule - the ui included, since a partially completed `latest` promotion could
+# otherwise pair a new backend with an old UI, which is precisely the mixed-version deploy this
+# gate exists to prevent. Asking for a service the file does not declare would hand the gate a
+# literal "null" from jq, which it correctly refuses as un-inspectable; deriving the list from the
+# file instead keeps a legitimately slimmed-down deployment working.
+compose_json=$(docker compose -f "$COMPOSE_FILE" config --format json)
+VERIFY_IMAGES=()
+for svc in "${PULL_SERVICES[@]}"; do
+    img=$(printf '%s' "$compose_json" | jq -r --arg s "$svc" '.services[$s].image // empty')
+    if [ -z "$img" ]; then
+        echo "ERROR: service '$svc' declares no image in '$COMPOSE_FILE'." >&2
+        echo "  Nothing was restarted; the running stack is untouched." >&2
+        exit 1
+    fi
+    VERIFY_IMAGES+=("$img")
+done
 
-if ! ./scripts/verify-image-revisions.sh "$srv_img" "$is_img" "$ui_img"; then
+if ! ./scripts/verify-image-revisions.sh "${VERIFY_IMAGES[@]}"; then
     echo "" >&2
     echo "  Nothing was restarted; the running stack is untouched." >&2
     exit 1

--- a/docker-compose.local.yml
+++ b/docker-compose.local.yml
@@ -1,0 +1,89 @@
+# =============================================================================
+# Citadel Workspace - LOCAL CLIENT
+#
+# For people USING the workspace, not developing it. Runs the two pieces that must
+# live on your own machine:
+#
+#   agent (internal-service) - a native Citadel node. It holds your ratchet keys, does the
+#                              crypto, and speaks the Citadel protocol over TCP/QUIC. A browser
+#                              cannot do any of that, which is why it must run here and not on
+#                              a server. Keeping it local is what makes your P2P messages and
+#                              file transfers end-to-end encrypted: nobody else's machine ever
+#                              holds your keys.
+#   ui                       - nginx serving the app, and proxying /ws to the agent above.
+#
+# The shared workspace SERVER is not here - it runs once, centrally, and you point at it from
+# the login screen.
+#
+# Usage:
+#   docker login ghcr.io                      # one-time; the packages are private
+#   docker compose -f docker-compose.local.yml pull
+#   docker compose -f docker-compose.local.yml up -d
+#   open http://localhost:8080
+#     ...then enter the workspace server address at the login screen.
+#
+# Nothing is built. Both images are pulled prebuilt (~300 MB total), so you need neither a Rust
+# toolchain nor Node.
+#
+# NETWORKING - READ THIS IF P2P DOES NOT WORK
+#
+# The agent establishes DIRECT peer-to-peer links to other users' agents, using NAT traversal
+# (STUN/UPnP) to punch through your router. It therefore wants the real network stack, which is
+# why `network_mode: host` is used below.
+#
+#   Linux            - works as written.
+#   macOS / Windows  - Docker runs inside a VM, so "host" is the VM's network, not your machine's.
+#                      That adds a second NAT layer around the agent. Server-mediated features
+#                      (workspaces, offices, group chat) are unaffected, but DIRECT P2P - private
+#                      messages and file transfer - may fail to connect. If it does, run the agent
+#                      as a native binary on your machine instead and point the UI at it with
+#                      AGENT_UPSTREAM=host.docker.internal:12345. This is a known limitation of
+#                      containerising a NAT-traversing peer, not a bug in the app.
+# =============================================================================
+
+services:
+  agent:
+    image: ghcr.io/avarok-cybersecurity/citadel-workspace-internal-service:${IMAGE_TAG:-latest}
+    environment:
+      - RUST_LOG=citadel=info
+      - INTERNAL_SERVICE_PORT=${INTERNAL_SERVICE_PORT:-12345}
+      # Bind to loopback: the ONLY thing that should reach the agent's control socket is the UI
+      # on this same machine. It is an unauthenticated control plane - anything that can talk to
+      # it can drive your sessions - so it must never be exposed on your LAN.
+      - INTERNAL_SERVICE_BIND_HOST=127.0.0.1
+      # Persist keys and sessions, so you are not re-registering every restart.
+      - INTERNAL_SERVICE_BACKEND=filesystem
+      - INTERNAL_SERVICE_DATA_DIR=/data/internal-service
+    volumes:
+      - agent_data:/data/internal-service
+    restart: unless-stopped
+    healthcheck:
+      test: ["CMD", "nc", "-z", "127.0.0.1", "${INTERNAL_SERVICE_PORT:-12345}"]
+      interval: 15s
+      timeout: 5s
+      retries: 5
+      start_period: 20s
+    network_mode: host
+
+  ui:
+    image: ghcr.io/avarok-cybersecurity/citadel-workspace-ui:${IMAGE_TAG:-latest}
+    environment:
+      # Where nginx forwards /ws. Loopback, because the agent above is on host networking.
+      # If you run the agent natively instead of in Docker, set this to
+      # host.docker.internal:12345 and drop `network_mode: host` from this service.
+      - AGENT_UPSTREAM=127.0.0.1:${INTERNAL_SERVICE_PORT:-12345}
+    depends_on:
+      agent:
+        condition: service_healthy
+    restart: unless-stopped
+    healthcheck:
+      test: ["CMD", "wget", "-q", "--spider", "http://127.0.0.1:8080/"]
+      interval: 15s
+      timeout: 5s
+      retries: 3
+      start_period: 10s
+    network_mode: host
+
+volumes:
+  # Your account keys and session state. Deleting this means re-registering.
+  agent_data:

--- a/docker-compose.local.yml
+++ b/docker-compose.local.yml
@@ -25,20 +25,26 @@
 # Nothing is built. Both images are pulled prebuilt (~300 MB total), so you need neither a Rust
 # toolchain nor Node.
 #
-# NETWORKING - READ THIS IF P2P DOES NOT WORK
+# NETWORKING
 #
-# The agent establishes DIRECT peer-to-peer links to other users' agents, using NAT traversal
-# (STUN/UPnP) to punch through your router. It therefore wants the real network stack, which is
-# why `network_mode: host` is used below.
+# The agent tries to establish a DIRECT peer-to-peer link to other users' agents, hole-punching
+# through your router. That is an OPTIMISATION, not a requirement: when the hole punch fails, the
+# Citadel protocol falls back to relaying peer traffic through the workspace server (a TURN-style
+# proxy - see check_proxy() in citadel_proto). The server forwards the packets without decrypting
+# them, since peers encrypt end-to-end with their own ratchet, so E2E is preserved either way.
+# The cost of relaying is latency and server bandwidth, not functionality.
 #
-#   Linux            - works as written.
+# `network_mode: host` below gives the agent the real network stack, which is what lets the direct
+# path work at all.
+#
+#   Linux            - direct P2P works as written.
 #   macOS / Windows  - Docker runs inside a VM, so "host" is the VM's network, not your machine's.
-#                      That adds a second NAT layer around the agent. Server-mediated features
-#                      (workspaces, offices, group chat) are unaffected, but DIRECT P2P - private
-#                      messages and file transfer - may fail to connect. If it does, run the agent
-#                      as a native binary on your machine instead and point the UI at it with
-#                      AGENT_UPSTREAM=host.docker.internal:12345. This is a known limitation of
-#                      containerising a NAT-traversing peer, not a bug in the app.
+#                      The extra NAT layer makes the DIRECT path less likely to succeed, so P2P is
+#                      more likely to be server-relayed. Everything still works; DMs and file
+#                      transfer just take the slower route. If you want the direct path (e.g. for
+#                      large file transfers), run the agent as a native binary on your machine and
+#                      point the UI at it with AGENT_UPSTREAM=host.docker.internal:12345 - this
+#                      image already supports that with no rebuild.
 # =============================================================================
 
 services:

--- a/docker-compose.local.yml
+++ b/docker-compose.local.yml
@@ -78,6 +78,19 @@ services:
       # If you run the agent natively instead of in Docker, set this to
       # host.docker.internal:12345 and drop `network_mode: host` from this service.
       - AGENT_UPSTREAM=127.0.0.1:${INTERNAL_SERVICE_PORT:-12345}
+      # Bind nginx to LOOPBACK, not 0.0.0.0.
+      #
+      # This service runs on host networking, so the image's 0.0.0.0 default (correct for a
+      # bridge-networked container, where -p cannot reach a loopback bind) would publish port
+      # 8080 on every interface - and /ws behind it. That would re-expose the agent's
+      # unauthenticated control plane to the whole LAN, undoing the 127.0.0.1 bind above: anyone
+      # on your network could drive your sessions. The UI is only ever opened from this machine.
+      - LISTEN_ADDR=127.0.0.1
+      # /ws proxies to the agent. Safe here, and ONLY here: the UI is loopback-bound (above) and
+      # nginx refuses any WebSocket whose Origin is not this page, which is what stops a malicious
+      # site you visit from driving your agent through your own browser. A publicly-served UI must
+      # set this to 0 - see docker-compose.production.yml.
+      - WS_PROXY_ENABLED=1
     depends_on:
       agent:
         condition: service_healthy

--- a/docker-compose.local.yml
+++ b/docker-compose.local.yml
@@ -16,11 +16,17 @@
 # the login screen.
 #
 # Usage:
-#   docker login ghcr.io                      # one-time; the packages are private
+#   docker login ghcr.io -u <your-github-username>
 #   docker compose -f docker-compose.local.yml pull
 #   docker compose -f docker-compose.local.yml up -d
 #   open http://localhost:8080
 #     ...then enter the workspace server address at the login screen.
+#
+# The `docker login` is one-time, and the password it asks for is NOT your GitHub password: these
+# images are private org packages, so it wants a Personal Access Token with the `read:packages`
+# scope. Create one at https://github.com/settings/tokens (classic), tick `read:packages` and
+# nothing else, and paste it at the password prompt. A token with only that scope cannot push
+# code or read private source - it can pull these images and nothing more.
 #
 # Nothing is built. Both images are pulled prebuilt (~300 MB total), so you need neither a Rust
 # toolchain nor Node.

--- a/docker-compose.local.yml
+++ b/docker-compose.local.yml
@@ -31,26 +31,38 @@
 # Nothing is built. Both images are pulled prebuilt (~300 MB total), so you need neither a Rust
 # toolchain nor Node.
 #
-# NETWORKING
+# NETWORKING - why this uses a private bridge and not host networking
 #
-# The agent tries to establish a DIRECT peer-to-peer link to other users' agents, hole-punching
-# through your router. That is an OPTIMISATION, not a requirement: when the hole punch fails, the
-# Citadel protocol falls back to relaying peer traffic through the workspace server (a TURN-style
-# proxy - see check_proxy() in citadel_proto). The server forwards the packets without decrypting
-# them, since peers encrypt end-to-end with their own ratchet, so E2E is preserved either way.
-# The cost of relaying is latency and server bandwidth, not functionality.
+# Everything below runs on a private Docker network, and the ONLY thing published to your machine
+# is the UI, on loopback. This is deliberate, for two independent reasons.
 #
-# `network_mode: host` below gives the agent the real network stack, which is what lets the direct
-# path work at all.
+# 1. It works the same on Linux, macOS and Windows. `network_mode: host` does not: on macOS and
+#    Windows, Docker runs inside a VM, so "host" is the VM's network rather than your machine's.
+#    Port 8080 is then bound inside the VM and http://localhost:8080 in your browser reaches
+#    nothing - the app would simply never load. (Docker Desktop has an opt-in host-networking mode,
+#    but it must be enabled by hand and is not the default.) A published port is the portable
+#    mechanism, so that is what this uses.
 #
-#   Linux            - direct P2P works as written.
-#   macOS / Windows  - Docker runs inside a VM, so "host" is the VM's network, not your machine's.
-#                      The extra NAT layer makes the DIRECT path less likely to succeed, so P2P is
-#                      more likely to be server-relayed. Everything still works; DMs and file
-#                      transfer just take the slower route. If you want the direct path (e.g. for
-#                      large file transfers), run the agent as a native binary on your machine and
-#                      point the UI at it with AGENT_UPSTREAM=host.docker.internal:12345 - this
-#                      image already supports that with no rebuild.
+# 2. It isolates the agent MORE tightly. The agent's WebSocket is an unauthenticated control plane
+#    - whatever can reach it can drive your sessions - and here it has no published port at all.
+#    It is reachable only from the `ui` container on this private network: not from your LAN, and
+#    not even from your own machine.
+#
+# The trade-off, stated honestly: behind Docker's NAT the agent is less likely to hole-punch a
+# DIRECT peer-to-peer link. That is an optimisation, not a requirement - when the hole punch fails,
+# the Citadel protocol relays peer traffic through the workspace server (a TURN-style proxy; see
+# check_proxy() in citadel_proto), which forwards packets WITHOUT decrypting them, because peers
+# encrypt end-to-end with their own ratchet. So end-to-end encryption holds either way and nothing
+# breaks; DMs and file transfer just take a slower route and spend server bandwidth.
+#
+# LINUX USERS WHO WANT DIRECT P2P can give the agent the real network stack. Host networking works
+# properly on Linux, and direct links measurably beat relayed ones for large file transfers. Change
+# these four things:
+#   agent:  add `network_mode: host`, and set INTERNAL_SERVICE_BIND_HOST=127.0.0.1
+#   ui:     add `network_mode: host`, drop the `ports:` block, and set
+#           LISTEN_ADDR=127.0.0.1 and AGENT_UPSTREAM=127.0.0.1:12345
+# Keep the agent on 127.0.0.1 there: under host networking a 0.0.0.0 bind would put that
+# unauthenticated control plane on your LAN.
 # =============================================================================
 
 services:
@@ -59,15 +71,18 @@ services:
     environment:
       - RUST_LOG=citadel=info
       - INTERNAL_SERVICE_PORT=${INTERNAL_SERVICE_PORT:-12345}
-      # Bind to loopback: the ONLY thing that should reach the agent's control socket is the UI
-      # on this same machine. It is an unauthenticated control plane - anything that can talk to
-      # it can drive your sessions - so it must never be exposed on your LAN.
-      - INTERNAL_SERVICE_BIND_HOST=127.0.0.1
+      # 0.0.0.0 is the CONTAINER's interfaces, not your machine's. With no `ports:` block below,
+      # nothing is published, so this socket is reachable only from the `ui` container on this
+      # private network. Binding loopback instead would make it unreachable even from there.
+      - INTERNAL_SERVICE_BIND_HOST=0.0.0.0
       # Persist keys and sessions, so you are not re-registering every restart.
       - INTERNAL_SERVICE_BACKEND=filesystem
       - INTERNAL_SERVICE_DATA_DIR=/data/internal-service
     volumes:
       - agent_data:/data/internal-service
+    # Deliberately NO `ports:`. Publishing the agent would expose an unauthenticated control plane
+    # to your machine, and on a 0.0.0.0 publish to your whole LAN. The UI reaches it over the
+    # private network by service name; nothing else needs to.
     restart: unless-stopped
     healthcheck:
       test: ["CMD", "nc", "-z", "127.0.0.1", "${INTERNAL_SERVICE_PORT:-12345}"]
@@ -75,28 +90,22 @@ services:
       timeout: 5s
       retries: 5
       start_period: 20s
-    network_mode: host
 
   ui:
     image: ghcr.io/avarok-cybersecurity/citadel-workspace-ui:${IMAGE_TAG:-latest}
     environment:
-      # Where nginx forwards /ws. Loopback, because the agent above is on host networking.
-      # If you run the agent natively instead of in Docker, set this to
-      # host.docker.internal:12345 and drop `network_mode: host` from this service.
-      - AGENT_UPSTREAM=127.0.0.1:${INTERNAL_SERVICE_PORT:-12345}
-      # Bind nginx to LOOPBACK, not 0.0.0.0.
-      #
-      # This service runs on host networking, so the image's 0.0.0.0 default (correct for a
-      # bridge-networked container, where -p cannot reach a loopback bind) would publish port
-      # 8080 on every interface - and /ws behind it. That would re-expose the agent's
-      # unauthenticated control plane to the whole LAN, undoing the 127.0.0.1 bind above: anyone
-      # on your network could drive your sessions. The UI is only ever opened from this machine.
-      - LISTEN_ADDR=127.0.0.1
-      # /ws proxies to the agent. Safe here, and ONLY here: the UI is loopback-bound (above) and
-      # nginx refuses any WebSocket whose Origin is not this page, which is what stops a malicious
-      # site you visit from driving your agent through your own browser. A publicly-served UI must
-      # set this to 0 - see docker-compose.production.yml.
+      # Reach the agent by service name on the private network. Docker's embedded DNS resolves it.
+      - AGENT_UPSTREAM=agent:${INTERNAL_SERVICE_PORT:-12345}
+      # /ws proxies to the agent. Safe here because the published port below is loopback-only and
+      # nginx refuses any WebSocket whose Origin is not this page and whose Host is not a loopback
+      # name - which is what stops a malicious site you visit from driving your agent through your
+      # own browser. A publicly-served UI must leave this off; see docker-compose.production.yml.
       - WS_PROXY_ENABLED=1
+    ports:
+      # 127.0.0.1 on the LEFT is load-bearing: it publishes the UI to THIS MACHINE only. A bare
+      # "8080:8080" would bind every interface and hand /ws - and the agent behind it - to anyone
+      # on your network.
+      - "127.0.0.1:8080:8080"
     depends_on:
       agent:
         condition: service_healthy
@@ -107,7 +116,6 @@ services:
       timeout: 5s
       retries: 3
       start_period: 10s
-    network_mode: host
 
 volumes:
   # Your account keys and session state. Deleting this means re-registering.

--- a/docker-compose.production.yml
+++ b/docker-compose.production.yml
@@ -173,6 +173,13 @@ services:
   # Vite build served via nginx
   # ---------------------------------------------------------------------------
   ui:
+    # Prebuilt from GHCR, like the other two. The image needs no per-environment build now: the
+    # app derives its socket URL from window.location at runtime, and nginx's /ws upstream is the
+    # AGENT_UPSTREAM env var below - so one published image serves every deployment.
+    image: ghcr.io/avarok-cybersecurity/citadel-workspace-ui:${IMAGE_TAG:-latest}
+    environment:
+      # This stack runs on host networking, so the agent is on loopback.
+      - AGENT_UPSTREAM=127.0.0.1:${INTERNAL_SERVICE_PORT:-12345}
     build:
       context: .
       dockerfile: ./docker/ui/Dockerfile

--- a/docker-compose.production.yml
+++ b/docker-compose.production.yml
@@ -9,22 +9,28 @@
 #                                                     └── server (citadel:12349)
 #
 # Usage:
-#   # Local testing (no tunnel) — serves the static UI only:
-#   docker compose -f docker-compose.production.yml up --build
-#   # The UI loads at http://localhost:8080, but the browser's WebSocket to
-#   # the internal service will NOT connect unless VITE_WS_URL is built to a
-#   # SAME-ORIGIN endpoint: the nginx CSP is `connect-src 'self'`, so an
-#   # off-origin `ws://localhost:12345` (the empty-VITE_WS_URL fallback) is
-#   # blocked by the browser. There is no built-in `/ws` reverse proxy, so a
-#   # fully-working no-tunnel deployment requires fronting this container
-#   # with your own same-origin WS proxy and building with VITE_WS_URL set to
-#   # it (e.g. `wss://yourdomain/ws`). For an end-to-end working stack, use
-#   # the tunnel profile below. nginx runs as the unprivileged `nginx` user
-#   # on 8080 so it doesn't need root to bind; do NOT add
-#   # CAP_NET_BIND_SERVICE — front it with a reverse proxy for 80/443.
+#   docker compose -f docker-compose.production.yml up -d
+#   # Nothing is built: all three images are pulled from GHCR (see deploy.sh).
 #
-#   # Production with Cloudflare Tunnel (full, working stack):
-#   TUNNEL_TOKEN=<your-token> docker compose -f docker-compose.production.yml --profile tunnel up --build -d
+#   # With Cloudflare Tunnel, to serve the UI publicly:
+#   TUNNEL_TOKEN=<your-token> docker compose -f docker-compose.production.yml --profile tunnel up -d
+#
+# THE UI SERVED HERE CANNOT REACH AN AGENT, BY DESIGN.
+#
+# The browser talks to the agent over a WebSocket, and the UI image can proxy that at a
+# same-origin /ws. This stack sets WS_PROXY_ENABLED=0 to switch that proxy OFF, because the UI
+# here is served PUBLICLY and the agent's socket is an unauthenticated control plane - proxying
+# it from a public origin would expose it to the internet (an Origin check does not help; a
+# non-browser client forges the header trivially). A hosted UI backed by one shared agent would
+# also put every user's ratchet keys on the operator's machine, which defeats the E2E guarantee.
+#
+# Users therefore run the agent and UI on their OWN machine - see docker-compose.local.yml - and
+# point it at the `server` hosted here. This stack's job is the SERVER. The `ui` and
+# `internal-service` services are retained from the older centralized topology; if you are not
+# using them, they are dead weight and can be dropped.
+#
+# nginx runs as the unprivileged `nginx` user on 8080 so it doesn't need root to bind; do NOT add
+# CAP_NET_BIND_SERVICE — front it with a reverse proxy for 80/443.
 #
 # Required environment variables (set in .env or export):
 #   WORKSPACE_MASTER_PASSWORD  - Master password for workspace initialization
@@ -173,26 +179,27 @@ services:
   # Vite build served via nginx
   # ---------------------------------------------------------------------------
   ui:
-    # Prebuilt from GHCR, like the other two. The image needs no per-environment build now: the
-    # app derives its socket URL from window.location at runtime, and nginx's /ws upstream is the
-    # AGENT_UPSTREAM env var below - so one published image serves every deployment.
+    # Prebuilt from GHCR, like the other two. There is deliberately NO `build:` block: with both
+    # `image:` and `build:` present, Compose builds locally and the published image - the one the
+    # release gate verified and the one carrying the nginx config - is silently bypassed. The
+    # image needs no per-environment build anyway: the app derives its socket URL from
+    # window.location at runtime, so one published image serves every deployment.
     image: ghcr.io/avarok-cybersecurity/citadel-workspace-ui:${IMAGE_TAG:-latest}
     environment:
-      # This stack runs on host networking, so the agent is on loopback.
-      - AGENT_UPSTREAM=127.0.0.1:${INTERNAL_SERVICE_PORT:-12345}
-    build:
-      context: .
-      dockerfile: ./docker/ui/Dockerfile
-      target: production
-      args:
-        # Vite bakes VITE_* env vars at build time. The frontend's
-        # WebSocket URL falls back to `ws://localhost:12345` if this
-        # is empty, which the production CSP `connect-src 'self'`
-        # blocks (different port from the served origin and wrong
-        # scheme behind a Cloudflare tunnel). Operators set this in
-        # `.env` to a same-origin `wss://yourdomain.com/ws` so the
-        # browser can actually connect.
-        VITE_WS_URL: ${VITE_WS_URL:-}
+      # THE AGENT PROXY IS OFF HERE, AND MUST STAY OFF.
+      #
+      # This stack serves the UI publicly (that is what the `cloudflared` profile below does).
+      # The agent's WebSocket is an UNAUTHENTICATED control plane - whoever reaches it drives the
+      # user's sessions - so proxying it from a public origin would hand it to the internet. An
+      # Origin check does not save you: WebSockets carry no CORS preflight and a non-browser
+      # client forges the header with a single curl flag. The only sound control is not to proxy
+      # it at all from a publicly-served UI.
+      #
+      # A hosted UI backed by one shared agent is also incompatible with the product's threat
+      # model: that agent would hold EVERY user's ratchet keys, so the operator could read all
+      # P2P traffic. Users run their own agent locally instead - see docker-compose.local.yml,
+      # which is where /ws is both safe and enabled.
+      - WS_PROXY_ENABLED=0
     deploy:
       resources:
         limits:

--- a/docker/ui/16-validate-runtime-vars.sh
+++ b/docker/ui/16-validate-runtime-vars.sh
@@ -1,0 +1,65 @@
+#!/bin/sh
+#
+# Validate the three runtime variables BEFORE envsubst renders them into the nginx config.
+#
+# WHY THIS EXISTS
+#
+# envsubst substitutes these values into the config file verbatim, so any character that means
+# something to nginx's parser is an injection vector. Demonstrated on the unvalidated image:
+#
+#   AGENT_UPSTREAM='127.0.0.1:12345/; return 200 "INJECTED"; #'
+#
+# renders `proxy_pass http://127.0.0.1:12345/; return 200 "INJECTED"; #/;` - and nginx STARTS,
+# because the `;` closed the directive and the rest became real configuration. The same trick works
+# through WS_PROXY_ENABLED and LISTEN_ADDR, which land inside a quoted `set` and a `listen`.
+#
+# Whoever sets these variables is largely trusted - if you can set env on the container you can
+# usually replace the image - so this is defence in depth rather than a boundary. But it is the
+# same reasoning that makes NGINX_ENVSUBST_FILTER worth pinning: an environment variable should
+# configure the proxy, never rewrite it. It also turns a class of operator typo (a stray scheme, a
+# trailing slash, a full URL) into a loud startup failure instead of a subtly wrong proxy.
+#
+# Runs at 16 so it lands after the base image's own 10-/15- scripts and BEFORE
+# 20-envsubst-on-templates.sh, i.e. before the values reach the config.
+
+set -eu
+
+die() {
+  echo "[validate-runtime-vars] FATAL: $1" >&2
+  echo "[validate-runtime-vars] refusing to start rather than render an unvalidated config." >&2
+  exit 1
+}
+
+# host:port - a DNS name, IPv4 literal, or docker service name, plus a numeric port. Deliberately
+# strict: no scheme, no path, no whitespace, no shell or nginx metacharacters.
+upstream="${AGENT_UPSTREAM:-}"
+[ -n "$upstream" ] || die "AGENT_UPSTREAM is empty."
+echo "$upstream" | grep -Eq '^[A-Za-z0-9]([A-Za-z0-9._-]*[A-Za-z0-9])?:[0-9]{1,5}$' \
+  || die "AGENT_UPSTREAM='$upstream' is not a bare host:port (e.g. 127.0.0.1:12345 or agent:12345). A scheme, path, or punctuation is rejected because this value is substituted directly into proxy_pass."
+
+# Checked for INJECTION SAFETY only - deliberately NOT restricted to {0,1}.
+#
+# The config is opt-in: anything that is not exactly "1" disables the proxy. That is the documented
+# fail-closed behaviour and it is what makes `WS_PROXY_ENABLED=false` safe rather than surprising.
+# Demanding 0-or-1 here would turn that into a container that refuses to boot, so an operator who
+# wrote the intuitive "false" would get a dead UI instead of a working one with the proxy off -
+# trading a good failure mode for a worse one.
+#
+# So allow any benign token and let the config decide, while blocking the characters that would let
+# this value escape its quoted `set` directive and become configuration.
+enabled="${WS_PROXY_ENABLED:-}"
+case "$enabled" in
+  *[\"\;\$\\]* | *"'"* )
+    die "WS_PROXY_ENABLED contains a character that could break out of the nginx directive it is substituted into. Use a plain token such as 1 or 0." ;;
+esac
+case "$enabled" in
+  *[!A-Za-z0-9_-]* )
+    die "WS_PROXY_ENABLED='$enabled' must be a plain alphanumeric token (1 enables the proxy; anything else disables it)." ;;
+esac
+
+# An IP literal to bind. Not a hostname: this goes into `listen`, which wants an address.
+listen_addr="${LISTEN_ADDR:-}"
+echo "$listen_addr" | grep -Eq '^[0-9]{1,3}(\.[0-9]{1,3}){3}$|^\[[0-9A-Fa-f:]+\]$' \
+  || die "LISTEN_ADDR='$listen_addr' must be an IPv4 address (e.g. 0.0.0.0 or 127.0.0.1) or a bracketed IPv6 address."
+
+echo "[validate-runtime-vars] ok: upstream=$upstream ws_proxy=$enabled listen=$listen_addr"

--- a/docker/ui/Dockerfile
+++ b/docker/ui/Dockerfile
@@ -126,92 +126,32 @@ RUN chown -R nginx:nginx /usr/share/nginx/html /var/cache/nginx /var/log/nginx \
     && chown nginx:nginx /var/run/nginx.pid \
     && rm -f /etc/nginx/conf.d/default.conf
 
-# Custom nginx config for SPA routing (all routes -> index.html).
+# nginx config lives in docker/ui/nginx.conf.template and is rendered at CONTAINER
+# START by the nginx image's envsubst entrypoint, not baked in at build time.
 #
-# Security headers note: nginx `add_header` does NOT inherit across
-# nesting levels — if a `location` block declares its own `add_header`,
-# it silently replaces ALL inherited headers from the parent `server`
-# block. So the security headers below must be repeated in every
-# `location` block that also adds Cache-Control. Verbose, but explicit
-# and correct; alternatives (sub-include files, `more_set_headers` from
-# nginx-extras) require either extra build wiring or a non-stable
-# nginx variant.
-#
-# CSP rationale:
-#   * `script-src 'self' 'wasm-unsafe-eval'` — WASM compilation
-#     (WebAssembly.compile / instantiate) is blocked by default CSP
-#     unless `'wasm-unsafe-eval'` is granted. The Citadel WASM client
-#     will fail to initialise without it.
-#   * `style-src 'self' 'unsafe-inline'` — Vite/React + several Radix
-#     UI components emit inline styles for layout/measurement.
-#   * `img-src 'self' data:` — small inline icons use data: URLs.
-#   * `connect-src 'self'` — WebSocket to the internal service and
-#     workspace server is the app's primary transport, and in
-#     production all of that traffic flows through the Cloudflare
-#     tunnel as same-origin `wss://yourdomain.com`, which `'self'`
-#     already covers. We DO NOT add `wss:` here: per the CSP spec a
-#     bare scheme source matches ANY host with that scheme (not just
-#     the document's host), so `wss:` would let an XSS payload
-#     exfiltrate data to `wss://attacker.example`. Dev uses Vite's
-#     own CSP, not this config.
-#   * `object-src 'none'` — defence-in-depth against legacy plugin
-#     content (<object>, <embed>, <applet>). Without it, `object-src`
-#     falls back to `default-src 'self'`, allowing same-origin plugin
-#     loads. The app uses no such content, so `'none'` is strictly
-#     more restrictive with zero functional cost — and it's the
-#     OWASP-recommended baseline.
-RUN printf 'server {\n\
-    listen 8080;\n\
-    server_name _;\n\
-    root /usr/share/nginx/html;\n\
-    index index.html;\n\
-\n\
-    # Gzip compression\n\
-    gzip on;\n\
-    gzip_types text/plain text/css application/json application/javascript text/xml application/xml application/xml+rss text/javascript application/wasm;\n\
-    gzip_vary on;\n\
-    gzip_min_length 256;\n\
-\n\
-    # Security headers (server-level; re-emitted in any location that\n\
-    # also calls add_header — see comment above).\n\
-    add_header X-Frame-Options "SAMEORIGIN" always;\n\
-    add_header X-Content-Type-Options "nosniff" always;\n\
-    add_header Referrer-Policy "strict-origin-when-cross-origin" always;\n\
-    add_header Permissions-Policy "geolocation=(), microphone=(), camera=()" always;\n\
-    add_header Content-Security-Policy "default-src '\''self'\''; script-src '\''self'\'' '\''wasm-unsafe-eval'\''; style-src '\''self'\'' '\''unsafe-inline'\''; img-src '\''self'\'' data:; font-src '\''self'\'' data:; connect-src '\''self'\''; worker-src '\''self'\'' blob:; object-src '\''none'\''; frame-ancestors '\''self'\''; base-uri '\''self'\''; form-action '\''self'\''" always;\n\
-\n\
-    # Cache static assets aggressively (hashed filenames from Vite)\n\
-    location /assets/ {\n\
-        expires 1y;\n\
-        add_header Cache-Control "public, immutable" always;\n\
-        add_header X-Frame-Options "SAMEORIGIN" always;\n\
-        add_header X-Content-Type-Options "nosniff" always;\n\
-        add_header Referrer-Policy "strict-origin-when-cross-origin" always;\n\
-        add_header Permissions-Policy "geolocation=(), microphone=(), camera=()" always;\n\
-        add_header Content-Security-Policy "default-src '\''self'\''; script-src '\''self'\'' '\''wasm-unsafe-eval'\''; style-src '\''self'\'' '\''unsafe-inline'\''; img-src '\''self'\'' data:; font-src '\''self'\'' data:; connect-src '\''self'\''; worker-src '\''self'\'' blob:; object-src '\''none'\''; frame-ancestors '\''self'\''; base-uri '\''self'\''; form-action '\''self'\''" always;\n\
-    }\n\
-\n\
-    # WASM files\n\
-    location ~* \\.wasm$ {\n\
-        types { application/wasm wasm; }\n\
-        expires 1y;\n\
-        add_header Cache-Control "public, immutable" always;\n\
-        add_header X-Frame-Options "SAMEORIGIN" always;\n\
-        add_header X-Content-Type-Options "nosniff" always;\n\
-        add_header Referrer-Policy "strict-origin-when-cross-origin" always;\n\
-        add_header Permissions-Policy "geolocation=(), microphone=(), camera=()" always;\n\
-        add_header Content-Security-Policy "default-src '\''self'\''; script-src '\''self'\'' '\''wasm-unsafe-eval'\''; style-src '\''self'\'' '\''unsafe-inline'\''; img-src '\''self'\'' data:; font-src '\''self'\'' data:; connect-src '\''self'\''; worker-src '\''self'\'' blob:; object-src '\''none'\''; frame-ancestors '\''self'\''; base-uri '\''self'\''; form-action '\''self'\''" always;\n\
-    }\n\
-\n\
-    # SPA fallback - serve index.html for all non-file routes.\n\
-    # CAUTION: Do NOT add `add_header` here without also repeating ALL\n\
-    # security headers above — nginx `add_header` does not inherit when\n\
-    # a nested block declares its own header, so a Cache-Control line\n\
-    # added here would silently drop the CSP / X-Frame-Options block.\n\
-    location / {\n\
-        try_files $uri $uri/ /index.html;\n\
-    }\n\
-}\n' > /etc/nginx/conf.d/default.conf
+# WHY IT IS A TEMPLATE: the config now proxies `/ws` to the Citadel agent, and the
+# agent sits somewhere different in each topology - 127.0.0.1 on host networking,
+# a service name on a bridge network, host.docker.internal when it runs natively
+# on the user's machine. Baking the upstream in would mean one image per topology,
+# which defeats the point of publishing it to a registry. AGENT_UPSTREAM is
+# therefore a RUNTIME setting with a sane default.
+COPY docker/ui/nginx.conf.template /etc/nginx/templates/default.conf.template
+
+# Where the agent lives. Default suits host networking (and the dev stack). Override
+# with `-e AGENT_UPSTREAM=internal-service:12345` on a bridge network, or
+# `host.docker.internal:12345` for an agent running natively on the host.
+ENV AGENT_UPSTREAM=127.0.0.1:12345
+
+# Substitute ONLY AGENT_UPSTREAM. Without this filter, envsubst would also expand
+# nginx's own runtime variables ($host, $uri, $http_upgrade, $connection_upgrade)
+# into empty strings, silently producing a config that proxies nothing and drops
+# the upgrade handshake. This one line is load-bearing.
+ENV NGINX_ENVSUBST_FILTER=^AGENT_UPSTREAM$
+
+# The entrypoint renders templates into /etc/nginx/conf.d at start-up, and we run as
+# the unprivileged `nginx` user - so that directory must be writable by it. Without
+# this the container starts, fails to write the rendered config, and serves nothing.
+RUN chown -R nginx:nginx /etc/nginx/conf.d
 
 USER nginx
 EXPOSE 8080

--- a/docker/ui/Dockerfile
+++ b/docker/ui/Dockerfile
@@ -38,16 +38,19 @@ CMD ["npm", "run", "dev:docker"]
 # ==============================================================================
 FROM node:20-alpine AS build
 
-# Vite substitutes `import.meta.env.VITE_*` at build time. The runtime
-# WebSocket URL in `lib/websocket-service/core.ts` resolves to
-# `config.websocketUrl || import.meta.env.VITE_WS_URL || ws://localhost:12345`,
-# and the production CSP (`connect-src 'self'`) blocks the localhost
-# fallback when the page is served from a different origin (Cloudflare
-# tunnel, custom domain, etc.). Operators MUST set `VITE_WS_URL` to a
-# same-origin `wss://yourdomain.com/...` for the production deploy to
-# establish a WebSocket connection. docker-compose.production.yml
-# forwards the env var via `args:` so the operator's `.env` is the
-# single source of truth.
+# LEAVE THIS EMPTY. It exists only as an escape hatch, and setting it re-breaks the
+# thing this image was fixed to do.
+#
+# The app now derives its WebSocket URL from `window.location` at runtime, reaching the
+# agent through the same-origin `/ws` proxy below. That is what lets ONE published image
+# serve every topology. Baking an absolute URL in here pins the image to a single
+# deployment - and an OFF-ORIGIN one is blocked outright by the production CSP
+# (`connect-src 'self'`), which is the exact bug this replaced: the app appeared to work
+# in dev, whose CSP was laxer, and could not connect at all once built.
+#
+# Only a SAME-ORIGIN value (`wss://yourdomain.com/ws`) can work, and that is precisely
+# what the runtime default already produces - so there is no reason to set it. CI passes
+# no build-arg deliberately.
 ARG VITE_WS_URL=
 ENV VITE_WS_URL=${VITE_WS_URL}
 
@@ -111,7 +114,12 @@ RUN npm run build
 # (Cloudflare tunnel in this repo) — the container internal port
 # does not need to be 80.
 # ==============================================================================
-FROM nginx:stable-alpine AS production
+# Pinned to a minor line, not the moving `stable-alpine` tag. This image's behaviour depends on
+# the base's envsubst entrypoint (NGINX_ENVSUBST_FILTER), so an upstream major bump could change
+# how the config renders. The smoke test asserts the rendered output, so such a break would fail
+# the build rather than ship - but a deterministic base means it fails when we bump it, not at a
+# random hour because upstream moved a tag. Patch releases still flow in.
+FROM nginx:1.30-alpine AS production
 
 # Copy the built static assets from the build stage
 COPY --from=build /app/dist /usr/share/nginx/html
@@ -142,13 +150,21 @@ COPY docker/ui/nginx.conf.template /etc/nginx/templates/default.conf.template
 # `host.docker.internal:12345` for an agent running natively on the host.
 ENV AGENT_UPSTREAM=127.0.0.1:12345
 
-# Whether /ws proxies to the agent at all. The agent's socket is an UNAUTHENTICATED
-# control plane, and an Origin check cannot protect it from a non-browser client that
-# simply forges the header - so any deployment whose UI is reachable off-box (e.g.
-# served through a public tunnel) MUST set this to 0. Defaults to 1 because the
-# shipped topology is the local client, where the proxy is safe and required.
+# Whether /ws proxies to the agent at all. DEFAULTS TO OFF - the image FAILS CLOSED.
+#
+# The agent's socket is an UNAUTHENTICATED control plane, and an Origin check cannot
+# protect it from a non-browser client that simply forges the header. So the blast
+# radius of a permissive default is: anyone who runs this image in a topology we did
+# not anticipate - `docker run --network host`, a bridge run with `-p 8080:8080`,
+# behind someone else's ingress - silently republishes that control plane to whoever
+# can reach the port. An image cannot know which of those it is in.
+#
+# So the deployment declares its intent instead of inheriting it. docker-compose.local.yml
+# sets this to 1 because there the UI is loopback-bound and the proxy is both safe and
+# required; every other topology gets no proxy unless it asks. A wrong default here is a
+# security hole, whereas a wrong default the other way is a visible 404.
 # See the SECURITY note in nginx.conf.template.
-ENV WS_PROXY_ENABLED=1
+ENV WS_PROXY_ENABLED=0
 
 # Address nginx binds. 0.0.0.0 is right for a bridge-networked container (`-p 8080:8080`
 # cannot reach a loopback bind). Under HOST networking it would publish /ws to the LAN,

--- a/docker/ui/Dockerfile
+++ b/docker/ui/Dockerfile
@@ -142,11 +142,25 @@ COPY docker/ui/nginx.conf.template /etc/nginx/templates/default.conf.template
 # `host.docker.internal:12345` for an agent running natively on the host.
 ENV AGENT_UPSTREAM=127.0.0.1:12345
 
-# Substitute ONLY AGENT_UPSTREAM. Without this filter, envsubst would also expand
-# nginx's own runtime variables ($host, $uri, $http_upgrade, $connection_upgrade)
-# into empty strings, silently producing a config that proxies nothing and drops
-# the upgrade handshake. This one line is load-bearing.
-ENV NGINX_ENVSUBST_FILTER=^AGENT_UPSTREAM$
+# Whether /ws proxies to the agent at all. The agent's socket is an UNAUTHENTICATED
+# control plane, and an Origin check cannot protect it from a non-browser client that
+# simply forges the header - so any deployment whose UI is reachable off-box (e.g.
+# served through a public tunnel) MUST set this to 0. Defaults to 1 because the
+# shipped topology is the local client, where the proxy is safe and required.
+# See the SECURITY note in nginx.conf.template.
+ENV WS_PROXY_ENABLED=1
+
+# Address nginx binds. 0.0.0.0 is right for a bridge-networked container (`-p 8080:8080`
+# cannot reach a loopback bind). Under HOST networking it would publish /ws to the LAN,
+# so docker-compose.local.yml overrides this to 127.0.0.1.
+ENV LISTEN_ADDR=0.0.0.0
+
+# Substitute ONLY these three. Without this filter, envsubst would also expand nginx's
+# own runtime variables ($host, $uri, $http_upgrade, $connection_upgrade) into empty
+# strings, silently producing a config that proxies nothing and drops the upgrade
+# handshake. This one line is load-bearing, and the smoke test in publish-images.yml
+# asserts the rendered config still contains them.
+ENV NGINX_ENVSUBST_FILTER=^(AGENT_UPSTREAM|WS_PROXY_ENABLED|LISTEN_ADDR)$
 
 # The entrypoint renders templates into /etc/nginx/conf.d at start-up, and we run as
 # the unprivileged `nginx` user - so that directory must be writable by it. Without

--- a/docker/ui/Dockerfile
+++ b/docker/ui/Dockerfile
@@ -145,6 +145,13 @@ RUN chown -R nginx:nginx /usr/share/nginx/html /var/cache/nginx /var/log/nginx \
 # therefore a RUNTIME setting with a sane default.
 COPY docker/ui/nginx.conf.template /etc/nginx/templates/default.conf.template
 
+# Validate the runtime variables before envsubst renders them. They are substituted into the
+# config VERBATIM, so a value containing `;` injects real nginx directives - demonstrated with
+# AGENT_UPSTREAM='127.0.0.1:12345/; return 200 "x"; #', which nginx accepted and started on.
+# Numbered 16 so it runs after the base image's own scripts and before 20-envsubst-on-templates.sh.
+COPY docker/ui/16-validate-runtime-vars.sh /docker-entrypoint.d/16-validate-runtime-vars.sh
+RUN chmod +x /docker-entrypoint.d/16-validate-runtime-vars.sh
+
 # Where the agent lives. Default suits host networking (and the dev stack). Override
 # with `-e AGENT_UPSTREAM=internal-service:12345` on a bridge network, or
 # `host.docker.internal:12345` for an agent running natively on the host.

--- a/docker/ui/Dockerfile
+++ b/docker/ui/Dockerfile
@@ -171,11 +171,19 @@ ENV WS_PROXY_ENABLED=0
 # so docker-compose.local.yml overrides this to 127.0.0.1.
 ENV LISTEN_ADDR=0.0.0.0
 
-# Substitute ONLY these three. Without this filter, envsubst would also expand nginx's
-# own runtime variables ($host, $uri, $http_upgrade, $connection_upgrade) into empty
-# strings, silently producing a config that proxies nothing and drops the upgrade
-# handshake. This one line is load-bearing, and the smoke test in publish-images.yml
-# asserts the rendered config still contains them.
+# Pin envsubst to exactly these three names.
+#
+# The entrypoint builds its substitution list from the names of REAL environment
+# variables, so nginx's own `$http_upgrade` / `$connection_upgrade` are not at risk
+# merely because the filter is absent - verified by rendering both ways. What the
+# filter actually prevents is a COLLISION: without it, every environment variable is
+# eligible, so an env var whose name happens to match an nginx variable rewrites the
+# config. Demonstrated - running the unfiltered image with `-e host=pwned` renders
+# `proxy_set_header Host pwned;`, while the filtered image keeps `$host`.
+#
+# That makes this an injection guard: whoever can set env vars on the container could
+# otherwise alter the proxy's behaviour, including the headers it forwards. The smoke
+# test asserts the property directly by starting the image with a colliding variable.
 ENV NGINX_ENVSUBST_FILTER=^(AGENT_UPSTREAM|WS_PROXY_ENABLED|LISTEN_ADDR)$
 
 # The entrypoint renders templates into /etc/nginx/conf.d at start-up, and we run as

--- a/docker/ui/nginx.conf.template
+++ b/docker/ui/nginx.conf.template
@@ -1,0 +1,132 @@
+# =============================================================================
+# nginx config for the Citadel Workspace UI.
+#
+# Rendered at CONTAINER START by the nginx image's envsubst entrypoint
+# (/docker-entrypoint.d/20-envsubst-on-templates.sh), which substitutes
+# ${AGENT_UPSTREAM} and writes the result to /etc/nginx/conf.d/. Only that one
+# variable is substituted - NGINX_ENVSUBST_FILTER pins it - so nginx's own
+# runtime variables ($host, $uri, $http_upgrade, ...) survive untouched. Getting
+# that filter wrong would silently mangle the config, which is why it is set.
+#
+# This lives in a real file rather than a printf'd one-liner in the Dockerfile:
+# the config now has a proxy block with upgrade headers and timeouts, and
+# maintaining that as escaped `\n\` continuations is a bug farm.
+# =============================================================================
+
+# WebSocket upgrade handshake. `Connection` must be `upgrade` for a websocket and
+# `close` otherwise; hardcoding `upgrade` breaks plain HTTP requests through the
+# same proxy. `map` is http-level context, which is what conf.d files are included
+# into.
+map $http_upgrade $connection_upgrade {
+    default upgrade;
+    ''      close;
+}
+
+server {
+    listen 8080;
+    server_name _;
+    root /usr/share/nginx/html;
+    index index.html;
+
+    # Gzip compression
+    gzip on;
+    gzip_types text/plain text/css application/json application/javascript text/xml application/xml application/xml+rss text/javascript application/wasm;
+    gzip_vary on;
+    gzip_min_length 256;
+
+    # -------------------------------------------------------------------------
+    # Security headers.
+    #
+    # nginx `add_header` does NOT inherit into a nested block that declares its
+    # own `add_header` - the nested set silently REPLACES the inherited one. So
+    # every location that adds a header must repeat all of them. Verbose, but the
+    # alternative is a location that quietly ships with no CSP.
+    #
+    # CSP rationale:
+    #   * script-src 'wasm-unsafe-eval' - WebAssembly.instantiate is blocked by
+    #     default CSP without it, and the Citadel WASM client will not initialise.
+    #   * style-src 'unsafe-inline'     - React/Radix emit inline styles.
+    #   * connect-src 'self'            - the app's only outbound connection is the
+    #     WebSocket to the agent, and that is now SAME-ORIGIN (see /ws below), so
+    #     'self' covers it. We deliberately do NOT add `ws:`/`wss:`: a bare scheme
+    #     source matches ANY host with that scheme, so it would let an XSS payload
+    #     exfiltrate to wss://attacker.example. Same-origin proxying is what lets
+    #     this stay strict.
+    #   * object-src 'none'             - defence in depth against legacy plugins.
+    # -------------------------------------------------------------------------
+    add_header X-Frame-Options "SAMEORIGIN" always;
+    add_header X-Content-Type-Options "nosniff" always;
+    add_header Referrer-Policy "strict-origin-when-cross-origin" always;
+    add_header Permissions-Policy "geolocation=(), microphone=(), camera=()" always;
+    add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'wasm-unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; font-src 'self' data:; connect-src 'self'; worker-src 'self' blob:; object-src 'none'; frame-ancestors 'self'; base-uri 'self'; form-action 'self'" always;
+
+    # -------------------------------------------------------------------------
+    # The agent socket.
+    #
+    # This is the whole point of the file. The browser cannot speak the Citadel
+    # protocol (raw TCP/QUIC), so it talks to a native agent over a WebSocket. The
+    # app resolves that socket to a SAME-ORIGIN `/ws` path, and nginx forwards it
+    # to the agent. Same-origin is what allows `connect-src 'self'` above to remain
+    # strict: a direct `ws://localhost:12345` from a page served here is a
+    # different origin and the browser blocks it outright.
+    #
+    # AGENT_UPSTREAM is set at RUN time, not baked in, because the agent sits
+    # somewhere different in each topology:
+    #   127.0.0.1:12345          - agent container on host networking (and dev)
+    #   internal-service:12345   - agent container on a bridge network
+    #   host.docker.internal:12345 - agent running natively on the user's machine
+    # One image serves all three.
+    #
+    # The trailing slash strips the `/ws` prefix, so the agent sees `/`. (It uses
+    # tokio-tungstenite's accept_async and ignores the path entirely, but sending
+    # it the path it would get from a direct connection keeps the proxy
+    # transparent.)
+    location /ws {
+        proxy_pass http://${AGENT_UPSTREAM}/;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection $connection_upgrade;
+        proxy_set_header Host $host;
+
+        # A Citadel session is a long-lived socket that can sit idle between
+        # messages. nginx's default proxy_read_timeout is 60s, which would tear
+        # down an idle session and surface to the user as a random disconnect.
+        proxy_read_timeout 3600s;
+        proxy_send_timeout 3600s;
+
+        # Never buffer a bidirectional stream - buffering would delay message
+        # delivery until nginx's buffer filled or flushed.
+        proxy_buffering off;
+    }
+
+    # Cache static assets aggressively (Vite emits content-hashed filenames)
+    location /assets/ {
+        expires 1y;
+        add_header Cache-Control "public, immutable" always;
+        add_header X-Frame-Options "SAMEORIGIN" always;
+        add_header X-Content-Type-Options "nosniff" always;
+        add_header Referrer-Policy "strict-origin-when-cross-origin" always;
+        add_header Permissions-Policy "geolocation=(), microphone=(), camera=()" always;
+        add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'wasm-unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; font-src 'self' data:; connect-src 'self'; worker-src 'self' blob:; object-src 'none'; frame-ancestors 'self'; base-uri 'self'; form-action 'self'" always;
+    }
+
+    # WASM files
+    location ~* \.wasm$ {
+        types { application/wasm wasm; }
+        expires 1y;
+        add_header Cache-Control "public, immutable" always;
+        add_header X-Frame-Options "SAMEORIGIN" always;
+        add_header X-Content-Type-Options "nosniff" always;
+        add_header Referrer-Policy "strict-origin-when-cross-origin" always;
+        add_header Permissions-Policy "geolocation=(), microphone=(), camera=()" always;
+        add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'wasm-unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; font-src 'self' data:; connect-src 'self'; worker-src 'self' blob:; object-src 'none'; frame-ancestors 'self'; base-uri 'self'; form-action 'self'" always;
+    }
+
+    # SPA fallback - serve index.html for all non-file routes.
+    #
+    # CAUTION: do NOT add an `add_header` here without repeating ALL the security
+    # headers above; see the note at the top of the server block.
+    location / {
+        try_files $uri $uri/ /index.html;
+    }
+}

--- a/docker/ui/nginx.conf.template
+++ b/docker/ui/nginx.conf.template
@@ -22,8 +22,22 @@ map $http_upgrade $connection_upgrade {
     ''      close;
 }
 
+# Host part of the Origin header, or "" when absent. Used to enforce same-origin on
+# /ws (see below). We compare only the HOST, never the scheme: where TLS is
+# terminated upstream (a Cloudflare tunnel), the browser sends `https://x` while
+# nginx sees `$scheme` = http, so a scheme comparison would reject every legitimate
+# request behind a TLS-terminating proxy.
+map $http_origin $ws_origin_host {
+    default "";
+    "~^https?://(.+)$" $1;
+}
+
 server {
-    listen 8080;
+    # LISTEN_ADDR is 0.0.0.0 by default, which is what a bridge-networked container
+    # needs for `-p 8080:8080` to reach it. Under HOST networking, though, 0.0.0.0
+    # publishes /ws - and therefore the agent behind it - to the whole LAN, so the
+    # local-client compose overrides this to 127.0.0.1. See docker-compose.local.yml.
+    listen ${LISTEN_ADDR}:8080;
     server_name _;
     root /usr/share/nginx/html;
     index index.html;
@@ -81,7 +95,53 @@ server {
     # tokio-tungstenite's accept_async and ignores the path entirely, but sending
     # it the path it would get from a direct connection keeps the proxy
     # transparent.)
-    location /ws {
+    #
+    # -------------------------------------------------------------------------
+    # SECURITY. The agent's WebSocket is an UNAUTHENTICATED CONTROL PLANE: whoever
+    # can talk to it can drive the user's sessions. Proxying it therefore needs two
+    # independent controls, because neither is sufficient alone.
+    #
+    # 1. WS_PROXY_ENABLED. WebSockets are exempt from the same-origin policy and
+    #    carry no CORS preflight, and a non-browser client can forge any Origin it
+    #    likes (`curl -H 'Origin: https://yourdomain'`). So an Origin check does NOT
+    #    protect a publicly-reachable /ws - anyone on the internet would simply
+    #    forge the header and drive the agent. The only sound control for a UI that
+    #    is served publicly (e.g. behind the Cloudflare tunnel in
+    #    docker-compose.production.yml) is to not proxy the agent at all. This flag
+    #    is the switch, and any deployment whose UI is reachable off-box MUST set it
+    #    to 0. It defaults to 1 because the shipped topology - the local client in
+    #    docker-compose.local.yml - is the one where the proxy is both safe and
+    #    required.
+    #
+    # 2. Same-origin Origin check. Even when the UI is bound to loopback, a browser
+    #    is a confused deputy: a malicious page the user visits can open a WebSocket
+    #    to http://localhost:8080/ws FROM the user's own machine, and the request
+    #    arrives from 127.0.0.1 looking entirely legitimate (this is cross-site
+    #    WebSocket hijacking). A network/IP-based control cannot see the difference;
+    #    the Origin header can. Browsers set it truthfully and cannot be made to lie,
+    #    which is exactly the case this defends. Requests with no Origin are refused
+    #    too - the UI is a browser and always sends one.
+    # -------------------------------------------------------------------------
+    location = /ws {
+        # `location = /ws` is an EXACT match, deliberately. A prefix match would also
+        # capture /wsfoo and /ws/anything and forward them to the agent.
+
+        # Deliberately NO add_header here. Because this block declares none, nginx inherits
+        # the full server-level set - including onto the 403/404/502 error pages below, and
+        # through the `if` contexts. Confirmed by request, not assumed: adding even one
+        # add_header here would REPLACE the inherited set, so the error pages would silently
+        # ship with no CSP. That is exactly why /assets/ and .wasm below must repeat all of
+        # them (they add Cache-Control, which breaks their inheritance).
+        set $ws_proxy_enabled "${WS_PROXY_ENABLED}";
+        if ($ws_proxy_enabled = "0") {
+            return 404;
+        }
+
+        # Same-origin or nothing. See (2) above.
+        if ($ws_origin_host != $http_host) {
+            return 403;
+        }
+
         proxy_pass http://${AGENT_UPSTREAM}/;
         proxy_http_version 1.1;
         proxy_set_header Upgrade $http_upgrade;

--- a/docker/ui/nginx.conf.template
+++ b/docker/ui/nginx.conf.template
@@ -34,6 +34,32 @@ map $http_origin $ws_origin_host {
     "~^https?://(.+)$" $1;
 }
 
+# Is the Host header one this machine can legitimately be addressed by? This is the
+# DNS-REBINDING defence, and it is NOT the same check as same-origin below.
+#
+# Origin == Host proves the request is SAME-SITE. It does not prove it is SAME-MACHINE.
+# An attacker serves a page from evil.example (DNS TTL 0), then re-points evil.example
+# at 127.0.0.1 and has the page open ws://evil.example:8080/ws. The browser connects to
+# THIS nginx and sends `Host: evil.example:8080` and `Origin: http://evil.example:8080` -
+# equal, so a same-origin check alone waves it straight through, and the attacker's
+# JavaScript is now driving the unauthenticated agent. Binding to loopback does not help:
+# the connection really does originate from 127.0.0.1, out of the victim's own browser.
+#
+# The name the attacker rebinds is a name WE never serve under. So pin the Host to the
+# ones a user can actually reach this UI by - the loopback names - and the rebound
+# request fails on a header the attacker cannot forge without giving up the attack (the
+# browser sends the hostname the page was loaded from, by construction).
+#
+# This is why /ws is a local-only facility. A deployment that needs to serve the UI on a
+# real hostname must not proxy the agent at all (WS_PROXY_ENABLED=0); there is no Host it
+# could add here that would be safe, because the agent has no authentication of its own.
+map $http_host $ws_host_allowed {
+    default                            0;
+    "~*^localhost(:[0-9]+)?$"          1;
+    "~*^127\.0\.0\.1(:[0-9]+)?$"       1;
+    "~*^\[::1\](:[0-9]+)?$"            1;
+}
+
 server {
     # LISTEN_ADDR is 0.0.0.0 by default, which is what a bridge-networked container
     # needs for `-p 8080:8080` to reach it. Under HOST networking, though, 0.0.0.0
@@ -100,8 +126,9 @@ server {
     #
     # -------------------------------------------------------------------------
     # SECURITY. The agent's WebSocket is an UNAUTHENTICATED CONTROL PLANE: whoever
-    # can talk to it can drive the user's sessions. Proxying it therefore needs two
-    # independent controls, because neither is sufficient alone.
+    # can talk to it can drive the user's sessions. Proxying it therefore needs THREE
+    # independent controls, because no one of them is sufficient alone. Each defeats an
+    # attack the others do not even see.
     #
     # 1. WS_PROXY_ENABLED. WebSockets are exempt from the same-origin policy and
     #    carry no CORS preflight, and a non-browser client can forge any Origin it
@@ -118,14 +145,23 @@ server {
     #    and a wrong default here is a security hole, whereas a wrong default the other
     #    way is a visible 404.
     #
-    # 2. Same-origin Origin check. Even when the UI is bound to loopback, a browser
-    #    is a confused deputy: a malicious page the user visits can open a WebSocket
-    #    to http://localhost:8080/ws FROM the user's own machine, and the request
-    #    arrives from 127.0.0.1 looking entirely legitimate (this is cross-site
-    #    WebSocket hijacking). A network/IP-based control cannot see the difference;
-    #    the Origin header can. Browsers set it truthfully and cannot be made to lie,
-    #    which is exactly the case this defends. Requests with no Origin are refused
-    #    too - the UI is a browser and always sends one.
+    # 2. Loopback Host allowlist. Defeats DNS REBINDING, which the same-origin check
+    #    below is blind to: a rebound `evil.example` sends Host and Origin that MATCH
+    #    each other, so same-origin says yes while the request is entirely attacker-
+    #    controlled. Origin==Host proves same-SITE, not same-MACHINE. Pinning Host to
+    #    the loopback names is what proves the latter. See the $ws_host_allowed map.
+    #
+    # 3. Same-origin Origin check. Defeats cross-site WebSocket hijacking, which the
+    #    Host allowlist is blind to: a malicious page the user visits can open a socket
+    #    to http://localhost:8080/ws from the user's own machine - a perfectly
+    #    allowlisted Host - and the request arrives from 127.0.0.1 looking entirely
+    #    legitimate. A network/IP control cannot tell the difference; the Origin header
+    #    can, because a browser sets it truthfully and cannot be made to lie about it.
+    #    Requests with no Origin are refused too - the UI is a browser and always sends
+    #    one.
+    #
+    # (2) and (3) are a pair: each is exactly the case the other cannot see. Removing
+    # either re-opens a hole that the remaining check will happily wave through.
     # -------------------------------------------------------------------------
     location = /ws {
         # `location = /ws` is an EXACT match, deliberately. A prefix match would also
@@ -142,7 +178,12 @@ server {
             return 404;
         }
 
-        # Same-origin or nothing. See (2) above.
+        # (2) Loopback Host only. Blocks DNS rebinding - see the $ws_host_allowed map.
+        if ($ws_host_allowed = 0) {
+            return 403;
+        }
+
+        # (3) Same-origin or nothing. Blocks cross-site WebSocket hijacking.
         if ($ws_origin_host != $http_host) {
             return 403;
         }

--- a/docker/ui/nginx.conf.template
+++ b/docker/ui/nginx.conf.template
@@ -2,11 +2,13 @@
 # nginx config for the Citadel Workspace UI.
 #
 # Rendered at CONTAINER START by the nginx image's envsubst entrypoint
-# (/docker-entrypoint.d/20-envsubst-on-templates.sh), which substitutes
-# ${AGENT_UPSTREAM} and writes the result to /etc/nginx/conf.d/. Only that one
-# variable is substituted - NGINX_ENVSUBST_FILTER pins it - so nginx's own
-# runtime variables ($host, $uri, $http_upgrade, ...) survive untouched. Getting
-# that filter wrong would silently mangle the config, which is why it is set.
+# (/docker-entrypoint.d/20-envsubst-on-templates.sh), which writes the result to
+# /etc/nginx/conf.d/. Exactly three variables are substituted - ${AGENT_UPSTREAM},
+# ${WS_PROXY_ENABLED} and ${LISTEN_ADDR} - and NGINX_ENVSUBST_FILTER in the Dockerfile
+# pins the list to those, so nginx's OWN runtime variables ($host, $uri, $http_upgrade,
+# $connection_upgrade, ...) survive untouched. Without that filter envsubst would expand
+# them to empty strings, silently producing a config that drops the upgrade handshake
+# while still looking healthy - which is why the smoke test asserts the rendered output.
 #
 # This lives in a real file rather than a printf'd one-liner in the Dockerfile:
 # the config now has a proxy block with upgrade headers and timeouts, and
@@ -107,11 +109,14 @@ server {
     #    protect a publicly-reachable /ws - anyone on the internet would simply
     #    forge the header and drive the agent. The only sound control for a UI that
     #    is served publicly (e.g. behind the Cloudflare tunnel in
-    #    docker-compose.production.yml) is to not proxy the agent at all. This flag
-    #    is the switch, and any deployment whose UI is reachable off-box MUST set it
-    #    to 0. It defaults to 1 because the shipped topology - the local client in
-    #    docker-compose.local.yml - is the one where the proxy is both safe and
-    #    required.
+    #    docker-compose.production.yml) is to not proxy the agent at all.
+    #
+    #    So this FAILS CLOSED: the image defaults it to 0 and a deployment must opt
+    #    in. docker-compose.local.yml sets it to 1, because there the UI is bound to
+    #    loopback and the proxy is both safe and required; docker-compose.production.yml
+    #    leaves it off. An image cannot know which topology it has been dropped into,
+    #    and a wrong default here is a security hole, whereas a wrong default the other
+    #    way is a visible 404.
     #
     # 2. Same-origin Origin check. Even when the UI is bound to loopback, a browser
     #    is a confused deputy: a malicious page the user visits can open a WebSocket

--- a/docker/ui/nginx.conf.template
+++ b/docker/ui/nginx.conf.template
@@ -4,11 +4,15 @@
 # Rendered at CONTAINER START by the nginx image's envsubst entrypoint
 # (/docker-entrypoint.d/20-envsubst-on-templates.sh), which writes the result to
 # /etc/nginx/conf.d/. Exactly three variables are substituted - ${AGENT_UPSTREAM},
-# ${WS_PROXY_ENABLED} and ${LISTEN_ADDR} - and NGINX_ENVSUBST_FILTER in the Dockerfile
-# pins the list to those, so nginx's OWN runtime variables ($host, $uri, $http_upgrade,
-# $connection_upgrade, ...) survive untouched. Without that filter envsubst would expand
-# them to empty strings, silently producing a config that drops the upgrade handshake
-# while still looking healthy - which is why the smoke test asserts the rendered output.
+# ${WS_PROXY_ENABLED} and ${LISTEN_ADDR} - because NGINX_ENVSUBST_FILTER in the
+# Dockerfile pins the list to those names.
+#
+# That pinning is an INJECTION GUARD, not (as one might assume) protection against
+# envsubst blanking nginx's own `$host` / `$http_upgrade`: the entrypoint substitutes
+# only names that exist as environment variables, so those survive either way. What it
+# does prevent is a name COLLISION - unfiltered, an env var called `host` rewrites every
+# `$host` in this file. Verified: the unfiltered image run with `-e host=pwned` renders
+# `proxy_set_header Host pwned;`. The smoke test asserts this directly.
 #
 # This lives in a real file rather than a printf'd one-liner in the Dockerfile:
 # the config now has a proxy block with upgrade headers and timeouts, and

--- a/docker/ui/nginx.conf.template
+++ b/docker/ui/nginx.conf.template
@@ -29,6 +29,12 @@ map $http_upgrade $connection_upgrade {
 # terminated upstream (a Cloudflare tunnel), the browser sends `https://x` while
 # nginx sees `$scheme` = http, so a scheme comparison would reject every legitimate
 # request behind a TLS-terminating proxy.
+#
+# The capture deliberately takes everything after the scheme rather than parsing out
+# a strict host[:port]. Per RFC 6454 an Origin never carries userinfo, so there is
+# nothing to strip - and if something ever sent one anyway, the extra `user:pass@`
+# would make this value DIFFER from $http_host and the request would be refused.
+# The imprecision fails closed, which is the direction it has to fail in.
 map $http_origin $ws_origin_host {
     default "";
     "~^https?://(.+)$" $1;
@@ -53,11 +59,18 @@ map $http_origin $ws_origin_host {
 # This is why /ws is a local-only facility. A deployment that needs to serve the UI on a
 # real hostname must not proxy the agent at all (WS_PROXY_ENABLED=0); there is no Host it
 # could add here that would be safe, because the agent has no authentication of its own.
+# `0.0.0.0` is included because LISTEN_ADDR defaults to it, so an operator who reads
+# the bind address off `docker ps` and browses to http://0.0.0.0:8080 would otherwise
+# get a bare 403 from a UI that looks fine. It costs nothing: 0.0.0.0 is a literal
+# address, not a name, so it cannot be DNS-rebound, and a page served from anywhere
+# else still fails the Origin check below. Anything genuinely remote - a LAN address,
+# a real hostname - stays refused, which is the point.
 map $http_host $ws_host_allowed {
     default                            0;
     "~*^localhost(:[0-9]+)?$"          1;
     "~*^127\.0\.0\.1(:[0-9]+)?$"       1;
     "~*^\[::1\](:[0-9]+)?$"            1;
+    "~*^0\.0\.0\.0(:[0-9]+)?$"         1;
 }
 
 server {

--- a/docker/ui/nginx.conf.template
+++ b/docker/ui/nginx.conf.template
@@ -34,6 +34,14 @@ map $http_upgrade $connection_upgrade {
 # nginx sees `$scheme` = http, so a scheme comparison would reject every legitimate
 # request behind a TLS-terminating proxy.
 #
+# NOTE for anyone debugging an unexplained 403: this compares Origin's host to the
+# Host header, so the two must agree about the PORT. They do for every supported
+# topology, because /ws is loopback-only and reached on an explicit port. But if you
+# ever front this with a TLS terminator serving on the default 443 while rewriting
+# Host to include an internal port, the browser omits :443 from Origin (RFC 6454) and
+# every request 403s. That configuration is out of scope by design - a publicly served
+# UI must set WS_PROXY_ENABLED=0 - but the symptom is opaque enough to be worth naming.
+#
 # The capture deliberately takes everything after the scheme rather than parsing out
 # a strict host[:port]. Per RFC 6454 an Origin never carries userinfo, so there is
 # nothing to strip - and if something ever sent one anyway, the extra `user:pass@`

--- a/docker/ui/nginx.conf.template
+++ b/docker/ui/nginx.conf.template
@@ -186,8 +186,20 @@ server {
         # add_header here would REPLACE the inherited set, so the error pages would silently
         # ship with no CSP. That is exactly why /assets/ and .wasm below must repeat all of
         # them (they add Cache-Control, which breaks their inheritance).
+        # Opt-IN, not opt-out: anything that is not exactly "1" disables the proxy.
+        #
+        # The obvious spelling of this test - `if ($ws_proxy_enabled = "0")` - fails OPEN
+        # for every value except "0", which is the wrong direction for a switch guarding
+        # an unauthenticated control plane. An operator writing the intuitive
+        # `WS_PROXY_ENABLED=false` (or `off`, or `no`, or an empty value from a compose
+        # line like `WS_PROXY_ENABLED=`) would have been silently ENABLING it while
+        # believing they had turned it off. Verified: each of those values proxied.
+        #
+        # Requiring the literal "1" means every typo, every empty value and every
+        # not-yet-invented spelling of "off" lands on 404. The only way to expose the
+        # agent is to say so exactly.
         set $ws_proxy_enabled "${WS_PROXY_ENABLED}";
-        if ($ws_proxy_enabled = "0") {
+        if ($ws_proxy_enabled != "1") {
             return 404;
         }
 

--- a/scripts/smoke-ui-ws.sh
+++ b/scripts/smoke-ui-ws.sh
@@ -176,4 +176,28 @@ echo "$rendered" | grep -q 'proxy_set_header Upgrade \$http_upgrade' \
   || fail "an environment variable named 'http_upgrade' rewrote \$http_upgrade in the rendered config - NGINX_ENVSUBST_FILTER is not pinning substitution."
 echo "  envsubst: pinned - colliding env vars (host, http_upgrade) cannot rewrite nginx's own variables."
 
+# ---------------------------------------------------------------------------
+# 4. Runtime variables cannot inject nginx configuration.
+# ---------------------------------------------------------------------------
+# These values are substituted into the config VERBATIM, so a `;` closes the directive and
+# everything after it becomes real configuration. Before validation was added, AGENT_UPSTREAM=
+# '127.0.0.1:12345/; return 200 "X"; #' rendered a working config and nginx STARTED on it. The
+# entrypoint validator must now refuse to start instead.
+for bad_var in "AGENT_UPSTREAM=127.0.0.1:12345/; return 200 \"X\"; #" \
+               "WS_PROXY_ENABLED=1\"; return 200 \"X\"; #" \
+               "LISTEN_ADDR=0.0.0.0; return 200 \"X\"; #"; do
+  vc="smoke-ui-inject"
+  docker rm -f "$vc" >/dev/null 2>&1 || true
+  docker run -d --name "$vc" -e WS_PROXY_ENABLED=1 -e AGENT_UPSTREAM=127.0.0.1:12345 \
+    -e "$bad_var" "$IMAGE" >/dev/null 2>&1 || true
+  sleep 3
+  state=$(docker inspect -f '{{.State.Status}}' "$vc" 2>/dev/null || echo missing)
+  logs=$(docker logs "$vc" 2>&1 | grep -c "validate-runtime-vars.*FATAL" || true)
+  docker rm -f "$vc" >/dev/null 2>&1 || true
+  if [ "$state" = "running" ] || [ "$logs" = "0" ]; then
+    fail "the image STARTED with an injecting runtime variable (${bad_var%%=*}), or did not report why it refused. That value is substituted straight into the nginx config, so it can add arbitrary directives."
+  fi
+done
+echo "  injection: runtime variables containing nginx metacharacters are rejected at startup."
+
 echo "== all /ws smoke assertions passed =="

--- a/scripts/smoke-ui-ws.sh
+++ b/scripts/smoke-ui-ws.sh
@@ -27,36 +27,41 @@ PORT="${2:-18080}"
 BASE="http://127.0.0.1:${PORT}"
 CTR="smoke-ui-ws-$$"
 
-# Remove the container AND wait for the published port to actually come free. `docker rm -f`
-# returns once the container is gone, but the daemon's port binding can outlive it briefly - and
-# this script cycles seven containers over the same port, so a race there would surface as a
-# spurious "port is already allocated" failure in a SECURITY gate. A flaky gate is worse than a
-# missing one: it trains people to re-run until green.
-cleanup() {
-  docker rm -f "$CTR" >/dev/null 2>&1 || true
-  local i
-  for i in $(seq 1 30); do
-    # Nothing listening on the host port means the binding is released.
-    (exec 3<>"/dev/tcp/127.0.0.1/${PORT}") 2>/dev/null || return 0
-    exec 3<&- 2>/dev/null || true
-    sleep 0.2
-  done
-  echo "warning: port ${PORT} still bound after container removal; continuing anyway" >&2
-}
+cleanup() { docker rm -f "$CTR" >/dev/null 2>&1 || true; }
 trap cleanup EXIT
 
 fail() { echo "::error::$*"; exit 1; }
 
 # Start the image with a given WS_PROXY_ENABLED value ("__unset__" passes no env at all),
 # published on LOOPBACK - /ws requires a loopback Host, exactly as a real browser provides.
+#
+# `docker run` is RETRIED rather than the port being probed first. This script cycles seven
+# containers over the same published port, and `docker rm -f` returns once the container is gone
+# while the daemon's port binding can briefly outlive it - so a naive run can lose the race with
+# "port is already allocated". Probing the port to predict that is the wrong shape: every probe is
+# itself a TCP connection to whatever still holds the socket, and a probe that succeeds tells you
+# nothing about whether the NEXT bind will. Retrying the actual operation tests the actual
+# precondition, and costs nothing when it succeeds first time (the common case).
+#
+# It matters because this is a SECURITY gate: one that fails at random trains people to re-run
+# until green, and the next real regression gets waved through the same way.
 start() {
   local val="$1"
   cleanup
-  if [ "$val" = "__unset__" ]; then
-    docker run -d --name "$CTR" -p "127.0.0.1:${PORT}:8080" "$IMAGE" >/dev/null
-  else
-    docker run -d --name "$CTR" -e WS_PROXY_ENABLED="$val" -p "127.0.0.1:${PORT}:8080" "$IMAGE" >/dev/null
-  fi
+  local args=(-d --name "$CTR" -p "127.0.0.1:${PORT}:8080")
+  [ "$val" = "__unset__" ] || args+=(-e "WS_PROXY_ENABLED=$val")
+  local attempt run_err
+  for attempt in 1 2 3 4 5; do
+    if run_err=$(docker run "${args[@]}" "$IMAGE" 2>&1 >/dev/null); then
+      break
+    fi
+    if [ "$attempt" -eq 5 ]; then
+      fail "could not start the smoke container after 5 attempts: $run_err"
+    fi
+    # Almost always the previous container's port binding has not been released yet.
+    docker rm -f "$CTR" >/dev/null 2>&1 || true
+    sleep 1
+  done
   local i
   for i in $(seq 1 30); do
     curl -sf -o /dev/null "$BASE/" 2>/dev/null && return 0

--- a/scripts/smoke-ui-ws.sh
+++ b/scripts/smoke-ui-ws.sh
@@ -147,7 +147,11 @@ echo "  enabled: SPA served; envsubst intact; same-origin enforced (403 cross-or
 # ---------------------------------------------------------------------------
 # Tested with the values an operator would plausibly reach for to turn it OFF. The obvious
 # spelling of the guard (`= "0"`) fails OPEN for every one of these.
-for val in "__unset__" "" "0" "false" "off" "no"; do
+# Includes TRUTHY-looking values (on/yes/true). They must still DISABLE the proxy: the switch is
+# an explicit opt-in on the literal "1", so anything else fails closed. Pinning the truthy ones
+# matters more than the falsy ones - someone writing `true` expects it enabled, and this asserts
+# they instead get a safe 404 rather than a silently exposed agent.
+for val in "__unset__" "" "0" "false" "off" "no" "on" "yes" "true"; do
   start "$val"
   got="$(code /ws "$BASE")"
   [ "$got" = "404" ] \
@@ -156,7 +160,7 @@ for val in "__unset__" "" "0" "false" "off" "no"; do
     || fail "with the proxy disabled the SPA stopped serving; disabling /ws must not break the app."
 done
 
-echo "  opt-in: only the literal WS_PROXY_ENABLED=1 enables the proxy; unset, '', 0, false, off and no all disable it while still serving the SPA."
+echo "  opt-in: only the literal WS_PROXY_ENABLED=1 enables the proxy; unset, '', 0, false, off, no, on, yes and true all disable it while still serving the SPA."
 
 # ---------------------------------------------------------------------------
 # 3. envsubst is pinned to our three variables (NGINX_ENVSUBST_FILTER).

--- a/scripts/smoke-ui-ws.sh
+++ b/scripts/smoke-ui-ws.sh
@@ -1,0 +1,151 @@
+#!/usr/bin/env bash
+#
+# Smoke-test the UI image's /ws agent proxy and its security controls.
+#
+# WHY THIS IS A SCRIPT AND NOT INLINE YAML
+#
+# These assertions guard an UNAUTHENTICATED control plane: whatever reaches the agent's
+# WebSocket can drive a user's sessions. They therefore have to run on the pull request
+# that could break them, not only on the publish pipeline that runs after the merge
+# decision has already been made. Living in one file means validate.yml (PR gate) and
+# publish-images.yml (release gate) assert exactly the same things, and neither can
+# quietly drift into testing less than the other.
+#
+# This is not hypothetical. The switch below was once written `if ($flag = "0")`, which
+# fails OPEN for every value except the literal "0" - so `WS_PROXY_ENABLED=false` exposed
+# the agent while reading as if it disabled it. Nothing in the PR gate would have caught
+# that.
+#
+# Usage:  scripts/smoke-ui-ws.sh <image-ref> [host-port]
+#
+# Requires: docker, curl. Exits non-zero on the first failed assertion.
+
+set -euo pipefail
+
+IMAGE="${1:?usage: smoke-ui-ws.sh <image-ref> [host-port]}"
+PORT="${2:-18080}"
+BASE="http://127.0.0.1:${PORT}"
+CTR="smoke-ui-ws-$$"
+
+cleanup() { docker rm -f "$CTR" >/dev/null 2>&1 || true; }
+trap cleanup EXIT
+
+fail() { echo "::error::$*"; exit 1; }
+
+# Start the image with a given WS_PROXY_ENABLED value ("__unset__" passes no env at all),
+# published on LOOPBACK - /ws requires a loopback Host, exactly as a real browser provides.
+start() {
+  local val="$1"
+  cleanup
+  if [ "$val" = "__unset__" ]; then
+    docker run -d --name "$CTR" -p "127.0.0.1:${PORT}:8080" "$IMAGE" >/dev/null
+  else
+    docker run -d --name "$CTR" -e WS_PROXY_ENABLED="$val" -p "127.0.0.1:${PORT}:8080" "$IMAGE" >/dev/null
+  fi
+  local i
+  for i in $(seq 1 30); do
+    curl -sf -o /dev/null "$BASE/" 2>/dev/null && return 0
+    sleep 1
+  done
+  # A container that never started would make every assertion below trivially "pass" as a
+  # connection error, so treat not-ready as a hard failure and show why.
+  docker logs "$CTR" 2>&1 | tail -30
+  fail "the UI container never became ready; the assertions would be meaningless."
+}
+
+# Status code for a request, with optional Host and Origin overrides.
+code() { # <path> [origin] [host]
+  local path="$1" origin="${2:-}" host="${3:-}"
+  local args=(-s -o /dev/null -w '%{http_code}')
+  [ -n "$origin" ] && args+=(-H "Origin: $origin")
+  [ -n "$host" ] && args+=(-H "Host: $host")
+  curl "${args[@]}" "$BASE$path"
+}
+
+echo "== UI /ws smoke test: $IMAGE =="
+
+# ---------------------------------------------------------------------------
+# 1. The proxy ENABLED. Everything below is the deployed local-client posture.
+# ---------------------------------------------------------------------------
+start 1
+
+curl -sf "$BASE/" | grep -q '<div id="root"' \
+  || fail "the UI did not serve the SPA shell. nginx binds even when it serves nothing, so this is the real liveness check."
+
+# The render must contain the proxy and keep nginx's own variables. This catches a
+# grossly broken template or a bad substitution; it does NOT by itself prove the envsubst
+# filter is in place (see the collision check further down, which does).
+docker exec "$CTR" grep -q 'location = /ws' /etc/nginx/conf.d/default.conf \
+  || { docker exec "$CTR" cat /etc/nginx/conf.d/default.conf; fail "'location = /ws' is missing from the rendered config."; }
+docker exec "$CTR" grep -q 'proxy_set_header Upgrade \$http_upgrade' /etc/nginx/conf.d/default.conf \
+  || { docker exec "$CTR" cat /etc/nginx/conf.d/default.conf; fail "the rendered config lost \$http_upgrade - the websocket upgrade would be silently dropped."; }
+
+# Same-origin. A page on another origin must not drive the agent through the user's browser
+# (cross-site WebSocket hijacking), and neither must a client that sends no Origin at all.
+[ "$(code /ws 'http://evil.example')" = "403" ] \
+  || fail "/ws accepted a CROSS-ORIGIN request; expected 403. This is a cross-site WebSocket hijacking hole."
+[ "$(code /ws)" = "403" ] \
+  || fail "/ws accepted a request with NO Origin; expected 403."
+
+# DNS rebinding: Host and Origin MATCH each other, so the same-origin check alone says yes.
+# Only the loopback Host allowlist catches this.
+[ "$(code /ws 'http://evil.example:8080' 'evil.example:8080')" = "403" ] \
+  || fail "/ws accepted a DNS-REBINDING handshake (Host=Origin=evil.example); expected 403."
+
+# The allowlist contains an IP literal (0.0.0.0), so prove it did not become "any IP".
+[ "$(code /ws 'http://192.168.1.50:8080' '192.168.1.50:8080')" = "403" ] \
+  || fail "/ws accepted a LAN Host; expected 403. Serving /ws to the local network hands the agent to every machine on it."
+
+# ...and it must still ACCEPT its own origin, or the gate is uselessly strict and the app can
+# never connect. No agent runs here, so 502 is the proof the request passed every gate and
+# nginx went looking for the upstream.
+[ "$(code /ws "$BASE")" = "502" ] \
+  || fail "/ws refused a SAME-ORIGIN request (got $(code /ws "$BASE"), expected 502 = gates passed, no agent present). A 403 here means the app could never connect."
+
+# Exact-match location: a prefix match would forward /wsfoo to the agent too.
+[ "$(code /wsfoo "$BASE")" = "200" ] \
+  || fail "/wsfoo was not served by the SPA - the /ws location is matching as a prefix."
+
+# Error pages must still carry the CSP. This holds only because the /ws block declares no
+# add_header of its own and so inherits the server-level set; adding one there silently
+# replaces them all.
+curl -s -D - -o /dev/null -H "Origin: http://evil.example" "$BASE/ws" | grep -qi '^content-security-policy' \
+  || fail "/ws error responses lost the Content-Security-Policy header."
+
+echo "  enabled: SPA served; envsubst intact; same-origin enforced (403 cross-origin, 403 no-Origin, 403 rebinding, 403 LAN); same-origin proxied; no prefix match; CSP preserved."
+
+# ---------------------------------------------------------------------------
+# 2. The switch is OPT-IN. Only the literal "1" may enable the proxy.
+# ---------------------------------------------------------------------------
+# Tested with the values an operator would plausibly reach for to turn it OFF. The obvious
+# spelling of the guard (`= "0"`) fails OPEN for every one of these.
+for val in "__unset__" "" "0" "false" "off" "no"; do
+  start "$val"
+  got="$(code /ws "$BASE")"
+  [ "$got" = "404" ] \
+    || fail "WS_PROXY_ENABLED='${val/__unset__/<unset>}' left /ws ENABLED (got $got, want 404). The switch must be opt-in: anything but the literal 1 has to disable the proxy, or an operator turning it 'off' would expose the agent."
+  [ "$(code /)" = "200" ] \
+    || fail "with the proxy disabled the SPA stopped serving; disabling /ws must not break the app."
+done
+
+echo "  opt-in: only the literal WS_PROXY_ENABLED=1 enables the proxy; unset, '', 0, false, off and no all disable it while still serving the SPA."
+
+# ---------------------------------------------------------------------------
+# 3. envsubst is pinned to our three variables (NGINX_ENVSUBST_FILTER).
+# ---------------------------------------------------------------------------
+# Unfiltered, envsubst is eligible to replace EVERY environment variable - so an env var
+# whose name collides with an nginx variable rewrites the config. Start the image with a
+# colliding `host` and assert `$host` survives. Without the filter this renders
+# `proxy_set_header Host pwned;`, which is config injection by whoever can set env vars.
+cleanup
+docker run -d --name "$CTR" -e WS_PROXY_ENABLED=1 -e host=pwned -e http_upgrade=pwned \
+  -p "127.0.0.1:${PORT}:8080" "$IMAGE" >/dev/null
+for i in $(seq 1 30); do curl -sf -o /dev/null "$BASE/" 2>/dev/null && break; sleep 1; done
+rendered=$(docker exec "$CTR" cat /etc/nginx/conf.d/default.conf)
+echo "$rendered" | grep -q 'proxy_set_header Host \$host' \
+  || fail "an environment variable named 'host' rewrote \$host in the rendered config - NGINX_ENVSUBST_FILTER is not pinning substitution, so env vars can inject into the proxy config."
+echo "$rendered" | grep -q 'proxy_set_header Upgrade \$http_upgrade' \
+  || fail "an environment variable named 'http_upgrade' rewrote \$http_upgrade in the rendered config - NGINX_ENVSUBST_FILTER is not pinning substitution."
+echo "  envsubst: pinned - colliding env vars (host, http_upgrade) cannot rewrite nginx's own variables."
+
+echo "== all /ws smoke assertions passed =="

--- a/scripts/smoke-ui-ws.sh
+++ b/scripts/smoke-ui-ws.sh
@@ -116,6 +116,14 @@ docker exec "$CTR" grep -q 'proxy_set_header Upgrade \$http_upgrade' /etc/nginx/
 [ "$(code /ws 'http://192.168.1.50:8080' '192.168.1.50:8080')" = "403" ] \
   || fail "/ws accepted a LAN Host; expected 403. Serving /ws to the local network hands the agent to every machine on it."
 
+# BOTH checks failing at once. nginx evaluates the `if` blocks in this location sequentially and
+# `return` inside one terminates immediately - but that is implicit rewrite-module behaviour, and
+# "if is evil" precisely because its interactions are easy to get wrong. Pin it: a request that
+# fails the Host allowlist AND the Origin check must be refused, not fall through to proxy_pass.
+# A 502 here would mean it reached the agent despite failing two independent gates.
+[ "$(code /ws 'http://other.example' 'evil.example:8080')" = "403" ] \
+  || fail "/ws returned $(code /ws 'http://other.example' 'evil.example:8080') for a request failing BOTH the Host and Origin checks; expected 403. Anything else means the if-chain let it through to the agent."
+
 # ...and it must still ACCEPT its own origin, or the gate is uselessly strict and the app can
 # never connect. No agent runs here, so 502 is the proof the request passed every gate and
 # nginx went looking for the upstream.
@@ -132,7 +140,7 @@ docker exec "$CTR" grep -q 'proxy_set_header Upgrade \$http_upgrade' /etc/nginx/
 curl -s -D - -o /dev/null -H "Origin: http://evil.example" "$BASE/ws" | grep -qi '^content-security-policy' \
   || fail "/ws error responses lost the Content-Security-Policy header."
 
-echo "  enabled: SPA served; envsubst intact; same-origin enforced (403 cross-origin, 403 no-Origin, 403 rebinding, 403 LAN); same-origin proxied; no prefix match; CSP preserved."
+echo "  enabled: SPA served; envsubst intact; same-origin enforced (403 cross-origin, 403 no-Origin, 403 rebinding, 403 LAN, 403 both-fail); same-origin proxied; no prefix match; CSP preserved."
 
 # ---------------------------------------------------------------------------
 # 2. The switch is OPT-IN. Only the literal "1" may enable the proxy.

--- a/scripts/smoke-ui-ws.sh
+++ b/scripts/smoke-ui-ws.sh
@@ -63,7 +63,7 @@ start() {
     sleep 1
   done
   local i
-  for i in $(seq 1 30); do
+  for ((i = 1; i <= 30; i++)); do
     curl -sf -o /dev/null "$BASE/" 2>/dev/null && return 0
     sleep 1
   done
@@ -168,7 +168,7 @@ echo "  opt-in: only the literal WS_PROXY_ENABLED=1 enables the proxy; unset, ''
 cleanup
 docker run -d --name "$CTR" -e WS_PROXY_ENABLED=1 -e host=pwned -e http_upgrade=pwned \
   -p "127.0.0.1:${PORT}:8080" "$IMAGE" >/dev/null
-for i in $(seq 1 30); do curl -sf -o /dev/null "$BASE/" 2>/dev/null && break; sleep 1; done
+for ((i = 1; i <= 30; i++)); do curl -sf -o /dev/null "$BASE/" 2>/dev/null && break; sleep 1; done
 rendered=$(docker exec "$CTR" cat /etc/nginx/conf.d/default.conf)
 echo "$rendered" | grep -q 'proxy_set_header Host \$host' \
   || fail "an environment variable named 'host' rewrote \$host in the rendered config - NGINX_ENVSUBST_FILTER is not pinning substitution, so env vars can inject into the proxy config."

--- a/scripts/smoke-ui-ws.sh
+++ b/scripts/smoke-ui-ws.sh
@@ -27,7 +27,22 @@ PORT="${2:-18080}"
 BASE="http://127.0.0.1:${PORT}"
 CTR="smoke-ui-ws-$$"
 
-cleanup() { docker rm -f "$CTR" >/dev/null 2>&1 || true; }
+# Remove the container AND wait for the published port to actually come free. `docker rm -f`
+# returns once the container is gone, but the daemon's port binding can outlive it briefly - and
+# this script cycles seven containers over the same port, so a race there would surface as a
+# spurious "port is already allocated" failure in a SECURITY gate. A flaky gate is worse than a
+# missing one: it trains people to re-run until green.
+cleanup() {
+  docker rm -f "$CTR" >/dev/null 2>&1 || true
+  local i
+  for i in $(seq 1 30); do
+    # Nothing listening on the host port means the binding is released.
+    (exec 3<>"/dev/tcp/127.0.0.1/${PORT}") 2>/dev/null || return 0
+    exec 3<&- 2>/dev/null || true
+    sleep 0.2
+  done
+  echo "warning: port ${PORT} still bound after container removal; continuing anyway" >&2
+}
 trap cleanup EXIT
 
 fail() { echo "::error::$*"; exit 1; }


### PR DESCRIPTION
> **Blocked on Avarok-Cybersecurity/citadel-workspace-ui#14.** The submodule pointer here currently references that PR's branch commit. It must be re-pointed at the merged `master` commit of the UI repo before this merges — submodule before parent, per CLAUDE.md.

## Problem

The shipped UI cannot reach a local agent. At all.

The browser's only route to the Citadel agent is a WebSocket, and the app pointed it at `ws://localhost:12345`. But the production nginx CSP is `connect-src 'self'`, and a page served on `:8080` opening a socket on `:12345` is a **different origin** — so the browser blocks it. The bundled `VITE_WS_URL` also freezes the target **at build time**, which means one image per environment and nothing that can be distributed from a registry.

The result: `deploy.sh` had to build the UI on the production host, the published-image pipeline had to skip `ui` entirely, and there was no way to hand a coworker a UI that could talk to their own agent.

## Fix

The app now derives a **same-origin `/ws`** URL from `window.location` (companion PR), and nginx proxies `/ws` to the agent. Same-origin means `connect-src 'self'` covers it, so the strict CSP stays strict — no `ws:`/`wss:` wildcard, which would have let an XSS payload exfiltrate to any host.

**The agent's address is a runtime setting, not a build-time one.** `AGENT_UPSTREAM` (default `127.0.0.1:12345`) is substituted into the nginx config at container start, so **one published image serves every topology**:

| Topology | `AGENT_UPSTREAM` |
|---|---|
| agent container, host networking (and the dev stack) | `127.0.0.1:12345` |
| agent container, bridge network | `internal-service:12345` |
| agent running **natively** on the user's machine | `host.docker.internal:12345` |

That last row matters: it means the eventual native-agent/desktop path needs no new image.

## Changes

- **`docker/ui/nginx.conf.template`** — the nginx config moves out of the Dockerfile's escaped `printf` one-liner into a real file. It now has a proxy block with upgrade headers and timeouts; maintaining that as `\n\` continuations was untenable (the Dockerfile's own comments said as much).
- **`docker/ui/Dockerfile`** — renders the template at start-up via the nginx image's envsubst entrypoint. `NGINX_ENVSUBST_FILTER=^AGENT_UPSTREAM$` is **load-bearing**: without it envsubst would also expand nginx's own `$host` / `$http_upgrade` / `$connection_upgrade` into empty strings, silently producing a config that proxies nothing and drops the upgrade handshake.
- **`publish-images.yml`** — `ui` joins the matrix (with the WASM-artifact step it needs) and the `latest` promotion. Its smoke test asserts more than "the port is bound", since nginx binds even when serving nothing: it checks the SPA shell is served **and** that `location /ws` survived into the rendered config.
- **`docker-compose.production.yml` / `deploy.sh`** — the ui is pulled like everything else. **The production host now builds nothing at all.** The ui is also added to the revision-consistency gate: it ships from the same commit, so a partially-completed `latest` promotion could otherwise pair a new backend with an old UI — precisely the mixed-version deploy that gate exists to prevent.
- **`docker-compose.local.yml`** — new. Agent + UI, both pulled prebuilt (~300 MB), for people *using* the workspace. No Rust toolchain, no Node, no build.

## Verification

The proxy was tested end-to-end against the **real agent image**, not a mock:

```
envsubst rendered:  proxy_pass http://wsagent:12345/;      ← upstream substituted
                    proxy_set_header Upgrade $http_upgrade; ← nginx vars survived the filter
GET  /              → HTTP 200, SPA shell
HEAD /              → strict CSP present
GET  /ws  (upgrade) → HTTP/1.1 101 Switching Protocols     ← proxied to the real agent
```

Also validated: both compose files and both workflows parse; `deploy.sh` parses; the revision gate correctly accepts three matching images and refuses a mismatched third.

## Networking, stated accurately

The agent hole-punches to reach other agents directly. That is an **optimisation, not a requirement**: when the hole punch fails, Citadel **relays peer traffic through the workspace server** — `check_proxy()` in `citadel_proto` forwards any packet whose `target_cid` is not the session's, zero-copy and **without decrypting it** (peers encrypt end-to-end with their own endpoint ratchet, so the server only ever sees ciphertext). The SDK logs *"Will fallback to TCP only mode"*, disables UDP, and still hands the app a working peer channel.

So on **macOS/Windows**, where Docker's VM adds a NAT layer, direct P2P is less likely to succeed and DMs/file transfer are **more likely to be server-relayed. They do not break.** The cost is latency and server bandwidth — worth knowing for the box's capacity, since relayed file transfers flow through it.

`network_mode: host` is what makes the direct path possible where it can work. If someone wants the direct path on macOS/Windows, they run the agent natively and set `AGENT_UPSTREAM=host.docker.internal:12345` — **this image already supports that with no rebuild**, which is the reason the upstream is a runtime setting.

Containerising the agent is not new here: `docker/internal-service/Dockerfile` has existed since April 2025 and the dev, CI, and production stacks all run the agent in Docker with host networking.
