### PR TITLE
fix(deploy): guard restarts on the services the compose file declares

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -424,6 +424,68 @@ jobs:
           fi
           echo "PASS: mismatched images are refused."
 
+      - name: Deploy service selection covers every compose shape
+        # This selection decides what is pulled, revision-checked AND restarted. Both error
+        # directions are deployment-critical: too few silently skips a declared service while
+        # still reporting success, too many runs `up -d` on an image that was never pulled.
+        # docker-compose.production.yml documents that ui and internal-service are droppable,
+        # so the slimmed shapes are supported configurations, not hypotheticals.
+        run: |
+          set -euo pipefail
+          # Build fixtures from the real production compose so this tracks the actual file.
+          # Dangling depends_on entries must be stripped or compose rejects the project.
+          python3 - <<'PYEOF'
+          import yaml, pathlib
+          base = yaml.safe_load(open('docker-compose.production.yml'))
+          shapes = {'full':['server','internal-service','ui'], 'server-only':['server'],
+                    'server-ui':['server','ui'], 'server-is':['server','internal-service'],
+                    'no-server':['ui']}
+          for name, keep in shapes.items():
+              d = yaml.safe_load(yaml.safe_dump(base))
+              for svc in list(d['services']):
+                  if svc not in keep: d['services'].pop(svc)
+              for svc, cfg in d['services'].items():
+                  dep = cfg.get('depends_on')
+                  if isinstance(dep, dict):
+                      kept = {k: v for k, v in dep.items() if k in keep}
+                      cfg['depends_on'] = kept
+                      if not kept: cfg.pop('depends_on')
+                  elif isinstance(dep, list):
+                      kept = [x for x in dep if x in keep]
+                      cfg['depends_on'] = kept
+                      if not kept: cfg.pop('depends_on')
+              pathlib.Path(f'/tmp/fx-{name}.yml').write_text(yaml.safe_dump(d))
+          PYEOF
+
+          check() {  # <fixture> <expected space-separated services>
+            local got
+            got=$(./scripts/select-deploy-services.sh "/tmp/fx-$1.yml" | tr '\n' ' ' | sed 's/ $//')
+            if [ "$got" != "$2" ]; then
+              echo "::error::selection for '$1' was [$got], expected [$2]. A wrong set here means a half-applied deploy."
+              exit 1
+            fi
+            echo "  $1 -> $got"
+          }
+          check full        "server internal-service ui"
+          check server-only "server"
+          check server-ui   "server ui"
+          check server-is   "server internal-service"
+
+          # A compose file with no server must ABORT, not return an empty set - "nothing to
+          # deploy" reported as a successful no-op deploy is the worst possible outcome.
+          if ./scripts/select-deploy-services.sh /tmp/fx-no-server.yml >/dev/null 2>&1; then
+            echo "::error::a compose file with no 'server' service was accepted; it must abort."
+            exit 1
+          fi
+          echo "  no-server -> correctly aborts"
+
+          # An unreadable file must fail loudly rather than yield an empty selection.
+          if ./scripts/select-deploy-services.sh /tmp/definitely-absent.yml >/dev/null 2>&1; then
+            echo "::error::a missing compose file was accepted; it must abort."
+            exit 1
+          fi
+          echo "  missing file -> correctly aborts"
+
       - name: THREE images are all checked, not just the first two
         # deploy.sh now passes three images (server, internal-service, ui). The script iterates
         # over "$@", so this works - but nothing pinned it, and the failure mode of a hardcoded

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -424,6 +424,28 @@ jobs:
           fi
           echo "PASS: mismatched images are refused."
 
+      - name: A SINGLE image is still inspected
+        # A server-only deployment passes exactly ONE image, so this is a supported production
+        # shape rather than a degenerate call - and it must still be inspected. "Nothing to
+        # compare against" removes the cross-image check, not the provenance check.
+        #
+        # The failure direction is the load-bearing one. An `if [ "$#" -eq 1 ]; then exit 0`
+        # fast path looks harmless and passes both success cases below, but it returns before
+        # `docker image inspect` runs - so a server-only deploy whose pull silently failed, or
+        # whose tag does not exist, would sail through the gate built to catch precisely that.
+        # The end-to-end test cannot see this: its docker stub always inspects successfully.
+        run: |
+          set -euo pipefail
+          ./scripts/verify-image-revisions.sh rev-a
+          echo "PASS: a single labelled image deploys."
+          ./scripts/verify-image-revisions.sh rev-none
+          echo "PASS: a single unlabelled image warns but does not block."
+          if ./scripts/verify-image-revisions.sh definitely-not-pulled:latest 2>/dev/null; then
+            echo "::error::The gate allowed a single image it could not inspect. A server-only deploy whose pull never completed would restart production on a stale or missing image."
+            exit 1
+          fi
+          echo "PASS: a single un-inspectable image is refused."
+
       - name: Deploy restart guards - run deploy.sh end to end
         # The selector test below proves the LIST is right. This proves deploy.sh ACTS on it:
         # it runs the real script against fixture compose files with a recording `docker` stub on

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -468,6 +468,13 @@ jobs:
           # PyYAML is declared rather than inherited from the runner image: a runner change would
           # otherwise turn this deterministic gate into an opaque ModuleNotFoundError.
           python3 -c 'import yaml' 2>/dev/null || pip install --quiet pyyaml
+          # Fixtures are written into the CHECKOUT, not /tmp. `docker compose -f <file>` takes the
+          # file's directory as the project directory, so a fixture in /tmp resolves `env_file:`
+          # paths and ${VAR} references against /tmp instead of the repo root - the test could then
+          # fail, or silently resolve a variable to empty, for reasons having nothing to do with
+          # service selection, and it would not match how deploy.sh invokes the same command.
+          trap 'rm -f fx-*.yml' EXIT
+
           # Build fixtures from the real production compose so this tracks the actual file.
           # Dangling depends_on entries must be stripped or compose rejects the project.
           python3 - <<'PYEOF'
@@ -490,12 +497,12 @@ jobs:
                       kept = [x for x in dep if x in keep]
                       cfg['depends_on'] = kept
                       if not kept: cfg.pop('depends_on')
