### PR TITLE
ci: assert the packaged binary matches the architecture its name claims

### DIFF
--- a/scripts/smoke-agent.sh
+++ b/scripts/smoke-agent.sh
@@ -38,6 +38,25 @@ if "$WORK/citadel-agent" >/dev/null 2>&1; then
   exit 1
 fi
 
+# The asset NAME is a promise about the architecture inside, and the UI relies on
+# it: macOS users are offered "Apple Silicon" and "Intel" as separate downloads
+# precisely because we refuse to guess for them. A matrix entry pointing the
+# wrong target at the wrong asset name would hand an Intel binary to an ARM Mac,
+# which fails only after the download and reads as a broken release.
+case "$ARCHIVE" in
+  *macos-arm64*) WANT="arm64" ;;
+  *macos-x64*)   WANT="x86_64" ;;
+  *linux-x64*)   WANT="x86-64" ;;
+  *)             WANT="" ;;
+esac
+if [ -n "$WANT" ]; then
+  DESC="$(file -b "$WORK/citadel-agent")"
+  case "$DESC" in
+    *"$WANT"*) echo "  architecture matches the asset name ($WANT)" ;;
+    *) echo "::error::$ARCHIVE claims $WANT but the binary is: $DESC" >&2; exit 1 ;;
+  esac
+fi
+
 # Pick a free port rather than hardcoding 12345, so this never collides with a
 # real agent already running on the machine doing the release.
 PORT="$(python3 -c 'import socket;s=socket.socket();s.bind(("127.0.0.1",0));print(s.getsockname()[1]);s.close()')"


### PR DESCRIPTION
The asset name is a promise the UI relies on — macOS users pick between "Apple Silicon" and "Intel" because we refuse to guess for them. A matrix entry pairing the wrong target with the wrong asset name would hand an Intel binary to an ARM Mac, failing only after the download.

Nothing else catches this: the build succeeds, the archive is well-formed, and the smoke test's run step passes on the build machine because runner and target agree there. It is only wrong on the user's machine.

Verified both directions against real published artifacts — the macos-arm64 archive passes, and the linux-x64 binary renamed to macos-arm64 fails with what it actually found.