### PR TITLE
ci: smoke-test the Windows agent too

### DIFF
--- a/.github/workflows/release-agent.yml
+++ b/.github/workflows/release-agent.yml
@@ -93,8 +93,11 @@ jobs:
           (cd "$staging" && 7z a -tzip "$OLDPWD/${{ matrix.asset }}" .)
           sha256sum "${{ matrix.asset }}" > "${{ matrix.asset }}.sha256"
 
+      # Windows was excluded here while the smoke test only understood tar.gz,
+      # which meant the Windows archive shipped WITHOUT the one check that
+      # proves a downloaded agent runs — on the platform where "it built" and
+      # "it runs" are least likely to coincide.
       - name: Smoke-test the packaged binary
-        if: runner.os != 'Windows'
         shell: bash
         run: ./scripts/smoke-agent.sh "${{ matrix.asset }}"
 

--- a/scripts/smoke-agent.sh
+++ b/scripts/smoke-agent.sh
@@ -26,14 +26,21 @@ cleanup() {
 }
 trap cleanup EXIT
 
-tar -xzf "$ARCHIVE" -C "$WORK"
+case "$ARCHIVE" in
+  *.zip)    unzip -q "$ARCHIVE" -d "$WORK"; BIN="$WORK/citadel-agent.exe" ;;
+  *.tar.gz) tar -xzf "$ARCHIVE" -C "$WORK"; BIN="$WORK/citadel-agent" ;;
+  *)        echo "::error::unknown archive type: $ARCHIVE" >&2; exit 1 ;;
+esac
 
-[ -f "$WORK/citadel-agent" ] || { echo "::error::archive has no citadel-agent binary" >&2; ls -la "$WORK" >&2; exit 1; }
-[ -f "$WORK/README.md" ]     || { echo "::error::archive ships no README; a user gets a bare binary with a required flag and no way to know it" >&2; exit 1; }
-[ -x "$WORK/citadel-agent" ] || { echo "::error::citadel-agent is not executable — packaging dropped the mode bit" >&2; exit 1; }
+[ -f "$BIN" ]            || { echo "::error::archive has no $(basename "$BIN")" >&2; ls -la "$WORK" >&2; exit 1; }
+[ -f "$WORK/README.md" ] || { echo "::error::archive ships no README; a user gets a bare binary with a required flag and no way to know it" >&2; exit 1; }
+# Windows has no executable bit; the check is meaningful only where it exists.
+case "$ARCHIVE" in
+  *.tar.gz) [ -x "$BIN" ] || { echo "::error::citadel-agent is not executable — packaging dropped the mode bit" >&2; exit 1; } ;;
+esac
 
 # No --bind must FAIL. A binary that exits 0 here is not our agent, or is a stub.
-if "$WORK/citadel-agent" >/dev/null 2>&1; then
+if "$BIN" >/dev/null 2>&1; then
   echo "::error::agent exited 0 with no --bind; it should refuse to start" >&2
   exit 1
 fi
@@ -47,10 +54,11 @@ case "$ARCHIVE" in
   *macos-arm64*) WANT="arm64" ;;
   *macos-x64*)   WANT="x86_64" ;;
   *linux-x64*)   WANT="x86-64" ;;
+  *windows-x64*) WANT="x86-64" ;;
   *)             WANT="" ;;
 esac
 if [ -n "$WANT" ]; then
-  DESC="$(file -b "$WORK/citadel-agent")"
+  DESC="$(file -b "$BIN")"
   case "$DESC" in
     *"$WANT"*) echo "  architecture matches the asset name ($WANT)" ;;
     *) echo "::error::$ARCHIVE claims $WANT but the binary is: $DESC" >&2; exit 1 ;;
@@ -61,7 +69,7 @@ fi
 # real agent already running on the machine doing the release.
 PORT="$(python3 -c 'import socket;s=socket.socket();s.bind(("127.0.0.1",0));print(s.getsockname()[1]);s.close()')"
 
-"$WORK/citadel-agent" --bind "127.0.0.1:$PORT" --backend in-memory >"$WORK/agent.log" 2>&1 &
+"$BIN" --bind "127.0.0.1:$PORT" --backend in-memory >"$WORK/agent.log" 2>&1 &
 AGENT_PID=$!
 
 for _ in $(seq 1 60); do


### PR DESCRIPTION
Windows was excluded from the smoke step while the script only understood tar.gz, so the Windows archive shipped without the one check that proves a downloaded agent runs — on the platform whose build has already failed once here (openssl-sys).

The script now handles .zip and .tar.gz, tracks the binary name, and skips only the executable-bit check on zip (Windows has no such bit). The architecture assertion covers windows-x64 as PE32+ x86-64.

Verified locally: the macOS tar.gz path still passes end to end; the published Windows zip unpacks, is confirmed PE32+ x86-64, and correctly fails the run step on macOS — showing the run check is live for zips. The run itself is exercised on the Windows runner.