-              pathlib.Path(f'/tmp/fx-{name}.yml').write_text(yaml.safe_dump(d))
+              pathlib.Path(f'fx-{name}.yml').write_text(yaml.safe_dump(d))
           PYEOF
 
           check() {  # <fixture> <expected space-separated services>
             local got
-            got=$(./scripts/select-deploy-services.sh "/tmp/fx-$1.yml" | tr '\n' ' ' | sed 's/ $//')
+            got=$(./scripts/select-deploy-services.sh "fx-$1.yml" | tr '\n' ' ' | sed 's/ $//')
             if [ "$got" != "$2" ]; then
               echo "::error::selection for '$1' was [$got], expected [$2]. A wrong set here means a half-applied deploy."
               exit 1
@@ -509,18 +516,49 @@ jobs:
 
           # A compose file with no server must ABORT, not return an empty set - "nothing to
           # deploy" reported as a successful no-op deploy is the worst possible outcome.
-          if ./scripts/select-deploy-services.sh /tmp/fx-no-server.yml >/dev/null 2>&1; then
+          if ./scripts/select-deploy-services.sh fx-no-server.yml >/dev/null 2>&1; then
             echo "::error::a compose file with no 'server' service was accepted; it must abort."
             exit 1
           fi
           echo "  no-server -> correctly aborts"
 
           # An unreadable file must fail loudly rather than yield an empty selection.
-          if ./scripts/select-deploy-services.sh /tmp/definitely-absent.yml >/dev/null 2>&1; then
+          if ./scripts/select-deploy-services.sh fx-definitely-absent.yml >/dev/null 2>&1; then
             echo "::error::a missing compose file was accepted; it must abort."
             exit 1
           fi
           echo "  missing file -> correctly aborts"
+
+          # DRIFT GUARD: every deployable service the production compose declares must appear in
+          # the selection. The selector filters against a hardcoded DEPLOYABLE list, so a service
+          # added to docker-compose.production.yml but not to that list would be silently dropped
+          # from pull, revision-check and restart - the selector's own documented "too few ->
+          # silently skipped while the run still reports success" failure, and the direction the
+          # shape checks above cannot see.
+          #
+          # This runs against the REAL compose file, not fx-full.yml: the fixture builder keeps a
+          # hardcoded ['server','internal-service','ui'], so it would strip a newly added service
+          # before the assertion ever saw it and this guard would pass while the drift shipped.
+          #
+          # cloudflared is excluded deliberately - it is profile-gated and handled by deploy.sh's
+          # TUNNEL_PROFILE_ACTIVE branch rather than by this selection.
+          # Both sides are captured into variables rather than compared as `diff <(a) <(b)`.
+          # Process substitution discards the child's exit status, so if `docker compose config`
+          # failed, both sides would be EMPTY and diff would report no difference - a guard that
+          # passes precisely when it cannot see anything. Assigning first means `set -e` aborts on
+          # a failed read, and the emptiness check below makes a vacuous pass impossible.
+          declared=$(docker compose -f docker-compose.production.yml config --services | grep -vx cloudflared | sort)
+          selected=$(./scripts/select-deploy-services.sh docker-compose.production.yml | sort)
+          if [ -z "$declared" ] || [ -z "$selected" ]; then
+            echo "::error::could not read services from docker-compose.production.yml; the drift guard cannot run and must not pass silently."
+            exit 1
+          fi
+          if [ "$declared" != "$selected" ]; then
+            echo "::error::docker-compose.production.yml declares a deployable service the selector does not return. Add it to DEPLOYABLE in scripts/select-deploy-services.sh, or it will be silently skipped by pull, revision-check and restart."
+            diff <(printf '%s\n' "$declared") <(printf '%s\n' "$selected") || true
+            exit 1
+          fi
+          echo "  production compose -> no service missing from the selection"
 
       - name: THREE images are all checked, not just the first two
         # deploy.sh now passes three images (server, internal-service, ui). The script iterates

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -424,6 +424,17 @@ jobs:
           fi
           echo "PASS: mismatched images are refused."
 
+      - name: Deploy restart guards - run deploy.sh end to end
+        # The selector test below proves the LIST is right. This proves deploy.sh ACTS on it:
+        # it runs the real script against fixture compose files with a recording `docker` stub on
+        # PATH, and asserts which services were pulled and restarted - and that an omitted service
+        # is never touched. Without this, the headline fix (no unconditional `up -d --no-deps ui`)
+        # has no coverage and could be reintroduced with every other test still green.
+        #
+        # This is not hypothetical: it immediately caught that a server-only deploy still aborted,
+        # because the release gate rejected a single-image deployment as a usage error.
+        run: ./scripts/test-deploy-services.sh
+
       - name: Deploy service selection covers every compose shape
         # This selection decides what is pulled, revision-checked AND restarted. Both error
         # directions are deployment-critical: too few silently skips a declared service while
@@ -432,6 +443,9 @@ jobs:
         # so the slimmed shapes are supported configurations, not hypotheticals.
         run: |
           set -euo pipefail
+          # PyYAML is declared rather than inherited from the runner image: a runner change would
+          # otherwise turn this deterministic gate into an opaque ModuleNotFoundError.
+          python3 -c 'import yaml' 2>/dev/null || pip install --quiet pyyaml
           # Build fixtures from the real production compose so this tracks the actual file.
           # Dangling depends_on entries must be stripped or compose rejects the project.
           python3 - <<'PYEOF'

--- a/deploy.sh
+++ b/deploy.sh
@@ -195,42 +195,47 @@ fi
 # a cryptic mid-deploy exit into a one-line fix.
 echo "[2/4] Pulling images (tag: ${IMAGE_TAG:-latest})..."
 
-# Pull whichever of the three services this compose file actually declares, rather than a
-# hardcoded list. docker-compose.production.yml documents that `ui` and `internal-service` are
-# droppable for a server-only deployment, and an operator who takes that option would otherwise
-# hit `no such service: ui` here - a deploy broken by following our own documentation. `server`
-# is the one service that is genuinely required.
-declared_services=$(docker compose -f "$COMPOSE_FILE" config --services)
-PULL_SERVICES=()
-for svc in server internal-service ui; do
-    if printf '%s\n' "$declared_services" | grep -qx "$svc"; then
-        PULL_SERVICES+=("$svc")
-    fi
-done
-if ! printf '%s\n' "${PULL_SERVICES[@]}" | grep -qx server; then
-    echo "ERROR: '$COMPOSE_FILE' declares no 'server' service; there is nothing to deploy." >&2
+# Which services this deployment covers. Derived rather than hardcoded, because
+# docker-compose.production.yml documents that `ui` and `internal-service` are droppable for a
+# server-only deployment - an operator who takes that option would otherwise hit
+# `no such service: ui`, a deploy broken by following our own documentation.
+#
+# The selection lives in scripts/select-deploy-services.sh so it can be tested directly (see
+# validate.yml -> deploy-gate-tests). It is safety-critical in both directions: too few and a
+# declared service is silently skipped while the run still reports success; too many and we
+# `up -d` a service that was never pulled. Neither is testable wedged inline between a pull
+# and a production restart.
+if ! mapfile -t DEPLOY_SERVICES < <(./scripts/select-deploy-services.sh "$COMPOSE_FILE"); then
     exit 1
 fi
-echo "  Services in this compose file: ${PULL_SERVICES[*]}"
+if [ "${#DEPLOY_SERVICES[@]}" -eq 0 ]; then
+    echo "ERROR: no deployable services selected from '$COMPOSE_FILE'." >&2
+    exit 1
+fi
+echo "  Services in this deployment: ${DEPLOY_SERVICES[*]}"
 
-# True if this compose file declares $1.
+# True if $1 is part of THIS deployment - i.e. in the set selected above.
 #
-# The rolling restart in step 3 uses this for the same reason the pull list above is derived
-# rather than hardcoded. `ui` and `internal-service` are documented as droppable for a
-# server-only deployment, but the restart step used to run `up -d --no-deps ui` unconditionally.
-# An operator who followed that documentation got `no such service: ui` AFTER the server had
-# already been swapped to its new image - a half-applied deploy, which is the single outcome
-# the ordering in this script exists to prevent. Guarding the pull but not the restart just
-# moved the failure later, to the most expensive possible moment.
+# Named for what it tests, deliberately. It is NOT an independent "does the compose file
+# declare this?" query, and must not become one: the restart set has to be exactly the set
+# that was pulled and revision-checked. A second, independently-derived answer to the same
+# question is how you end up running `up -d` on a service whose image was never refreshed.
+# One source of truth - DEPLOY_SERVICES - for pull, verify and restart alike.
 #
-# `server` is deliberately NOT guarded: the check above already aborts when it is absent, so
-# by this point it is guaranteed present, and a guard there would silently turn "the compose
-# file is malformed" into "nothing was deployed, exit 0".
-service_declared() {
-    printf '%s\n' "${PULL_SERVICES[@]}" | grep -qx "$1"
+# The rolling restart in step 3 needs this because the restart step used to run
+# `up -d --no-deps ui` unconditionally. An operator following the documented server-only
+# option got `no such service: ui` AFTER the server had already been swapped to its new
+# image - a half-applied deploy, the single outcome this script's ordering exists to prevent.
+# Guarding the pull but not the restart just moved the failure to the most expensive moment.
+#
+# `server` is deliberately NOT guarded: selection already aborts when it is absent, so by this
+# point it is guaranteed present, and a guard there would silently turn "the compose file is
+# malformed" into "nothing was deployed, exit 0".
+in_deployment() {
+    printf '%s\n' "${DEPLOY_SERVICES[@]}" | grep -qx "$1"
 }
 
-if ! docker compose -f "$COMPOSE_FILE" "${PROFILE_ARGS[@]}" pull "${PULL_SERVICES[@]}"; then
+if ! docker compose -f "$COMPOSE_FILE" "${PROFILE_ARGS[@]}" pull "${DEPLOY_SERVICES[@]}"; then
     echo "" >&2
     echo "ERROR: failed to pull images (tag: ${IMAGE_TAG:-latest})." >&2
     echo "  Common causes:" >&2
@@ -272,7 +277,7 @@ echo "  Verifying all images came from the same commit..."
 # file instead keeps a legitimately slimmed-down deployment working.
 compose_json=$(docker compose -f "$COMPOSE_FILE" config --format json)
 VERIFY_IMAGES=()
-for svc in "${PULL_SERVICES[@]}"; do
+for svc in "${DEPLOY_SERVICES[@]}"; do
     img=$(printf '%s' "$compose_json" | jq -r --arg s "$svc" '.services[$s].image // empty')
     if [ -z "$img" ]; then
         echo "ERROR: service '$svc' declares no image in '$COMPOSE_FILE'." >&2
@@ -377,18 +382,18 @@ wait_for_port server 12349
 echo "  Server is up."
 
 # Internal service next, when this deployment includes one.
-if service_declared internal-service; then
+if in_deployment internal-service; then
     echo "  Restarting internal-service..."
     docker compose -f "$COMPOSE_FILE" "${PROFILE_ARGS[@]}" up -d --no-deps internal-service
     echo "  Waiting for internal-service to be healthy..."
     wait_for_port internal-service "${INTERNAL_SERVICE_PORT:-12345}"
     echo "  Internal service is up."
 else
-    echo "  Skipping internal-service: not declared in $COMPOSE_FILE."
+    echo "  Skipping internal-service: not part of this deployment."
 fi
 
 # UI last (lightweight, fast restart), when this deployment includes one.
-if service_declared ui; then
+if in_deployment ui; then
     echo "  Restarting ui..."
     # No `--build`: the ui image was already built in step 2, BEFORE anything was restarted.
     # Rebuilding it here would reopen the exact window step 2 exists to close - a build failure at
@@ -403,7 +408,7 @@ if service_declared ui; then
     wait_for_port ui 8080
     echo "  UI is up."
 else
-    echo "  Skipping ui: not declared in $COMPOSE_FILE."
+    echo "  Skipping ui: not part of this deployment."
 fi
 
 # Cloudflared if tunnel profile is active
@@ -443,9 +448,9 @@ echo ""
 # Advertise only endpoints this deployment actually serves. A server-only stack that
 # printed "Local access: http://localhost:8080" would send the operator to a port nothing
 # is listening on and read as a broken deploy rather than a correctly slimmed-down one.
-if service_declared ui; then
+if in_deployment ui; then
     echo "Local access:  http://localhost:8080"
 fi
-if service_declared internal-service; then
+if in_deployment internal-service; then
     echo "WebSocket:     ws://localhost:${INTERNAL_SERVICE_PORT:-12345}"
 fi

--- a/deploy.sh
+++ b/deploy.sh
@@ -235,21 +235,14 @@ echo "  Services in this deployment: ${DEPLOY_SERVICES[*]}"
 # So it REFUSES, here, before anything is pulled or restarted - the running stack is left exactly
 # as it was - and prints the command to clear the leftovers.
 #
-# Deliberately not `docker rm -f` on the operator's behalf. Removal would have to match containers
-# by the com.docker.compose.project label, which spans every checkout and account on the daemon,
-# so doing it safely needs a lock proving no other deploy is mid-flight - a large mechanism, and a
-# destructive one, for a transition that happens rarely and takes one command by hand.
-#
-# What that buys is a bounded failure, not an absence of races. This is a point-in-time check, and
-# nothing holds the project still afterwards: a CONCURRENT deploy of the same project from a
-# checkout whose compose file still declares `ui` can start one between this check and the restarts
-# below, and this run will finish without noticing. But because the check only ever REPORTS, losing
-# that race costs a missed refusal - never a container removed out from under another deploy, and
-# never a half-applied topology this script created. The stale container is left exactly where
-# master already leaves it, and the next deploy refuses on it.
-#
-# Closing that window means serializing every deploy of a project host-wide, which is a change to
-# how deployments are provisioned rather than a fix to this check; it is tracked separately.
+# Deliberately not `docker rm -f` on the operator's behalf, even though a lock is taken below.
+# These are two different jobs with two different bars. That lock SERIALIZES: it gates nothing
+# destructive, so an account that never contends for it is left exactly where this script already
+# was. Removing containers would make the lock AUTHORIZE destruction, and matching by the
+# com.docker.compose.project label reaches every checkout and account on the daemon - so it would
+# have to prove no other deploy is mid-flight anywhere on the host, which the per-account lock
+# below does not and cannot. That is a far larger mechanism, and a destructive one, for a
+# transition that happens rarely and takes one command by hand.
 if ! deployable_all=$(./scripts/select-deploy-services.sh --deployable); then
     exit 1
 fi
@@ -265,18 +258,7 @@ while read -r svc; do
     printf '%s\n' "${DEPLOY_SERVICES[@]}" | grep -qx "$svc" && continue
     # oneoff=False excludes `docker compose run` containers, which carry the same project and
     # service labels: a migration or debugging job is not a stale service.
-    #
-    # `ps -q`, NOT `ps -aq`. The refusal is about services that are still SERVING - an exited or
-    # never-started container for a dropped service answers no requests and holds no ports, so
-    # refusing over one would block the documented slim deploy on any host that still has leftovers
-    # from an old topology, and tell the operator to force-remove something already inert. `-q`
-    # covers exactly the states that can serve: running, paused (still holds its ports) and
-    # restarting (crash-looping, comes back). It leaves out `created`, `exited` and `dead`.
-    #
-    # Nor does an exited container come back on its own: under `restart: always` the daemon
-    # restarts it immediately, so it would be seen as running or restarting, and `unless-stopped`
-    # only stays exited when an operator stopped it deliberately.
-    if ! found=$(docker ps -q \
+    if ! found=$(docker ps -aq \
         --filter "label=com.docker.compose.project=${preflight_project}" \
         --filter "label=com.docker.compose.service=${svc}" \
         --filter "label=com.docker.compose.oneoff=False" 2>/dev/null); then
@@ -284,25 +266,63 @@ while read -r svc; do
         echo "  Refusing to deploy rather than guess; nothing has been changed." >&2
         exit 1
     fi
-    [ -n "$found" ] && stale_report="${stale_report}${svc}|$(printf '%s' "$found" | tr '\n' ' ')"$'\n'
+
+    # A leftover is a hazard if it serves now, or if it will serve again without anyone asking.
+    # Anything else is inert and must NOT block the deploy: hosts that once ran the full stack
+    # accumulate dead containers, and refusing over those would fail the documented slim deploy on
+    # exactly the hosts it is for, telling the operator to force-remove something already harmless.
+    #
+    # Serving now is `running`, plus `paused` (frozen, but still holding its published ports) and
+    # `restarting` (crash-looping back into service).
+    #
+    # Serving again is decided by the restart policy, and ONLY `always` qualifies. That is the sole
+    # difference between `always` and `unless-stopped`: both bring a crashed container back while
+    # the daemon runs, but a container stopped by hand stays stopped under `unless-stopped` and is
+    # started again under `always` the next time the daemon does - so an exited `always` container
+    # for a dropped service is a stale service waiting on the next host reboot. `no` never returns,
+    # and `on-failure` has either exited clean, where the policy does not apply, or exhausted its
+    # retries while the daemon was up.
+    while read -r cid; do
+        [ -n "$cid" ] || continue
+        if ! info=$(docker inspect -f '{{.State.Status}} {{.HostConfig.RestartPolicy.Name}}' "$cid" 2>/dev/null); then
+            # Judge by outcome: a container that vanished between the list and the inspect is the
+            # state we wanted anyway. Anything still there that we cannot read, we refuse on.
+            if docker ps -aq --filter "id=${cid}" 2>/dev/null | grep -q .; then
+                echo "ERROR: cannot inspect container ${cid} of the dropped service '${svc}'." >&2
+                echo "  Refusing to deploy rather than guess; nothing has been changed." >&2
+                exit 1
+            fi
+            continue
+        fi
+        read -r cstatus cpolicy <<<"$info"
+        case "$cstatus" in
+            running|paused|restarting) reason="$cstatus" ;;
+            *) [ "$cpolicy" = "always" ] && reason="restarts on reboot" || continue ;;
+        esac
+        stale_report="${stale_report}${svc}|${reason}|${cid}"$'\n'
+    done <<<"$found"
 done <<<"$deployable_all"
 
 if [ -n "$stale_report" ]; then
-    echo "ERROR: '${COMPOSE_FILE}' no longer declares these services, but they are still running:" >&2
-    while IFS='|' read -r svc ids; do
+    echo "ERROR: '${COMPOSE_FILE}' no longer declares these services, but they are still on this host:" >&2
+    while IFS='|' read -r svc reason cid; do
         [ -n "$svc" ] || continue
-        echo "    ${svc}: ${ids}" >&2
+        echo "    ${svc}: ${cid} (${reason})" >&2
     done <<<"$stale_report"
     echo "" >&2
     echo "  Deploying now would restart the services this file DOES declare while those kept" >&2
     echo "  serving their old images - a deployment that matches neither the old topology nor the" >&2
-    echo "  new one. Nothing has been changed." >&2
+    echo "  new one. A container marked 'restarts on reboot' is not serving yet, but its" >&2
+    echo "  restart: always policy will start it again the next time the Docker daemon does." >&2
+    echo "  Nothing has been changed." >&2
     echo "" >&2
     echo "  Remove them, then re-run:" >&2
-    while IFS='|' read -r svc ids; do
-        [ -n "$ids" ] || continue
-        echo "    docker rm -f ${ids% }" >&2
-    done <<<"$stale_report"
+    # `if`, not `[ -n ... ] &&`: the trailing blank line makes the test fail, which would be the
+    # loop's - and so the substitution's - exit status, and `set -e` would kill the script here.
+    stale_ids=$(while IFS='|' read -r _ _ cid; do
+        if [ -n "$cid" ]; then printf '%s ' "$cid"; fi
+    done <<<"$stale_report")
+    echo "    docker rm -f ${stale_ids% }" >&2
     exit 1
 fi
 

--- a/deploy.sh
+++ b/deploy.sh
@@ -238,9 +238,18 @@ echo "  Services in this deployment: ${DEPLOY_SERVICES[*]}"
 # Deliberately not `docker rm -f` on the operator's behalf. Removal would have to match containers
 # by the com.docker.compose.project label, which spans every checkout and account on the daemon,
 # so doing it safely needs a lock proving no other deploy is mid-flight - a large mechanism, and a
-# destructive one, for a transition that happens rarely and takes one command by hand. Reporting
-# is race-free by construction: the worst case is a stale container this deploy did not remove,
-# which is exactly where master already is.
+# destructive one, for a transition that happens rarely and takes one command by hand.
+#
+# What that buys is a bounded failure, not an absence of races. This is a point-in-time check, and
+# nothing holds the project still afterwards: a CONCURRENT deploy of the same project from a
+# checkout whose compose file still declares `ui` can start one between this check and the restarts
+# below, and this run will finish without noticing. But because the check only ever REPORTS, losing
+# that race costs a missed refusal - never a container removed out from under another deploy, and
+# never a half-applied topology this script created. The stale container is left exactly where
+# master already leaves it, and the next deploy refuses on it.
+#
+# Closing that window means serializing every deploy of a project host-wide, which is a change to
+# how deployments are provisioned rather than a fix to this check; it is tracked separately.
 if ! deployable_all=$(./scripts/select-deploy-services.sh --deployable); then
     exit 1
 fi

--- a/deploy.sh
+++ b/deploy.sh
@@ -222,6 +222,70 @@ if [ "${#DEPLOY_SERVICES[@]}" -eq 0 ] || [ -z "${DEPLOY_SERVICES[0]}" ]; then
 fi
 echo "  Services in this deployment: ${DEPLOY_SERVICES[*]}"
 
+# A service this compose file DROPS, whose container is still running, has to be dealt with before
+# the deploy can honestly claim to have applied it.
+#
+# `docker compose up` does not remove containers for services the file no longer declares - it
+# warns about "orphan containers" and leaves them running (verified). Guarding the restart above
+# without noticing that would turn one failure into a worse one: before this change a slimmed
+# deploy died at `up -d --no-deps ui` with "no such service", loudly; now it would succeed while
+# the old ui kept serving stale code on :8080, silently. A silent half-applied deploy is the one
+# outcome this script's ordering exists to prevent.
+#
+# So it REFUSES, here, before anything is pulled or restarted - the running stack is left exactly
+# as it was - and prints the command to clear the leftovers.
+#
+# Deliberately not `docker rm -f` on the operator's behalf. Removal would have to match containers
+# by the com.docker.compose.project label, which spans every checkout and account on the daemon,
+# so doing it safely needs a lock proving no other deploy is mid-flight - a large mechanism, and a
+# destructive one, for a transition that happens rarely and takes one command by hand. Reporting
+# is race-free by construction: the worst case is a stale container this deploy did not remove,
+# which is exactly where master already is.
+if ! deployable_all=$(./scripts/select-deploy-services.sh --deployable); then
+    exit 1
+fi
+preflight_project=$(docker compose -f "$COMPOSE_FILE" config --format json | jq -r '.name // empty')
+if [ -z "$preflight_project" ]; then
+    echo "ERROR: could not read the compose project name from '$COMPOSE_FILE'." >&2
+    exit 1
+fi
+
+stale_report=""
+while read -r svc; do
+    [ -n "$svc" ] || continue
+    printf '%s\n' "${DEPLOY_SERVICES[@]}" | grep -qx "$svc" && continue
+    # oneoff=False excludes `docker compose run` containers, which carry the same project and
+    # service labels: a migration or debugging job is not a stale service.
+    if ! found=$(docker ps -aq \
+        --filter "label=com.docker.compose.project=${preflight_project}" \
+        --filter "label=com.docker.compose.service=${svc}" \
+        --filter "label=com.docker.compose.oneoff=False" 2>/dev/null); then
+        echo "ERROR: cannot list containers for the dropped service '${svc}'." >&2
+        echo "  Refusing to deploy rather than guess; nothing has been changed." >&2
+        exit 1
+    fi
+    [ -n "$found" ] && stale_report="${stale_report}${svc}|$(printf '%s' "$found" | tr '\n' ' ')"$'\n'
+done <<<"$deployable_all"
+
+if [ -n "$stale_report" ]; then
+    echo "ERROR: '${COMPOSE_FILE}' no longer declares these services, but they are still running:" >&2
+    while IFS='|' read -r svc ids; do
+        [ -n "$svc" ] || continue
+        echo "    ${svc}: ${ids}" >&2
+    done <<<"$stale_report"
+    echo "" >&2
+    echo "  Deploying now would restart the services this file DOES declare while those kept" >&2
+    echo "  serving their old images - a deployment that matches neither the old topology nor the" >&2
+    echo "  new one. Nothing has been changed." >&2
+    echo "" >&2
+    echo "  Remove them, then re-run:" >&2
+    while IFS='|' read -r svc ids; do
+        [ -n "$ids" ] || continue
+        echo "    docker rm -f ${ids% }" >&2
+    done <<<"$stale_report"
+    exit 1
+fi
+
 # True if $1 is part of THIS deployment - i.e. in the set selected above.
 #
 # Named for what it tests, deliberately. It is NOT an independent "does the compose file

--- a/deploy.sh
+++ b/deploy.sh
@@ -96,6 +96,16 @@ if ! command -v jq >/dev/null 2>&1; then
     exit 1
 fi
 
+# flock serializes deploys of the same compose project (see the lock below). Checked here rather
+# than tolerated, because a deploy that silently skipped the lock would silently reintroduce the
+# interleaving the lock exists to stop - and there is nothing to weigh against that, since flock
+# ships with util-linux and is present on every Linux host this deploys to.
+if ! command -v flock >/dev/null 2>&1; then
+    echo "ERROR: 'flock' is required to serialize deploys. Install with:"
+    echo "  apt-get install util-linux   # Debian/Ubuntu"
+    exit 1
+fi
+
 # Load .env into the shell. Docker Compose already auto-reads .env, but the
 # wait_for_port probe below shell-expands ${INTERNAL_SERVICE_PORT} BEFORE it
 # hands off to docker compose, so an operator who customised the port would
@@ -249,6 +259,46 @@ fi
 preflight_project=$(docker compose -f "$COMPOSE_FILE" config --format json | jq -r '.name // empty')
 if [ -z "$preflight_project" ]; then
     echo "ERROR: could not read the compose project name from '$COMPOSE_FILE'." >&2
+    exit 1
+fi
+
+# Serialize deploys of this compose project, for the whole run.
+#
+# The check below is a point-in-time snapshot, and everything it protects happens afterwards. A
+# second deploy of the same project - typically the same operator from a different checkout, or a
+# rerun fired before the first finished - can start a `ui` container between the check and the
+# restarts, and this run would then report "Deploy complete" over a topology it never verified.
+#
+# The lock is taken BEFORE the check and held to the end of the script, so the snapshot stays true
+# for as long as anything depends on it. `exec 9>` keeps the descriptor open for the process
+# lifetime and the kernel drops the lock when the process exits, so there is no unlock path to get
+# wrong and no trap to misfire - and the file is deliberately never removed, since unlinking a lock
+# other deploys may already hold reintroduces the race it exists to close.
+#
+# Scoped to the account, under a directory it owns, so it needs no provisioning and cannot be
+# squatted in a shared world-writable directory. Two DIFFERENT accounts deploying the same project
+# therefore still will not serialize - but that only leaves them where this script already was, and
+# nothing here acts on the lock's authority: it gates no removal and no destructive step, so the
+# worst a missing or unshared lock costs is the missed refusal described above.
+#
+# Keyed off HOME alone, deliberately - NOT $XDG_RUNTIME_DIR. Two deploys serialize only if they
+# pick the same file, and XDG_RUNTIME_DIR is set inside a login session and absent from cron or a
+# bare ssh command, so honouring it would hand the same operator two different locks depending on
+# how the deploy was started, which is precisely when the two runs must contend.
+lock_dir="${HOME:?HOME must be set to locate the deploy lock}/.cache/citadel-deploy"
+if ! mkdir -p -m 700 "$lock_dir" 2>/dev/null; then
+    echo "ERROR: could not create the deploy lock directory '${lock_dir}'." >&2
+    exit 1
+fi
+lock_file="${lock_dir}/${preflight_project}.lock"
+if ! exec 9>"$lock_file"; then
+    echo "ERROR: could not open the deploy lock '${lock_file}'." >&2
+    exit 1
+fi
+if ! flock -n 9; then
+    echo "ERROR: another deploy of project '${preflight_project}' is already running." >&2
+    echo "  It holds ${lock_file}. Wait for it to finish, then re-run." >&2
+    echo "  Nothing has been changed." >&2
     exit 1
 fi
 

--- a/deploy.sh
+++ b/deploy.sh
@@ -273,9 +273,10 @@ fi
 # The comparison itself lives in scripts/verify-image-revisions.sh rather than inline
 # here, because it is the safety gate and an untested safety gate is a liability. As a
 # standalone script that takes images as arguments it is exercised directly in CI
-# (validate.yml -> deploy-gate-tests) against real images with matching, mismatched and
-# absent labels. Inline in this script - wedged between an image pull and a production
-# restart - none of those paths could be tested at all.
+# (validate.yml -> deploy-gate-tests) against real images: matching, mismatched, absent
+# labels, un-inspectable, and the single-image server-only shape. Inline in this script -
+# wedged between an image pull and a production restart - none of those paths could be
+# tested at all.
 echo "  Verifying all images came from the same commit..."
 # Verify exactly the services that were pulled. Every image in the deployment is subject to the
 # same consistency rule - the ui included, since a partially completed `latest` promotion could

--- a/deploy.sh
+++ b/deploy.sh
@@ -169,6 +169,37 @@ if [ "$TUNNEL_PROFILE_ACTIVE" = true ] && [ -z "${TUNNEL_TOKEN:-}" ]; then
     exit 1
 fi
 
+# Serialize runs from THIS CHECKOUT, before anything reads or writes it.
+#
+# The project lock further down cannot cover this. It is keyed on the compose project name, which
+# is only knowable by reading the compose file - so by the time it can be taken, `git pull` has
+# already run and the service selection has already read that file. A second run started from the
+# same directory would pull new code into the checkout underneath the first, which then goes on to
+# re-read the compose file for `pull`, `up -d` and `ps`: it would verify one revision and restart
+# another. Refusing the second run only after its git step is too late; the damage is done there.
+#
+# So this lock is taken first and covers the whole run, git step included. It is keyed on the one
+# thing already known before any file is read: the checkout itself. That is the working directory,
+# which is what every relative path in this script - `docker-compose.production.yml`,
+# `./scripts/...` - already resolves against, so it is exactly the resource at risk. Locking the
+# DIRECTORY's inode rather than a path-derived name means the identity is exact: no hashing, no
+# name collisions between checkouts, no path-length limit, and two runs from the same directory
+# necessarily open the same inode. The lock is advisory and only this script takes it, so it does
+# not interfere with git's own locking.
+#
+# Both locks are taken in this order, checkout then project, and both are non-blocking, so they
+# cannot deadlock: a run that cannot get the second lock exits and drops the first.
+checkout_dir="$PWD"
+if ! exec 8<"$checkout_dir"; then
+    echo "ERROR: could not open '${checkout_dir}' to lock this checkout." >&2
+    exit 1
+fi
+if ! flock -n 8; then
+    echo "ERROR: another deploy is already running from this checkout (${checkout_dir})." >&2
+    echo "  Wait for it to finish, then re-run. Nothing has been changed." >&2
+    exit 1
+fi
+
 # Step 1: Pull latest code
 if [ "$SKIP_PULL" = false ]; then
     echo "[1/4] Pulling latest code..."

--- a/deploy.sh
+++ b/deploy.sh
@@ -337,7 +337,19 @@ while read -r svc; do
         if ! info=$(docker inspect -f '{{.State.Status}} {{.HostConfig.RestartPolicy.Name}}' "$cid" 2>/dev/null); then
             # Judge by outcome: a container that vanished between the list and the inspect is the
             # state we wanted anyway. Anything still there that we cannot read, we refuse on.
-            if docker ps -aq --filter "id=${cid}" 2>/dev/null | grep -q .; then
+            #
+            # The re-query's SUCCESS is checked separately from its RESULT, and the difference is
+            # the whole point. `docker ps ... | grep -q .` collapses the two: it is equally false
+            # when the container is gone and when the query itself failed - and a failing query is
+            # the LIKELY case here, since whatever stopped `docker inspect` from answering
+            # (daemon down, API error) will usually stop this one too. Skipping on that reading
+            # would fail open on the one path written to fail closed.
+            if ! remaining=$(docker ps -aq --filter "id=${cid}" 2>/dev/null); then
+                echo "ERROR: cannot inspect container ${cid} of the dropped service '${svc}'," >&2
+                echo "  and cannot confirm whether it is still there. Nothing has been changed." >&2
+                exit 1
+            fi
+            if [ -n "$remaining" ]; then
                 echo "ERROR: cannot inspect container ${cid} of the dropped service '${svc}'." >&2
                 echo "  Refusing to deploy rather than guess; nothing has been changed." >&2
                 exit 1

--- a/deploy.sh
+++ b/deploy.sh
@@ -205,10 +205,18 @@ echo "[2/4] Pulling images (tag: ${IMAGE_TAG:-latest})..."
 # declared service is silently skipped while the run still reports success; too many and we
 # `up -d` a service that was never pulled. Neither is testable wedged inline between a pull
 # and a production restart.
-if ! mapfile -t DEPLOY_SERVICES < <(./scripts/select-deploy-services.sh "$COMPOSE_FILE"); then
+# Command substitution, NOT `mapfile < <(...)`. Bash does not propagate the exit status of a
+# process substitution: mapfile reads to EOF and returns 0 even when the child exited 1, and it
+# KEEPS whatever partial output the child managed to print. An `if ! mapfile` guard there is dead
+# code, and a selector that failed after printing one service would have been treated as success
+# with a truncated list. Verified both behaviours before changing this.
+if ! selection=$(./scripts/select-deploy-services.sh "$COMPOSE_FILE"); then
     exit 1
 fi
-if [ "${#DEPLOY_SERVICES[@]}" -eq 0 ]; then
+mapfile -t DEPLOY_SERVICES <<<"$selection"
+# Belt and braces: the selector already errors on an empty result, and the check above now
+# actually observes that, but a silent empty selection must never fall through to a restart.
+if [ "${#DEPLOY_SERVICES[@]}" -eq 0 ] || [ -z "${DEPLOY_SERVICES[0]}" ]; then
     echo "ERROR: no deployable services selected from '$COMPOSE_FILE'." >&2
     exit 1
 fi

--- a/deploy.sh
+++ b/deploy.sh
@@ -301,16 +301,23 @@ fi
 # restarts, and this run would then report "Deploy complete" over a topology it never verified.
 #
 # The lock is taken BEFORE the check and held to the end of the script, so the snapshot stays true
-# for as long as anything depends on it. `exec 9>` keeps the descriptor open for the process
-# lifetime and the kernel drops the lock when the process exits, so there is no unlock path to get
-# wrong and no trap to misfire - and the file is deliberately never removed, since unlinking a lock
-# other deploys may already hold reintroduces the race it exists to close.
+# for as long as anything depends on it - against every deploy that takes this same lock, which is
+# the precise limit of the guarantee; see the scoping note below for who that leaves out. `exec 9>`
+# keeps the descriptor open for the process lifetime and the kernel drops the lock when the process
+# exits, so there is no unlock path to get wrong and no trap to misfire - and the file is
+# deliberately never removed, since unlinking a lock other deploys may already hold reintroduces
+# the race it exists to close.
 #
 # Scoped to the account, under a directory it owns, so it needs no provisioning and cannot be
-# squatted in a shared world-writable directory. Two DIFFERENT accounts deploying the same project
-# therefore still will not serialize - but that only leaves them where this script already was, and
-# nothing here acts on the lock's authority: it gates no removal and no destructive step, so the
-# worst a missing or unshared lock costs is the missed refusal described above.
+# squatted in a shared world-writable directory. The cost is that the scope is narrower than the
+# thing being protected: containers and project labels live on the shared daemon, and the stale
+# check matches by project label across every account on it, so two accounts deploying the same
+# project take different lock files and do NOT serialize. Closing that needs a lock file both
+# accounts can open, which means an administrator provisioning it with ownership and permissions
+# that stop either account replacing it - a deployment-provisioning change, deliberately not made
+# here. What keeps it out of blocking territory is that nothing acts on this lock's authority: it
+# gates no removal and no destructive step, so an unshared lock costs the missed refusal described
+# above - exactly where this script already was - and never a destructive action.
 #
 # Keyed off HOME alone, deliberately - NOT $XDG_RUNTIME_DIR. Two deploys serialize only if they
 # pick the same file, and XDG_RUNTIME_DIR is set inside a login session and absent from cron or a

--- a/deploy.sh
+++ b/deploy.sh
@@ -256,7 +256,18 @@ while read -r svc; do
     printf '%s\n' "${DEPLOY_SERVICES[@]}" | grep -qx "$svc" && continue
     # oneoff=False excludes `docker compose run` containers, which carry the same project and
     # service labels: a migration or debugging job is not a stale service.
-    if ! found=$(docker ps -aq \
+    #
+    # `ps -q`, NOT `ps -aq`. The refusal is about services that are still SERVING - an exited or
+    # never-started container for a dropped service answers no requests and holds no ports, so
+    # refusing over one would block the documented slim deploy on any host that still has leftovers
+    # from an old topology, and tell the operator to force-remove something already inert. `-q`
+    # covers exactly the states that can serve: running, paused (still holds its ports) and
+    # restarting (crash-looping, comes back). It leaves out `created`, `exited` and `dead`.
+    #
+    # Nor does an exited container come back on its own: under `restart: always` the daemon
+    # restarts it immediately, so it would be seen as running or restarting, and `unless-stopped`
+    # only stays exited when an operator stopped it deliberately.
+    if ! found=$(docker ps -q \
         --filter "label=com.docker.compose.project=${preflight_project}" \
         --filter "label=com.docker.compose.service=${svc}" \
         --filter "label=com.docker.compose.oneoff=False" 2>/dev/null); then

--- a/deploy.sh
+++ b/deploy.sh
@@ -213,6 +213,23 @@ if ! printf '%s\n' "${PULL_SERVICES[@]}" | grep -qx server; then
 fi
 echo "  Services in this compose file: ${PULL_SERVICES[*]}"
 
+# True if this compose file declares $1.
+#
+# The rolling restart in step 3 uses this for the same reason the pull list above is derived
+# rather than hardcoded. `ui` and `internal-service` are documented as droppable for a
+# server-only deployment, but the restart step used to run `up -d --no-deps ui` unconditionally.
+# An operator who followed that documentation got `no such service: ui` AFTER the server had
+# already been swapped to its new image - a half-applied deploy, which is the single outcome
+# the ordering in this script exists to prevent. Guarding the pull but not the restart just
+# moved the failure later, to the most expensive possible moment.
+#
+# `server` is deliberately NOT guarded: the check above already aborts when it is absent, so
+# by this point it is guaranteed present, and a guard there would silently turn "the compose
+# file is malformed" into "nothing was deployed, exit 0".
+service_declared() {
+    printf '%s\n' "${PULL_SERVICES[@]}" | grep -qx "$1"
+}
+
 if ! docker compose -f "$COMPOSE_FILE" "${PROFILE_ARGS[@]}" pull "${PULL_SERVICES[@]}"; then
     echo "" >&2
     echo "ERROR: failed to pull images (tag: ${IMAGE_TAG:-latest})." >&2
@@ -359,27 +376,35 @@ echo "  Waiting for server to be healthy..."
 wait_for_port server 12349
 echo "  Server is up."
 
-# Internal service next
-echo "  Restarting internal-service..."
-docker compose -f "$COMPOSE_FILE" "${PROFILE_ARGS[@]}" up -d --no-deps internal-service
-echo "  Waiting for internal-service to be healthy..."
-wait_for_port internal-service "${INTERNAL_SERVICE_PORT:-12345}"
-echo "  Internal service is up."
+# Internal service next, when this deployment includes one.
+if service_declared internal-service; then
+    echo "  Restarting internal-service..."
+    docker compose -f "$COMPOSE_FILE" "${PROFILE_ARGS[@]}" up -d --no-deps internal-service
+    echo "  Waiting for internal-service to be healthy..."
+    wait_for_port internal-service "${INTERNAL_SERVICE_PORT:-12345}"
+    echo "  Internal service is up."
+else
+    echo "  Skipping internal-service: not declared in $COMPOSE_FILE."
+fi
 
-# UI last (lightweight, fast restart)
-echo "  Restarting ui..."
-# No `--build`: the ui image was already built in step 2, BEFORE anything was restarted.
-# Rebuilding it here would reopen the exact window step 2 exists to close - a build failure at
-# this point (cache invalidation, disk pressure, a transient npm error) would land AFTER the
-# server and internal-service have already been swapped to their new images, leaving production
-# on a new backend with the old UI. Build everything first, restart afterwards.
-docker compose -f "$COMPOSE_FILE" "${PROFILE_ARGS[@]}" up -d --no-deps ui
-# Wait for nginx to actually serve (the ui healthcheck does a wget --spider
-# on :8080). Without this the deploy reports success even if nginx failed to
-# start (bad config, missing dist/) — the cloudflared step would then start
-# in front of a dead UI.
-wait_for_port ui 8080
-echo "  UI is up."
+# UI last (lightweight, fast restart), when this deployment includes one.
+if service_declared ui; then
+    echo "  Restarting ui..."
+    # No `--build`: the ui image was already built in step 2, BEFORE anything was restarted.
+    # Rebuilding it here would reopen the exact window step 2 exists to close - a build failure at
+    # this point (cache invalidation, disk pressure, a transient npm error) would land AFTER the
+    # server and internal-service have already been swapped to their new images, leaving production
+    # on a new backend with the old UI. Build everything first, restart afterwards.
+    docker compose -f "$COMPOSE_FILE" "${PROFILE_ARGS[@]}" up -d --no-deps ui
+    # Wait for nginx to actually serve (the ui healthcheck does a wget --spider
+    # on :8080). Without this the deploy reports success even if nginx failed to
+    # start (bad config, missing dist/) — the cloudflared step would then start
+    # in front of a dead UI.
+    wait_for_port ui 8080
+    echo "  UI is up."
+else
+    echo "  Skipping ui: not declared in $COMPOSE_FILE."
+fi
 
 # Cloudflared if tunnel profile is active
 if [[ "$TUNNEL_PROFILE_ACTIVE" == "true" ]]; then
@@ -415,5 +440,12 @@ echo "============================================"
 echo "  Deploy complete!"
 echo "============================================"
 echo ""
-echo "Local access:  http://localhost:8080"
-echo "WebSocket:     ws://localhost:${INTERNAL_SERVICE_PORT:-12345}"
+# Advertise only endpoints this deployment actually serves. A server-only stack that
+# printed "Local access: http://localhost:8080" would send the operator to a port nothing
+# is listening on and read as a broken deploy rather than a correctly slimmed-down one.
+if service_declared ui; then
+    echo "Local access:  http://localhost:8080"
+fi
+if service_declared internal-service; then
+    echo "WebSocket:     ws://localhost:${INTERNAL_SERVICE_PORT:-12345}"
+fi

--- a/scripts/select-deploy-services.sh
+++ b/scripts/select-deploy-services.sh
@@ -31,16 +31,29 @@
 # "nothing to deploy" should never be reported as a successful no-op deploy.
 #
 # Usage:  select-deploy-services.sh <compose-file>
+#         select-deploy-services.sh --deployable
 # Exit 0: prints one service per line.  Exit 1: no server service, message on stderr.
 
 set -euo pipefail
-
-COMPOSE_FILE="${1:?usage: select-deploy-services.sh <compose-file>}"
 
 # The services this project knows how to deploy, in restart order. `cloudflared` is
 # deliberately absent: it is profile-gated and handled separately by deploy.sh's
 # TUNNEL_PROFILE_ACTIVE branch, not by this selection.
 DEPLOYABLE=(server internal-service ui)
+
+# `--deployable` prints that full list without consulting any compose file.
+#
+# deploy.sh needs it to spot the services a slimmed deployment DROPPED, which by definition are
+# the ones the compose file no longer mentions - so they cannot be derived from the file, and the
+# set has to come from somewhere. It comes from here, for the same reason the selection does: two
+# hand-maintained lists of "the services we deploy" drift, and the direction they drift in is a
+# service nobody pulls, verifies, restarts, or notices is stale.
+if [ "${1:-}" = "--deployable" ]; then
+    printf '%s\n' "${DEPLOYABLE[@]}"
+    exit 0
+fi
+
+COMPOSE_FILE="${1:?usage: select-deploy-services.sh <compose-file> | --deployable}"
 
 declared=$(docker compose -f "$COMPOSE_FILE" config --services)
 

--- a/scripts/select-deploy-services.sh
+++ b/scripts/select-deploy-services.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+#
+# Print which of the deployable services a compose file actually declares, one per line,
+# in deploy order (server first).
+#
+# WHY THIS IS A SEPARATE SCRIPT
+#
+# This selection decides what gets pulled, what gets revision-checked, and what gets
+# restarted. Get it wrong in either direction and you get a half-applied deploy:
+#
+#   * too few  -> a declared service is silently skipped. No pull, no restart, no health
+#                 wait, and the run still prints "Deploy complete" while the old container
+#                 keeps serving old code. Silent, and far harder to notice than a crash.
+#   * too many -> `up -d` on a service that was never pulled, i.e. restarting onto a stale
+#                 or missing image, mid-deploy.
+#
+# deploy.sh already makes this argument about the release-consistency gate and moved it to
+# scripts/verify-image-revisions.sh for exactly this reason: a safety-critical decision
+# wedged between an image pull and a production restart cannot be tested where it sits.
+# Same reasoning, same treatment - as a standalone script taking a compose file, it is
+# exercised directly in CI (validate.yml -> deploy-gate-tests) against real compose files.
+#
+# THE INVARIANT THIS EXISTS TO HOLD
+#
+# The set printed here is used for pull, revision-check AND restart. They must be the same
+# set: you restart exactly what you pulled and verified. Do not reintroduce a second,
+# independent "is this declared?" test elsewhere in the deploy - two sources of truth for
+# the same question is precisely how the too-many case above gets in.
+#
+# `server` is required; its absence is an error rather than an empty result, because
+# "nothing to deploy" should never be reported as a successful no-op deploy.
+#
+# Usage:  select-deploy-services.sh <compose-file>
+# Exit 0: prints one service per line.  Exit 1: no server service, message on stderr.
+
+set -euo pipefail
+
+COMPOSE_FILE="${1:?usage: select-deploy-services.sh <compose-file>}"
+
+# The services this project knows how to deploy, in restart order. `cloudflared` is
+# deliberately absent: it is profile-gated and handled separately by deploy.sh's
+# TUNNEL_PROFILE_ACTIVE branch, not by this selection.
+DEPLOYABLE=(server internal-service ui)
+
+declared=$(docker compose -f "$COMPOSE_FILE" config --services)
+
+selected=()
+for svc in "${DEPLOYABLE[@]}"; do
+    if printf '%s\n' "$declared" | grep -qx "$svc"; then
+        selected+=("$svc")
+    fi
+done
+
+if ! printf '%s\n' "${selected[@]:-}" | grep -qx server; then
+    echo "ERROR: '$COMPOSE_FILE' declares no 'server' service; there is nothing to deploy." >&2
+    exit 1
+fi
+
+printf '%s\n' "${selected[@]}"

--- a/scripts/test-deploy-services.sh
+++ b/scripts/test-deploy-services.sh
@@ -103,8 +103,13 @@ if [ "${1:-}" = "ps" ]; then
     esac
   done
   # `ps -aq --filter id=X` is deploy.sh re-checking whether a container it failed to inspect is
-  # still there. Nothing in these fixtures removes containers mid-run, so it still exists.
-  if [ -n "$by_id" ]; then echo "$by_id"; exit 0; fi
+  # still there. $PS_ID_FAILS models the daemon refusing that question too - the likely case, since
+  # whatever broke `docker inspect` usually breaks this as well. Nothing in these fixtures removes
+  # containers mid-run, so otherwise it still exists.
+  if [ -n "$by_id" ]; then
+    if [ -n "${PS_ID_FAILS:-}" ]; then exit 1; fi
+    echo "$by_id"; exit 0
+  fi
   case " ${PREEXISTING:-} " in *" $svc "*) echo "cid-$svc" ;; esac
   # Real `docker ps` lists paused and restarting containers WITHOUT -a: both are still holding
   # their published ports, so they belong with the running ones, not with the exited ones.
@@ -177,6 +182,7 @@ run_deploy() { # <name> <service>...
   export PREEXISTING_LATENT="${PREEXISTING_LATENT:-}"
   export PREEXISTING_PAUSED="${PREEXISTING_PAUSED:-}"
   export INSPECT_FAILS="${INSPECT_FAILS:-}"
+  export PS_ID_FAILS="${PS_ID_FAILS:-}"
   : > "$CALLS"
   # --no-pull skips step 1 (git pull); the fixture dir is deliberately not a git repo, and the
   # git step is not what is under test here.
@@ -365,6 +371,20 @@ assert_failed "$d"
 grep -q "cannot inspect container" "$d/out.txt" \
   || fail "an uninspectable leftover did not stop the deploy; output was: $(tail -8 "$d/out.txt")"
 echo "  inspect-fails -> refused on a leftover it could not classify"; pass_count=$((pass_count+1))
+
+# --- the recheck query ALSO fails: still refuse, never skip -------------------
+# Whatever stops `docker inspect` answering usually stops `docker ps` answering too, so this is the
+# likely shape of the case above rather than an exotic one. "Query returned nothing" and "query
+# failed" must not collapse into the same branch: reading a failed query as "the container is gone"
+# would skip the one leftover the guard could not classify, and proceed.
+d=$(PREEXISTING="ui" INSPECT_FAILS="cid-ui" PS_ID_FAILS=1 run_deploy inspect-and-ps-fail server)
+assert_failed "$d"
+grep -q "cannot confirm whether it is still there" "$d/out.txt" \
+  || fail "a failed re-query was treated as proof the container vanished; output was: $(tail -8 "$d/out.txt")"
+for verb in 'pull ' 'up -d'; do
+  grep -qF "$verb" "$d/calls.txt" && fail "ran '$verb' despite being unable to classify a leftover"
+done
+echo "  inspect+ps-fail -> refused when it could not confirm the leftover was gone"; pass_count=$((pass_count+1))
 
 # --- a concurrent deploy of the same project: refuse -------------------------
 # The stale-service check is a point-in-time snapshot and everything it protects happens after it.

--- a/scripts/test-deploy-services.sh
+++ b/scripts/test-deploy-services.sh
@@ -78,20 +78,29 @@ if [ "${1:-}" = "compose" ]; then
   exit 0
 fi
 
-# `docker ps -aq --filter label=...project=X --filter label=...service=Y` - deploy.sh's check for
+# `docker ps -q --filter label=...project=X --filter label=...service=Y` - deploy.sh's check for
 # services this compose file dropped that are still running. $PREEXISTING lists the services a
-# PREVIOUS deploy left containers for, so a case can model "full stack already running" and assert
-# what a slimmed redeploy does about it. $PREEXISTING_ONEOFF models a `docker compose run` job,
-# which carries the same project+service labels and is excluded only by oneoff=False.
+# PREVIOUS deploy left RUNNING containers for, so a case can model "full stack already running" and
+# assert what a slimmed redeploy does about it. $PREEXISTING_ONEOFF models a `docker compose run`
+# job, which carries the same project+service labels and is excluded only by oneoff=False.
+#
+# $PREEXISTING_EXITED models leftovers that are no longer serving. Real `docker ps` hides those
+# unless `-a` is passed, so the stub keys off the flag rather than ignoring it: that is what lets a
+# case assert a slim deploy PROCEEDS past an inert leftover, and what makes re-adding `-a` to
+# deploy.sh fail that case instead of silently passing it.
 if [ "${1:-}" = "ps" ]; then
-  svc=""; want_service_only=0
+  svc=""; want_service_only=0; want_all=0
   for a in "$@"; do
     case "$a" in
+      -a|-aq|-qa|--all) want_all=1 ;;
       *com.docker.compose.service=*) svc="${a##*=}" ;;
       *com.docker.compose.oneoff=False) want_service_only=1 ;;
     esac
   done
   case " ${PREEXISTING:-} " in *" $svc "*) echo "cid-$svc" ;; esac
