### PR TITLE
docs: correct the agent README's verification commands

### DIFF
--- a/docs/AGENT_README.md
+++ b/docs/AGENT_README.md
@@ -41,10 +41,29 @@ clears once the agent is listening. From a terminal:
 nc -z 127.0.0.1 12345 && echo "agent is listening"
 ```
 
-## Verifying your download
-
-Each release ships a `.sha256` beside every archive:
+If `nc` is not installed:
 
 ```bash
-shasum -a 256 -c citadel-agent-<platform>.tar.gz.sha256
+curl -sS --max-time 2 http://127.0.0.1:12345 >/dev/null 2>&1; \
+  [ $? -ne 7 ] && echo "agent is listening"
 ```
+
+(The agent speaks WebSocket, not HTTP, so curl will not get a useful reply — but
+exit code 7 is specifically "failed to connect", which is the question being
+asked.)
+
+## Verifying your download
+
+Each release ships a `.sha256` beside every archive. Run this in the directory
+holding both files:
+
+```bash
+# macOS
+shasum -a 256 -c citadel-agent-<platform>.tar.gz.sha256
+
+# Linux (shasum is Perl-based and not always installed)
+sha256sum -c citadel-agent-<platform>.tar.gz.sha256
+```
+
+Both print `OK`. Anything else means the download is not the file that was
+published, and you should not run it.


### PR DESCRIPTION
This README ships inside every release archive, where a reader cannot check it against source.

- `shasum -a 256 -c` was the only checksum command given; it is Perl-based and not guaranteed on Linux, where `sha256sum -c` is standard. Both are now given per platform.
- The liveness check offered only `nc`. A curl fallback is added using exit code 7 ("failed to connect"), since the agent speaks WebSocket and curl never gets a usable reply.

Verified: against the running agent curl exits 52; against a closed port it exits 7.