### PR TITLE
ci: add the agent release pipeline

### DIFF
--- a/.github/workflows/release-agent.yml
+++ b/.github/workflows/release-agent.yml
@@ -1,0 +1,124 @@
+# Builds and publishes the Citadel agent (the local internal service) so a user
+# whose browser cannot reach it can download and run one.
+#
+# The UI links straight at
+#   /releases/latest/download/<asset>
+# which GitHub resolves to the newest published release. That is deliberate: no
+# API call, no token, no rate limit, and nothing to break when the release list
+# changes. It does mean the ASSET NAMES here are a contract with the UI —
+# citadel-workspaces/src/lib/agent-download.ts holds the same list, and a test
+# there reads this file and fails if the two drift apart.
+name: Release agent
+
+on:
+  push:
+    tags:
+      - 'agent-v*'
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Tag to publish (e.g. agent-v0.1.0). Dry run if the tag does not exist.'
+        required: false
+
+permissions:
+  contents: write
+
+jobs:
+  build:
+    name: ${{ matrix.asset }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          # Platform TOKENS, not Rust target triples. The UI maps
+          # navigator.userAgentData/platform onto these, and "macos-arm64" is
+          # something a human can also pick off a release page correctly;
+          # "aarch64-apple-darwin" is not.
+          - os: macos-14
+            target: aarch64-apple-darwin
+            asset: citadel-agent-macos-arm64.tar.gz
+          - os: macos-13
+            target: x86_64-apple-darwin
+            asset: citadel-agent-macos-x64.tar.gz
+          - os: ubuntu-latest
+            target: x86_64-unknown-linux-gnu
+            asset: citadel-agent-linux-x64.tar.gz
+          - os: windows-latest
+            target: x86_64-pc-windows-msvc
+            asset: citadel-agent-windows-x64.zip
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Install Rust
+        run: rustup target add ${{ matrix.target }}
+
+      - name: Build the agent
+        run: cargo build --release --target ${{ matrix.target }} -p citadel_service_bin --bin internal-service
+        working-directory: citadel-internal-service
+
+      # Packaged with the run instructions beside the binary. `--bind` has no
+      # default in the agent's CLI, so a downloaded binary run bare exits with a
+      # structopt usage error; and the default account backend is in-memory, so
+      # anyone who omits --backend loses their account on restart and reports it
+      # as a bug.
+      - name: Package (unix)
+        if: runner.os != 'Windows'
+        shell: bash
+        run: |
+          set -euo pipefail
+          staging="$(mktemp -d)"
+          cp citadel-internal-service/target/${{ matrix.target }}/release/internal-service "$staging/citadel-agent"
+          cp docs/AGENT_README.md "$staging/README.md"
+          tar -czf "${{ matrix.asset }}" -C "$staging" .
+          shasum -a 256 "${{ matrix.asset }}" > "${{ matrix.asset }}.sha256"
+
+      - name: Package (windows)
+        if: runner.os == 'Windows'
+        shell: bash
+        run: |
+          set -euo pipefail
+          staging="$(mktemp -d)"
+          cp citadel-internal-service/target/${{ matrix.target }}/release/internal-service.exe "$staging/citadel-agent.exe"
+          cp docs/AGENT_README.md "$staging/README.md"
+          (cd "$staging" && 7z a -tzip "$OLDPWD/${{ matrix.asset }}" .)
+          sha256sum "${{ matrix.asset }}" > "${{ matrix.asset }}.sha256"
+
+      - name: Smoke-test the packaged binary
+        if: runner.os != 'Windows'
+        shell: bash
+        run: ./scripts/smoke-agent.sh "${{ matrix.asset }}"
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: ${{ matrix.asset }}
+          path: |
+            ${{ matrix.asset }}
+            ${{ matrix.asset }}.sha256
+          if-no-files-found: error
+
+  publish:
+    name: Publish release
+    needs: build
+    runs-on: ubuntu-latest
+    # Only a real tag push publishes. workflow_dispatch builds and smoke-tests
+    # every platform without creating a release, so the pipeline is exercisable
+    # without minting a version.
+    if: startsWith(github.ref, 'refs/tags/agent-v')
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          merge-multiple: true
+          path: dist
+      - name: Publish
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          ls -la dist
+          gh release create "${GITHUB_REF_NAME}" dist/* \
+            --repo "${GITHUB_REPOSITORY}" \
+            --title "Citadel agent ${GITHUB_REF_NAME#agent-}" \
+            --notes "The local agent that Citadel Workspace connects to. Download the build for your platform, unpack it, and run it as described in the bundled README."

--- a/docs/AGENT_README.md
+++ b/docs/AGENT_README.md
@@ -1,0 +1,50 @@
+# Citadel agent
+
+This is the local agent (the "internal service") that Citadel Workspace talks
+to. It owns your protocol connections: the browser never speaks the Citadel
+protocol directly, it speaks to this process over a WebSocket on your own
+machine.
+
+Nothing here phones home on its own. The agent connects where you tell it to.
+
+## Running it
+
+```bash
+./citadel-agent --bind 127.0.0.1:12345 --backend filesystem
+```
+
+Then reload Citadel Workspace in your browser.
+
+Both flags matter:
+
+- **`--bind` has no default.** Run the agent with no arguments and it exits with
+  a usage error rather than starting. `127.0.0.1:12345` is what the web app
+  expects; bind to `127.0.0.1` rather than `0.0.0.0` unless you intend other
+  machines on your network to reach it.
+- **`--backend filesystem` persists your account.** The default backend is
+  in-memory, which is right for tests and wrong for you: without this flag your
+  account and message history are gone the next time the agent restarts. Data
+  is written to `./internal-service-data` unless `--data-dir` says otherwise.
+
+## Windows
+
+```powershell
+.\citadel-agent.exe --bind 127.0.0.1:12345 --backend filesystem
+```
+
+## Checking it is up
+
+The web app tells you — the "unable to reach the connection service" notice
+clears once the agent is listening. From a terminal:
+
+```bash
+nc -z 127.0.0.1 12345 && echo "agent is listening"
+```
+
+## Verifying your download
+
+Each release ships a `.sha256` beside every archive:
+
+```bash
+shasum -a 256 -c citadel-agent-<platform>.tar.gz.sha256
+```

--- a/scripts/smoke-agent.sh
+++ b/scripts/smoke-agent.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+# Proves a packaged agent archive actually runs before it is published.
+#
+# Building successfully and shipping something usable are different claims. A
+# release can carry a binary that is the wrong architecture, was linked against
+# something absent on a clean machine, or lost its executable bit in packaging —
+# all of which build green and fail in the user's hands, which is the worst place
+# to find out.
+#
+# So this unpacks the artifact the way a user would and drives it:
+#   1. the archive contains the binary and the README;
+#   2. the binary is executable and refuses to start without --bind, proving the
+#      CLI is intact rather than a stub that exits 0;
+#   3. it actually LISTENS on a port when asked.
+#
+# (3) is the one that matters. The others can pass on a binary that cannot serve.
+set -euo pipefail
+
+ARCHIVE="${1:?usage: smoke-agent.sh <archive.tar.gz>}"
+[ -f "$ARCHIVE" ] || { echo "::error::no such archive: $ARCHIVE" >&2; exit 1; }
+
+WORK="$(mktemp -d)"
+cleanup() {
+  [ -n "${AGENT_PID:-}" ] && kill "$AGENT_PID" 2>/dev/null || true
+  rm -rf "$WORK"
+}
+trap cleanup EXIT
+
+tar -xzf "$ARCHIVE" -C "$WORK"
+
+[ -f "$WORK/citadel-agent" ] || { echo "::error::archive has no citadel-agent binary" >&2; ls -la "$WORK" >&2; exit 1; }
+[ -f "$WORK/README.md" ]     || { echo "::error::archive ships no README; a user gets a bare binary with a required flag and no way to know it" >&2; exit 1; }
+[ -x "$WORK/citadel-agent" ] || { echo "::error::citadel-agent is not executable — packaging dropped the mode bit" >&2; exit 1; }
+
+# No --bind must FAIL. A binary that exits 0 here is not our agent, or is a stub.
+if "$WORK/citadel-agent" >/dev/null 2>&1; then
+  echo "::error::agent exited 0 with no --bind; it should refuse to start" >&2
+  exit 1
+fi
+
+# Pick a free port rather than hardcoding 12345, so this never collides with a
+# real agent already running on the machine doing the release.
+PORT="$(python3 -c 'import socket;s=socket.socket();s.bind(("127.0.0.1",0));print(s.getsockname()[1]);s.close()')"
+
+"$WORK/citadel-agent" --bind "127.0.0.1:$PORT" --backend in-memory >"$WORK/agent.log" 2>&1 &
+AGENT_PID=$!
+
+for _ in $(seq 1 60); do
+  if ! kill -0 "$AGENT_PID" 2>/dev/null; then
+    echo "::error::agent exited while starting up:" >&2
+    tail -20 "$WORK/agent.log" >&2
+    exit 1
+  fi
+  if python3 -c "
+import socket,sys
+s=socket.socket(); s.settimeout(0.4)
+sys.exit(0 if s.connect_ex(('127.0.0.1',$PORT))==0 else 1)
+" 2>/dev/null; then
+    echo "  agent listens on 127.0.0.1:$PORT"
+    echo "== $ARCHIVE is runnable =="
+    exit 0
+  fi
+  sleep 1
+done
+
+echo "::error::agent never listened on 127.0.0.1:$PORT within 60s" >&2
+tail -20 "$WORK/agent.log" >&2
+exit 1


### PR DESCRIPTION
Builds and publishes the local agent so a user whose browser cannot reach one can install it.

Pipeline only, based on master, so it can land ahead of the UI that consumes it — `workflow_dispatch` is only offered for workflows on the default branch, so the pipeline cannot be exercised until it is there. Nothing here runs on its own: the triggers are an `agent-v*` tag or an explicit dispatch, and the publish job is gated on a real tag, so a dispatch builds and smoke-tests all four platforms without minting a release.

`scripts/smoke-agent.sh` unpacks each artifact as a user would and checks the binary and README are present, the executable bit survived packaging, the binary refuses to start without `--bind` (so a stub that exits 0 cannot pass), and that it actually listens on a port.

Verified locally: a real `cargo build --release` (20MB binary), packaged exactly as this workflow does (6.9MB archive), smoke test passing against it, and rejecting three deliberately broken packages.