+  if [ "$want_all" = "1" ]; then
+    case " ${PREEXISTING_EXITED:-} " in *" $svc "*) echo "cid-exited-$svc" ;; esac
+  fi
   if [ "$want_service_only" = "0" ]; then
     case " ${PREEXISTING_ONEOFF:-} " in *" $svc "*) echo "cid-oneoff-$svc" ;; esac
   fi
@@ -136,6 +145,7 @@ run_deploy() { # <name> <service>...
   export CALLS="$dir/calls.txt"
   export PREEXISTING="${PREEXISTING:-}"
   export PREEXISTING_ONEOFF="${PREEXISTING_ONEOFF:-}"
+  export PREEXISTING_EXITED="${PREEXISTING_EXITED:-}"
   : > "$CALLS"
   # --no-pull skips step 1 (git pull); the fixture dir is deliberately not a git repo, and the
   # git step is not what is under test here.
@@ -248,6 +258,31 @@ assert_succeeded "$d"
 assert_pulled "$d" "server"
 assert_restarted "$d" server
 echo "  slim-clean  -> deployed normally when the dropped services left nothing behind"; pass_count=$((pass_count+1))
+
+# --- slimming past INERT leftovers: also just deploys -------------------------
+# The refusal exists because a dropped service would keep SERVING its old image. An exited
+# container serves nothing and holds no ports, so it is not that hazard - and every host that has
+# ever run the full stack accumulates them. Refusing here would make the documented slim deploy
+# fail on exactly the hosts it is meant for, and send the operator to force-remove something
+# already inert. It must deploy, and must not name the inert containers as a reason to stop.
+d=$(PREEXISTING_EXITED="ui internal-service" run_deploy slim-exited server)
+assert_succeeded "$d"
+assert_pulled "$d" "server"
+assert_restarted "$d" server
+grep -q "cid-exited-" "$d/out.txt" \
+  && fail "an exited container was reported as a service that is still running"
+echo "  slim-exited -> deployed past exited leftovers instead of refusing over them"; pass_count=$((pass_count+1))
+
+# --- a RUNNING leftover still refuses, even beside exited ones ----------------
+# Pins the boundary from the other side: narrowing the query to running containers must not have
+# narrowed it into missing the hazard it exists to catch.
+d=$(PREEXISTING="ui" PREEXISTING_EXITED="internal-service" run_deploy slim-mixed server)
+assert_failed "$d"
+grep -q "docker rm -f cid-ui" "$d/out.txt" \
+  || fail "a running leftover was not reported when an exited one was also present; output was: $(tail -8 "$d/out.txt")"
+grep -q "cid-exited-" "$d/out.txt" \
+  && fail "an exited container was listed alongside the running one the operator must clear"
+echo "  slim-mixed  -> refused on the running leftover, ignored the exited one"; pass_count=$((pass_count+1))
 
 # --- no server: must abort BEFORE restarting anything ------------------------
 d=$(run_deploy no-server ui)

--- a/scripts/test-deploy-services.sh
+++ b/scripts/test-deploy-services.sh
@@ -84,26 +84,54 @@ fi
 # assert what a slimmed redeploy does about it. $PREEXISTING_ONEOFF models a `docker compose run`
 # job, which carries the same project+service labels and is excluded only by oneoff=False.
 #
-# $PREEXISTING_EXITED models leftovers that are no longer serving. Real `docker ps` hides those
-# unless `-a` is passed, so the stub keys off the flag rather than ignoring it: that is what lets a
-# case assert a slim deploy PROCEEDS past an inert leftover, and what makes re-adding `-a` to
-# deploy.sh fail that case instead of silently passing it.
+# $PREEXISTING_EXITED and $PREEXISTING_LATENT model leftovers that are not serving right now. Real
+# `docker ps` hides those unless `-a` is passed, so the stub keys off the flag rather than ignoring
+# it - a deploy that queried only running containers would never see them, which is the regression
+# the latent case below is built to catch.
+#
+# The two differ only in restart policy, which `docker inspect` reports: EXITED is
+# `unless-stopped` and stays down, LATENT is `always` and comes back the next time the daemon
+# starts. That distinction is the whole point of inspecting rather than trusting the state.
 if [ "${1:-}" = "ps" ]; then
-  svc=""; want_service_only=0; want_all=0
+  svc=""; want_service_only=0; want_all=0; by_id=""
   for a in "$@"; do
     case "$a" in
       -a|-aq|-qa|--all) want_all=1 ;;
       *com.docker.compose.service=*) svc="${a##*=}" ;;
       *com.docker.compose.oneoff=False) want_service_only=1 ;;
+      id=*) by_id="${a#id=}" ;;
     esac
   done
+  # `ps -aq --filter id=X` is deploy.sh re-checking whether a container it failed to inspect is
+  # still there. Nothing in these fixtures removes containers mid-run, so it still exists.
+  if [ -n "$by_id" ]; then echo "$by_id"; exit 0; fi
   case " ${PREEXISTING:-} " in *" $svc "*) echo "cid-$svc" ;; esac
+  # Real `docker ps` lists paused and restarting containers WITHOUT -a: both are still holding
+  # their published ports, so they belong with the running ones, not with the exited ones.
+  case " ${PREEXISTING_PAUSED:-} " in *" $svc "*) echo "cid-paused-$svc" ;; esac
   if [ "$want_all" = "1" ]; then
     case " ${PREEXISTING_EXITED:-} " in *" $svc "*) echo "cid-exited-$svc" ;; esac
+    case " ${PREEXISTING_LATENT:-} " in *" $svc "*) echo "cid-latent-$svc" ;; esac
   fi
   if [ "$want_service_only" = "0" ]; then
     case " ${PREEXISTING_ONEOFF:-} " in *" $svc "*) echo "cid-oneoff-$svc" ;; esac
   fi
+  exit 0
+fi
+
+# `docker inspect -f '{{.State.Status}} {{.HostConfig.RestartPolicy.Name}}' <cid>` - how deploy.sh
+# tells a leftover that is merely dead from one that is waiting for the next daemon start.
+if [ "${1:-}" = "inspect" ]; then
+  for cid; do :; done   # last argument
+  # $INSPECT_FAILS models a container docker will list but not describe. deploy.sh must refuse on
+  # it rather than assume it is harmless, so the harness needs a way to produce one.
+  case " ${INSPECT_FAILS:-} " in *" $cid "*) exit 1 ;; esac
+  case "$cid" in
+    cid-exited-*) echo "exited unless-stopped" ;;
+    cid-paused-*) echo "paused unless-stopped" ;;
+    cid-latent-*) echo "exited always" ;;
+    *)            echo "running unless-stopped" ;;
+  esac
   exit 0
 fi
 
@@ -146,6 +174,9 @@ run_deploy() { # <name> <service>...
   export PREEXISTING="${PREEXISTING:-}"
   export PREEXISTING_ONEOFF="${PREEXISTING_ONEOFF:-}"
   export PREEXISTING_EXITED="${PREEXISTING_EXITED:-}"
+  export PREEXISTING_LATENT="${PREEXISTING_LATENT:-}"
+  export PREEXISTING_PAUSED="${PREEXISTING_PAUSED:-}"
+  export INSPECT_FAILS="${INSPECT_FAILS:-}"
   : > "$CALLS"
   # --no-pull skips step 1 (git pull); the fixture dir is deliberately not a git repo, and the
   # git step is not what is under test here.
@@ -154,8 +185,13 @@ run_deploy() { # <name> <service>...
   # would let a deploy that makes every expected call and then dies in a later step pass the
   # whole suite - "it called the right things" is not the same claim as "it completed", and this
   # test exists to make the second one.
+  #
+  # HOME is redirected into the fixture so the project lock deploy.sh takes lands here rather than
+  # in the real user's runtime directory - otherwise the suite would contend with an actual deploy
+  # on the same machine, and leave files behind outside its own workspace.
   local status=0
-  ( cd "$dir" && PATH="$WORK/bin:$PATH" bash ./deploy.sh --no-pull >"$dir/out.txt" 2>&1 ) || status=$?
+  ( cd "$dir" && HOME="$dir" PATH="$WORK/bin:$PATH" \
+      bash ./deploy.sh --no-pull >"$dir/out.txt" 2>&1 ) || status=$?
   echo "$status" > "$dir/status.txt"
   echo "$dir"
 }
@@ -241,7 +277,7 @@ for verb in 'pull ' 'up -d'; do
 done
 grep -q "no longer declares" "$d/out.txt" \
   || fail "the refusal did not name the dropped services; output was: $(tail -8 "$d/out.txt")"
-grep -q "docker rm -f cid-ui" "$d/out.txt" \
+grep -qE "docker rm -f .*cid-ui" "$d/out.txt" \
   || fail "the refusal did not print the command to clear the leftovers; output was: $(tail -8 "$d/out.txt")"
 # A `docker compose run` job shares the project+service labels. It is somebody's migration or
 # debugging session, not a stale service, and must not be reported as one.
@@ -260,29 +296,67 @@ assert_restarted "$d" server
 echo "  slim-clean  -> deployed normally when the dropped services left nothing behind"; pass_count=$((pass_count+1))
 
 # --- slimming past INERT leftovers: also just deploys -------------------------
-# The refusal exists because a dropped service would keep SERVING its old image. An exited
-# container serves nothing and holds no ports, so it is not that hazard - and every host that has
-# ever run the full stack accumulates them. Refusing here would make the documented slim deploy
-# fail on exactly the hosts it is meant for, and send the operator to force-remove something
-# already inert. It must deploy, and must not name the inert containers as a reason to stop.
+# An exited `unless-stopped` container serves nothing, holds no ports, and cannot come back on its
+# own - the policy leaves a hand-stopped container stopped even across a daemon restart. Every host
+# that has ever run the full stack accumulates these, so refusing over them would fail the
+# documented slim deploy on exactly the hosts it is meant for, and send the operator to force-remove
+# something already harmless.
 d=$(PREEXISTING_EXITED="ui internal-service" run_deploy slim-exited server)
 assert_succeeded "$d"
 assert_pulled "$d" "server"
 assert_restarted "$d" server
 grep -q "cid-exited-" "$d/out.txt" \
-  && fail "an exited container was reported as a service that is still running"
-echo "  slim-exited -> deployed past exited leftovers instead of refusing over them"; pass_count=$((pass_count+1))
+  && fail "an inert exited container was reported as a stale service"
+echo "  slim-exited -> deployed past inert exited leftovers instead of refusing over them"; pass_count=$((pass_count+1))
+
+# --- an exited container that WILL come back: refuse -------------------------
+# `restart: always` is the one policy that starts a hand-stopped container again the next time the
+# Docker daemon does. Such a container is not serving now but is a stale service waiting on the
+# next host reboot, so letting the deploy report success over it is the silent half-applied
+# topology this guard exists to prevent - just deferred. Only the restart policy separates this
+# from the case above, which is why the state alone cannot decide it.
+d=$(PREEXISTING_LATENT="ui" run_deploy slim-latent server)
+assert_failed "$d"
+for verb in 'pull ' 'up -d'; do
+  grep -qF "$verb" "$d/calls.txt" && fail "refused only after running '$verb'; it must refuse before mutating anything"
+done
+grep -qE "docker rm -f .*cid-latent-ui" "$d/out.txt" \
+  || fail "an exited restart:always leftover was not reported; output was: $(tail -8 "$d/out.txt")"
+grep -q "restarts on reboot" "$d/out.txt" \
+  || fail "the refusal did not say WHY a stopped container blocks the deploy; output was: $(tail -8 "$d/out.txt")"
+echo "  slim-latent -> refused on an exited restart:always leftover before mutating anything"; pass_count=$((pass_count+1))
+
+# --- a PAUSED leftover refuses too -------------------------------------------
+# A paused container is frozen, not gone: the daemon still holds its published ports, so a slim
+# deploy that walked past one would leave :8080 bound by a service its compose file no longer
+# declares. "Not running" is not the same as "not serving", which is why the classification keys
+# off the full set of live states rather than a single equality against `running`.
+d=$(PREEXISTING_PAUSED="ui" run_deploy slim-paused server)
+assert_failed "$d"
+grep -qE "docker rm -f .*cid-paused-ui" "$d/out.txt" \
+  || fail "a paused leftover was not reported; output was: $(tail -8 "$d/out.txt")"
+echo "  slim-paused -> refused on a paused leftover still holding its ports"; pass_count=$((pass_count+1))
 
 # --- a RUNNING leftover still refuses, even beside exited ones ----------------
-# Pins the boundary from the other side: narrowing the query to running containers must not have
-# narrowed it into missing the hazard it exists to catch.
+# Pins the boundary from the other side: classifying by policy must not have classified away the
+# plain running container the guard exists to catch.
 d=$(PREEXISTING="ui" PREEXISTING_EXITED="internal-service" run_deploy slim-mixed server)
 assert_failed "$d"
-grep -q "docker rm -f cid-ui" "$d/out.txt" \
+grep -qE "docker rm -f .*cid-ui" "$d/out.txt" \
   || fail "a running leftover was not reported when an exited one was also present; output was: $(tail -8 "$d/out.txt")"
 grep -q "cid-exited-" "$d/out.txt" \
-  && fail "an exited container was listed alongside the running one the operator must clear"
-echo "  slim-mixed  -> refused on the running leftover, ignored the exited one"; pass_count=$((pass_count+1))
+  && fail "an inert container was listed alongside the running one the operator must clear"
+echo "  slim-mixed  -> refused on the running leftover, ignored the inert one"; pass_count=$((pass_count+1))
+
+# --- a leftover docker will list but not describe: refuse --------------------
+# Whether a stopped leftover is inert or latent is decided entirely by its restart policy, so a
+# container that cannot be inspected cannot be classified. Treating that as "probably fine" would
+# put the guard's one unanswerable case on the silent-success side; it refuses instead.
+d=$(PREEXISTING="ui" INSPECT_FAILS="cid-ui" run_deploy inspect-fails server)
+assert_failed "$d"
+grep -q "cannot inspect container" "$d/out.txt" \
+  || fail "an uninspectable leftover did not stop the deploy; output was: $(tail -8 "$d/out.txt")"
+echo "  inspect-fails -> refused on a leftover it could not classify"; pass_count=$((pass_count+1))
 
 # --- no server: must abort BEFORE restarting anything ------------------------
 d=$(run_deploy no-server ui)

--- a/scripts/test-deploy-services.sh
+++ b/scripts/test-deploy-services.sh
@@ -58,7 +58,7 @@ if [ "${1:-}" = "compose" ]; then
         awk '/^services:/{f=1;next} f&&/^[a-z]/{exit} f&&/^  [a-zA-Z0-9_-]+:/{gsub(/[ :]/,"");print}' "$file"
       else
         # `config --format json` - emit just what deploy.sh reads: .services[x].image
-        printf '{"services":{'
+        printf '{"name":"stubproj","services":{'
         first=1
         for s in $(awk '/^services:/{f=1;next} f&&/^[a-z]/{exit} f&&/^  [a-zA-Z0-9_-]+:/{gsub(/[ :]/,"");print}' "$file"); do
           [ $first -eq 0 ] && printf ','
@@ -75,6 +75,26 @@ if [ "${1:-}" = "compose" ]; then
     pull|up|logs|down) : ;;
     *) : ;;
   esac
+  exit 0
+fi
+
+# `docker ps -aq --filter label=...project=X --filter label=...service=Y` - deploy.sh's check for
+# services this compose file dropped that are still running. $PREEXISTING lists the services a
+# PREVIOUS deploy left containers for, so a case can model "full stack already running" and assert
+# what a slimmed redeploy does about it. $PREEXISTING_ONEOFF models a `docker compose run` job,
+# which carries the same project+service labels and is excluded only by oneoff=False.
+if [ "${1:-}" = "ps" ]; then
+  svc=""; want_service_only=0
+  for a in "$@"; do
+    case "$a" in
+      *com.docker.compose.service=*) svc="${a##*=}" ;;
+      *com.docker.compose.oneoff=False) want_service_only=1 ;;
+    esac
+  done
+  case " ${PREEXISTING:-} " in *" $svc "*) echo "cid-$svc" ;; esac
+  if [ "$want_service_only" = "0" ]; then
+    case " ${PREEXISTING_ONEOFF:-} " in *" $svc "*) echo "cid-oneoff-$svc" ;; esac
+  fi
   exit 0
 fi
 
@@ -114,6 +134,8 @@ run_deploy() { # <name> <service>...
   # deploy.sh requires a .env with a real master password.
   printf 'WORKSPACE_MASTER_PASSWORD=test-password-not-a-placeholder\n' > "$dir/.env"
   export CALLS="$dir/calls.txt"
+  export PREEXISTING="${PREEXISTING:-}"
+  export PREEXISTING_ONEOFF="${PREEXISTING_ONEOFF:-}"
   : > "$CALLS"
   # --no-pull skips step 1 (git pull); the fixture dir is deliberately not a git repo, and the
   # git step is not what is under test here.
@@ -194,6 +216,38 @@ assert_pulled "$d" "server internal-service"
 assert_restarted "$d" server internal-service
 assert_never_mentions "$d" ui
 echo "  server-is   -> never touched ui"; pass_count=$((pass_count+1))
+
+# --- slimming an EXISTING full stack: refuse, do not half-apply --------------
+# `docker compose up` leaves containers for undeclared services running and merely warns, so
+# guarding the restart alone would turn a loud failure into a silent one: the deploy would succeed
+# while the old ui kept serving its previous image. The deploy must refuse BEFORE pulling or
+# restarting - leaving the running stack exactly as it was - and say how to clear the leftovers.
+d=$(PREEXISTING="server internal-service ui" PREEXISTING_ONEOFF="ui" run_deploy slim-transition server)
+assert_failed "$d"
+for verb in 'pull ' 'up -d'; do
+  if grep -qF "$verb" "$d/calls.txt"; then
+    fail "a deploy that cannot be completed still ran '$verb' - it must refuse before mutating anything: $(grep -F "$verb" "$d/calls.txt" | head -1)"
+  fi
+done
+grep -q "no longer declares" "$d/out.txt" \
+  || fail "the refusal did not name the dropped services; output was: $(tail -8 "$d/out.txt")"
+grep -q "docker rm -f cid-ui" "$d/out.txt" \
+  || fail "the refusal did not print the command to clear the leftovers; output was: $(tail -8 "$d/out.txt")"
+# A `docker compose run` job shares the project+service labels. It is somebody's migration or
+# debugging session, not a stale service, and must not be reported as one.
+grep -q "cid-oneoff-" "$d/out.txt" \
+  && fail "a 'docker compose run' one-off container was reported as a stale service"
+echo "  slim-transition -> refused before pulling or restarting, named the leftovers and how to clear them"; pass_count=$((pass_count+1))
+
+# --- slimming with nothing left over: just deploys ---------------------------
+# The refusal is about leftovers, not about the shape. A server-only deploy on a host where ui was
+# never running has nothing to reconcile and must proceed untouched - otherwise the documented
+# slim option would need a manual step it does not actually need.
+d=$(run_deploy slim-clean server)
+assert_succeeded "$d"
+assert_pulled "$d" "server"
+assert_restarted "$d" server
+echo "  slim-clean  -> deployed normally when the dropped services left nothing behind"; pass_count=$((pass_count+1))
 
 # --- no server: must abort BEFORE restarting anything ------------------------
 d=$(run_deploy no-server ui)

--- a/scripts/test-deploy-services.sh
+++ b/scripts/test-deploy-services.sh
@@ -196,6 +196,12 @@ run_deploy() { # <name> <service>...
   # in the real user's runtime directory - otherwise the suite would contend with an actual deploy
   # on the same machine, and leave files behind outside its own workspace.
   local status=0
+  if [ -n "${HOLD_CHECKOUT:-}" ]; then
+    # Model a deploy already running from this same checkout: hold the directory's own lock. The
+    # second run must refuse before its git step, not after mutating the shared working tree.
+    exec 7<"$dir"
+    flock -n 7 || fail "test harness could not take the checkout lock it is meant to hold"
+  fi
   if [ -n "${HOLD_LOCK:-}" ]; then
     # Model a deploy of the same project already in flight: hold its lock across the run. The
     # second deploy must refuse instead of interleaving with the first.
@@ -206,6 +212,7 @@ run_deploy() { # <name> <service>...
   ( cd "$dir" && HOME="$dir" PATH="$WORK/bin:$PATH" \
       bash ./deploy.sh --no-pull >"$dir/out.txt" 2>&1 ) || status=$?
   [ -n "${HOLD_LOCK:-}" ] && exec 8>&-
+  [ -n "${HOLD_CHECKOUT:-}" ] && exec 7<&-
   echo "$status" > "$dir/status.txt"
   echo "$dir"
 }
@@ -399,6 +406,20 @@ done
 grep -q "another deploy of project" "$d/out.txt" \
   || fail "the refusal did not say a concurrent deploy holds the lock; output was: $(tail -8 "$d/out.txt")"
 echo "  concurrent  -> refused while another deploy held the project lock"; pass_count=$((pass_count+1))
+
+# --- a second deploy from the SAME CHECKOUT: refuse before the git step -------
+# The project lock cannot cover this: it is keyed on the compose project name, so it cannot be
+# taken until the compose file has been read - by which point a competing run has already pulled
+# new code into the shared working tree. The first run would then verify one revision of the
+# compose file and restart against another. The checkout lock is taken before anything reads or
+# writes the directory, so the second run stops there.
+d=$(HOLD_CHECKOUT=1 run_deploy same-checkout server ui internal-service)
+assert_failed "$d"
+grep -q "already running from this checkout" "$d/out.txt" \
+  || fail "a second deploy from the same checkout was not refused; output was: $(tail -8 "$d/out.txt")"
+grep -q "\[1/4\]" "$d/out.txt" \
+  && fail "the refusal came after step 1 had already run against the shared working tree"
+echo "  same-checkout -> refused before touching the shared working tree"; pass_count=$((pass_count+1))
 
 # --- the lock must not outlive the deploy that took it -----------------------
 # Same fixture, so the same HOME and the same lock file, run twice in a row. The kernel drops the

--- a/scripts/test-deploy-services.sh
+++ b/scripts/test-deploy-services.sh
@@ -1,0 +1,185 @@
+#!/usr/bin/env bash
+#
+# Integration test for deploy.sh's service selection AND the restart guards.
+#
+# WHY THIS EXISTS RATHER THAN JUST TESTING THE SELECTOR
+#
+# scripts/select-deploy-services.sh is unit-tested, but that only proves the *list* is right.
+# The defect this guards against lives one layer down: an unconditional
+# `up -d --no-deps ui` on a deployment that has no ui service. That aborts AFTER the server
+# has already been swapped to its new image - a half-applied deploy, which is the single
+# outcome deploy.sh's ordering exists to prevent. A selector-only test passes happily while
+# that bug is reintroduced.
+#
+# So this runs the REAL deploy.sh end to end against fixture compose files, with `docker`
+# replaced by a recording stub on PATH, and asserts what deploy.sh actually *did*: which
+# services it pulled, which it restarted, and - the point - that it never touched a service
+# the compose file does not declare.
+#
+# The stub records every invocation to $CALLS. Nothing real is pulled, started or restarted.
+#
+# Usage: scripts/test-deploy-services.sh        (from the repo root)
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+fail() { echo "::error::$*"; exit 1; }
+pass_count=0
+
+# ---------------------------------------------------------------------------
+# The docker stub. Answers only what deploy.sh actually asks for, and records
+# every call so the assertions can inspect them.
+# ---------------------------------------------------------------------------
+make_stub() {
+  mkdir -p "$WORK/bin"
+  cat > "$WORK/bin/docker" <<'STUB'
+#!/usr/bin/env bash
+echo "$*" >> "$CALLS"
+
+# `compose -f <file> <subcommand> ...` - find the subcommand after the -f pair.
+if [ "${1:-}" = "compose" ]; then
+  shift
+  file=""
+  while [ $# -gt 0 ]; do
+    case "$1" in
+      -f) file="$2"; shift 2 ;;
+      --profile) shift 2 ;;
+      *) break ;;
+    esac
+  done
+  sub="${1:-}"; shift || true
+  case "$sub" in
+    config)
+      if [ "${1:-}" = "--services" ]; then
+        # Service names are the top-level keys under `services:`.
+        awk '/^services:/{f=1;next} f&&/^[a-z]/{exit} f&&/^  [a-zA-Z0-9_-]+:/{gsub(/[ :]/,"");print}' "$file"
+      else
+        # `config --format json` - emit just what deploy.sh reads: .services[x].image
+        printf '{"services":{'
+        first=1
+        for s in $(awk '/^services:/{f=1;next} f&&/^[a-z]/{exit} f&&/^  [a-zA-Z0-9_-]+:/{gsub(/[ :]/,"");print}' "$file"); do
+          [ $first -eq 0 ] && printf ','
+          printf '"%s":{"image":"ghcr.io/avarok-cybersecurity/citadel-workspace-%s:latest"}' "$s" "$s"
+          first=0
+        done
+        printf '}}'
+      fi
+      ;;
+    ps)
+      # deploy.sh's wait_for_port reads .State/.Health from the first entry.
+      printf '{"Name":"stub","State":"running","Health":"healthy"}\n'
+      ;;
+    pull|up|logs|down) : ;;
+    *) : ;;
+  esac
+  exit 0
+fi
+
+# verify-image-revisions.sh calls `docker image inspect --format ... <ref>`
+if [ "${1:-}" = "image" ] && [ "${2:-}" = "inspect" ]; then
+  echo "testrevision0000"
+  exit 0
+fi
+exit 0
+STUB
+  chmod +x "$WORK/bin/docker"
+}
+
+# ---------------------------------------------------------------------------
+# Fixtures: minimal compose files with only the services under test. Written by
+# hand (not derived from the production file) so the stub's simple parser is
+# sufficient and the test states its inputs explicitly.
+# ---------------------------------------------------------------------------
+write_fixture() { # <path> <service>...
+  local path="$1"; shift
+  {
+    echo "services:"
+    for s in "$@"; do
+      echo "  $s:"
+      echo "    image: ghcr.io/avarok-cybersecurity/citadel-workspace-$s:latest"
+    done
+  } > "$path"
+}
+
+run_deploy() { # <name> <service>...
+  local name="$1"; shift
+  local dir="$WORK/$name"
+  mkdir -p "$dir/scripts"
+  write_fixture "$dir/docker-compose.production.yml" "$@"
+  cp "$REPO_ROOT/scripts/select-deploy-services.sh" "$REPO_ROOT/scripts/verify-image-revisions.sh" "$dir/scripts/"
+  cp "$REPO_ROOT/deploy.sh" "$dir/deploy.sh"
+  # deploy.sh requires a .env with a real master password.
+  printf 'WORKSPACE_MASTER_PASSWORD=test-password-not-a-placeholder\n' > "$dir/.env"
+  export CALLS="$dir/calls.txt"
+  : > "$CALLS"
+  # --no-pull skips step 1 (git pull); the fixture dir is deliberately not a git repo, and the
+  # git step is not what is under test here.
+  ( cd "$dir" && PATH="$WORK/bin:$PATH" bash ./deploy.sh --no-pull >"$dir/out.txt" 2>&1 ) || true
+  echo "$dir"
+}
+
+assert_pulled() { # <dir> <expected space-separated>
+  local got
+  # `|| true` on each stage: a non-matching grep exits 1, which under `set -e` would abort the
+  # whole run silently instead of reporting which assertion failed.
+  got=$(grep -E '^compose .* pull ' "$1/calls.txt" 2>/dev/null | head -1 | sed 's/.* pull //' || true)
+  [ "$got" = "$2" ] || fail "pull was [$got], expected [$2] (see $1/out.txt)"
+}
+
+assert_restarted() { # <dir> <service>...
+  local dir="$1"; shift
+  local got
+  got=$(grep -oE 'up -d --no-deps [a-z-]+' "$dir/calls.txt" 2>/dev/null | awk '{print $NF}' | tr '\n' ' ' | sed 's/ $//' || true)
+  [ "$got" = "$*" ] || fail "restarts were [$got], expected [$*] (see $dir/out.txt)"
+}
+
+assert_never_mentions() { # <dir> <service>
+  if grep -qE "up -d --no-deps $2\b" "$1/calls.txt"; then
+    fail "deploy.sh tried to restart '$2', which this compose file does not declare - that is the half-applied deploy this guard exists to prevent"
+  fi
+}
+
+echo "== deploy.sh service-selection integration test =="
+make_stub
+
+# --- full stack -------------------------------------------------------------
+d=$(run_deploy full server internal-service ui)
+assert_pulled "$d" "server internal-service ui"
+assert_restarted "$d" server internal-service ui
+echo "  full        -> pulled and restarted all three"; pass_count=$((pass_count+1))
+
+# --- server only: the documented slimmed deployment --------------------------
+d=$(run_deploy server-only server)
+assert_pulled "$d" "server"
+assert_restarted "$d" server
+assert_never_mentions "$d" ui
+assert_never_mentions "$d" internal-service
+echo "  server-only -> pulled/restarted server only; never touched ui or internal-service"; pass_count=$((pass_count+1))
+
+# --- server + ui ------------------------------------------------------------
+d=$(run_deploy server-ui server ui)
+assert_pulled "$d" "server ui"
+assert_restarted "$d" server ui
+assert_never_mentions "$d" internal-service
+echo "  server-ui   -> never touched internal-service"; pass_count=$((pass_count+1))
+
+# --- server + internal-service ----------------------------------------------
+d=$(run_deploy server-is server internal-service)
+assert_pulled "$d" "server internal-service"
+assert_restarted "$d" server internal-service
+assert_never_mentions "$d" ui
+echo "  server-is   -> never touched ui"; pass_count=$((pass_count+1))
+
+# --- no server: must abort BEFORE restarting anything ------------------------
+d=$(run_deploy no-server ui)
+if grep -qE 'up -d' "$d/calls.txt"; then
+  fail "a compose file with no 'server' service still reached the restart phase; it must abort first"
+fi
+grep -qi "no 'server' service" "$d/out.txt" \
+  || fail "no-server case did not report why it aborted; output was: $(head -3 "$d/out.txt")"
+echo "  no-server   -> aborted before any restart, with a clear reason"; pass_count=$((pass_count+1))
+
+echo "== all $pass_count deploy-selection assertions passed =="

--- a/scripts/test-deploy-services.sh
+++ b/scripts/test-deploy-services.sh
@@ -190,8 +190,16 @@ run_deploy() { # <name> <service>...
   # in the real user's runtime directory - otherwise the suite would contend with an actual deploy
   # on the same machine, and leave files behind outside its own workspace.
   local status=0
+  if [ -n "${HOLD_LOCK:-}" ]; then
+    # Model a deploy of the same project already in flight: hold its lock across the run. The
+    # second deploy must refuse instead of interleaving with the first.
+    mkdir -p "$dir/.cache/citadel-deploy"
+    exec 8>"$dir/.cache/citadel-deploy/stubproj.lock"
+    flock -n 8 || fail "test harness could not take the lock it is meant to hold"
+  fi
   ( cd "$dir" && HOME="$dir" PATH="$WORK/bin:$PATH" \
       bash ./deploy.sh --no-pull >"$dir/out.txt" 2>&1 ) || status=$?
+  [ -n "${HOLD_LOCK:-}" ] && exec 8>&-
   echo "$status" > "$dir/status.txt"
   echo "$dir"
 }
@@ -357,6 +365,33 @@ assert_failed "$d"
 grep -q "cannot inspect container" "$d/out.txt" \
   || fail "an uninspectable leftover did not stop the deploy; output was: $(tail -8 "$d/out.txt")"
 echo "  inspect-fails -> refused on a leftover it could not classify"; pass_count=$((pass_count+1))
+
+# --- a concurrent deploy of the same project: refuse -------------------------
+# The stale-service check is a point-in-time snapshot and everything it protects happens after it.
+# A second deploy of the same project can start a dropped service's container in that window,
+# leaving this run to report success over a topology it never verified. It must refuse to start
+# while another deploy holds the project lock, and must do so before touching anything.
+d=$(HOLD_LOCK=1 run_deploy concurrent server ui internal-service)
+assert_failed "$d"
+for verb in 'pull ' 'up -d'; do
+  grep -qF "$verb" "$d/calls.txt" && fail "a deploy that could not take the lock still ran '$verb'"
+done
+grep -q "another deploy of project" "$d/out.txt" \
+  || fail "the refusal did not say a concurrent deploy holds the lock; output was: $(tail -8 "$d/out.txt")"
+echo "  concurrent  -> refused while another deploy held the project lock"; pass_count=$((pass_count+1))
+
+# --- the lock must not outlive the deploy that took it -----------------------
+# Same fixture, so the same HOME and the same lock file, run twice in a row. The kernel drops the
+# lock when the process exits and the file is deliberately left in place; if that ever became a
+# lock that had to be released explicitly - a trap, a stale marker, a lock directory - the second
+# run would refuse and every deploy after the first would be blocked until someone cleaned up.
+d=$(run_deploy lock-reuse server)
+assert_succeeded "$d"
+d=$(run_deploy lock-reuse server)
+assert_succeeded "$d"
+grep -q "another deploy of project" "$d/out.txt" \
+  && fail "the lock outlived the deploy that took it; the next run was refused"
+echo "  lock-reuse  -> a second sequential deploy took the same lock again"; pass_count=$((pass_count+1))
 
 # --- no server: must abort BEFORE restarting anything ------------------------
 d=$(run_deploy no-server ui)

--- a/scripts/test-deploy-services.sh
+++ b/scripts/test-deploy-services.sh
@@ -117,8 +117,26 @@ run_deploy() { # <name> <service>...
   : > "$CALLS"
   # --no-pull skips step 1 (git pull); the fixture dir is deliberately not a git repo, and the
   # git step is not what is under test here.
-  ( cd "$dir" && PATH="$WORK/bin:$PATH" bash ./deploy.sh --no-pull >"$dir/out.txt" 2>&1 ) || true
+  #
+  # The status is RECORDED rather than discarded. Asserting only on the recorded docker calls
+  # would let a deploy that makes every expected call and then dies in a later step pass the
+  # whole suite - "it called the right things" is not the same claim as "it completed", and this
+  # test exists to make the second one.
+  local status=0
+  ( cd "$dir" && PATH="$WORK/bin:$PATH" bash ./deploy.sh --no-pull >"$dir/out.txt" 2>&1 ) || status=$?
+  echo "$status" > "$dir/status.txt"
   echo "$dir"
+}
+
+assert_succeeded() { # <dir>
+  local got; got=$(cat "$1/status.txt")
+  [ "$got" = "0" ] || fail "deploy.sh exited $got, expected 0. Output:
+$(cat "$1/out.txt")"
+}
+
+assert_failed() { # <dir>
+  local got; got=$(cat "$1/status.txt")
+  [ "$got" != "0" ] || fail "deploy.sh exited 0 on a compose file it must reject (see $1/out.txt)"
 }
 
 assert_pulled() { # <dir> <expected space-separated>
@@ -147,20 +165,23 @@ make_stub
 
 # --- full stack -------------------------------------------------------------
 d=$(run_deploy full server internal-service ui)
+assert_succeeded "$d"
 assert_pulled "$d" "server internal-service ui"
 assert_restarted "$d" server internal-service ui
 echo "  full        -> pulled and restarted all three"; pass_count=$((pass_count+1))
 
 # --- server only: the documented slimmed deployment --------------------------
 d=$(run_deploy server-only server)
+assert_succeeded "$d"
 assert_pulled "$d" "server"
 assert_restarted "$d" server
 assert_never_mentions "$d" ui
 assert_never_mentions "$d" internal-service
-echo "  server-only -> pulled/restarted server only; never touched ui or internal-service"; pass_count=$((pass_count+1))
+echo "  server-only -> completed; pulled/restarted server only, never touched ui or internal-service"; pass_count=$((pass_count+1))
 
 # --- server + ui ------------------------------------------------------------
 d=$(run_deploy server-ui server ui)
+assert_succeeded "$d"
 assert_pulled "$d" "server ui"
 assert_restarted "$d" server ui
 assert_never_mentions "$d" internal-service
@@ -168,6 +189,7 @@ echo "  server-ui   -> never touched internal-service"; pass_count=$((pass_count
 
 # --- server + internal-service ----------------------------------------------
 d=$(run_deploy server-is server internal-service)
+assert_succeeded "$d"
 assert_pulled "$d" "server internal-service"
 assert_restarted "$d" server internal-service
 assert_never_mentions "$d" ui
@@ -175,11 +197,12 @@ echo "  server-is   -> never touched ui"; pass_count=$((pass_count+1))
 
 # --- no server: must abort BEFORE restarting anything ------------------------
 d=$(run_deploy no-server ui)
+assert_failed "$d"
 if grep -qE 'up -d' "$d/calls.txt"; then
   fail "a compose file with no 'server' service still reached the restart phase; it must abort first"
 fi
 grep -qi "no 'server' service" "$d/out.txt" \
   || fail "no-server case did not report why it aborted; output was: $(head -3 "$d/out.txt")"
-echo "  no-server   -> aborted before any restart, with a clear reason"; pass_count=$((pass_count+1))
+echo "  no-server   -> exited nonzero before any restart, with a clear reason"; pass_count=$((pass_count+1))
 
 echo "== all $pass_count deploy-selection assertions passed =="

--- a/scripts/verify-image-revisions.sh
+++ b/scripts/verify-image-revisions.sh
@@ -20,12 +20,15 @@
 # gate is a liability. Pulled out here it takes images as arguments, touches no
 # global state, and is exercised directly by CI
 # (.github/workflows/validate.yml -> deploy-gate-tests) against real images with
-# matching, mismatched, and absent labels.
+# matching, mismatched, and absent labels, an image that cannot be inspected at
+# all, and the single-image server-only deployment.
 #
 # Usage:   verify-image-revisions.sh <image> [<image> ...]
-# Exit 0:  all images carry the same revision, OR one or more carry no label at
-#          all (a warning - locally-built and pre-label images are not blocked).
-# Exit 1:  two images carry DIFFERENT revisions.
+# Exit 0:  every image was inspected successfully, AND they all carry the same
+#          revision OR one or more carry no label at all (a warning - locally-built
+#          and pre-label images are not blocked).
+# Exit 1:  an image could not be inspected, or two images carry DIFFERENT revisions.
+# Exit 2:  no images given.
 # =============================================================================
 
 set -euo pipefail
@@ -35,18 +38,23 @@ if [ "$#" -lt 1 ]; then
     exit 2
 fi
 
-# ONE image is a valid deployment, not a usage error.
+# ONE image is a valid deployment, not a usage error - and it deliberately gets NO fast path.
 #
 # docker-compose.production.yml documents that `ui` and `internal-service` are droppable, so a
-# server-only stack legitimately has a single image to check - and a single image is trivially
-# self-consistent, there being nothing to disagree with. Requiring two here aborted that deploy
-# at the release gate AFTER the pull had already succeeded, which is precisely the half-applied
-# failure the caller's service selection exists to avoid. Caught by
-# scripts/test-deploy-services.sh, which runs deploy.sh end to end against a server-only fixture.
-if [ "$#" -eq 1 ]; then
-    echo "Only one image in this deployment ($1); nothing to compare against."
-    exit 0
-fi
+# server-only stack legitimately has a single image to check. Requiring two aborted that deploy
+# at the release gate AFTER the pull had already succeeded - precisely the half-applied failure
+# the caller's service selection exists to avoid.
+#
+# The tempting fix is `[ "$#" -eq 1 ] && exit 0` right here. Do not add it. "Nothing to compare
+# against" removes only the CROSS-image comparison; it does not make the image's provenance
+# unnecessary. Returning early skips image_revision() altogether and with it the
+# un-inspectable-image check below, so a server-only deploy whose pull silently failed, or whose
+# tag does not exist, would sail through the gate built to catch exactly that. The loop below
+# already handles one image correctly: it inspects it, refuses it if it cannot, warns if the
+# label is absent, and finds nothing to disagree with.
+#
+# Pinned by validate.yml -> "A SINGLE image is still inspected". The end-to-end deploy test
+# cannot catch a regression here - its docker stub always inspects successfully.
 
 REVISION_LABEL="org.opencontainers.image.revision"
 
@@ -122,4 +130,11 @@ if [ "$unlabelled" -eq 1 ]; then
     exit 0
 fi
 
-echo "All images are from commit ${reference_rev}."
+# Distinguish the two successes. "All images are from commit X" over a single image would read
+# as a cross-check that never happened; the point of the gate is that images AGREE, and one
+# image agreeing with itself is not evidence of a consistent promotion.
+if [ "$#" -eq 1 ]; then
+    echo "Single-image deployment: ${reference_img} is from commit ${reference_rev} (nothing to cross-check)."
+else
+    echo "All images are from commit ${reference_rev}."
+fi

--- a/scripts/verify-image-revisions.sh
+++ b/scripts/verify-image-revisions.sh
@@ -30,9 +30,22 @@
 
 set -euo pipefail
 
-if [ "$#" -lt 2 ]; then
-    echo "usage: $0 <image> <image> [<image> ...]" >&2
+if [ "$#" -lt 1 ]; then
+    echo "usage: $0 <image> [<image> ...]" >&2
     exit 2
+fi
+
+# ONE image is a valid deployment, not a usage error.
+#
+# docker-compose.production.yml documents that `ui` and `internal-service` are droppable, so a
+# server-only stack legitimately has a single image to check - and a single image is trivially
+# self-consistent, there being nothing to disagree with. Requiring two here aborted that deploy
+# at the release gate AFTER the pull had already succeeded, which is precisely the half-applied
+# failure the caller's service selection exists to avoid. Caught by
+# scripts/test-deploy-services.sh, which runs deploy.sh end to end against a server-only fixture.
+if [ "$#" -eq 1 ]; then
+    echo "Only one image in this deployment ($1); nothing to compare against."
+    exit 0
 fi
 
 REVISION_LABEL="org.opencontainers.image.revision"


### PR DESCRIPTION
## Overview

Fixes a deploy that breaks when an operator follows our own documentation.

`docker-compose.production.yml` documents that `ui` and `internal-service` are droppable for a server-only deployment. But `deploy.sh` restarted them unconditionally:

```bash
docker compose -f "$COMPOSE_FILE" up -d --no-deps ui
```

An operator who took that option got `no such service: ui` — **after** the server had already been swapped to its new image. A half-applied deploy, caused by following the docs.

## What changed

**Pull, revision-check and restart all derive from one selection.** `scripts/select-deploy-services.sh` decides which of the deployable services the compose file actually declares; `deploy.sh` uses that single set for every phase. Getting it wrong in either direction is a half-applied deploy — too few silently skips a declared service while still reporting success, too many restarts onto an image that was never pulled — so the selection is a standalone, directly tested script rather than inline logic wedged between a pull and a production restart.

**A slimmed deploy that would strand a running service refuses.** `docker compose up` does not remove containers for services the file no longer declares; it warns about orphans and leaves them running. Guarding the restart alone would therefore turn the loud failure above into a silent one — deploy succeeds, old `ui` keeps serving its previous image on `:8080`. Instead the deploy stops **before** pulling or restarting anything, names the containers, and prints the command to clear them.

It deliberately does not remove them itself. Removal has to match containers by the `com.docker.compose.project` label, which spans every checkout and account on the daemon, so doing it safely requires a lock proving no other deploy is mid-flight. That is a large and destructive mechanism for a transition that is rare and takes one command by hand; reporting is race-free by construction. Automatic cleanup is prototyped in #62 if we ever want it.

**A server-only deployment no longer trips the release gate.** `verify-image-revisions.sh` required two images to compare and treated one as a usage error, so the deploy aborted at the gate *after* the pull had succeeded. One image is a valid deployment: it is still inspected — an un-inspectable image is still refused — there is simply nothing to cross-check. Found by the new end-to-end test.

## Testing

`scripts/test-deploy-services.sh` runs the **real** `deploy.sh` end to end against fixture compose files with a recording `docker` stub on `PATH`, asserting what it actually did: which services it pulled and restarted, that it never touches one the file does not declare, and that it exits non-zero when it cannot finish. Seven cases covering every compose shape, both directions of the slim transition, and a `docker compose run` job that must not be mistaken for a stale service.

Each assertion was mutation-tested — the fix reverted, confirming the case fails — because a guard that cannot fail is not a guard. Both scripts are also exercised directly in CI (`validate.yml` → `deploy-gate-tests`) against real images.
