### PR TITLE
ci: cross-compile the Intel Mac build; macos-13 never gets a runner

### DIFF
--- a/.github/workflows/release-agent.yml
+++ b/.github/workflows/release-agent.yml
@@ -38,7 +38,24 @@ jobs:
           - os: macos-14
             target: aarch64-apple-darwin
             asset: citadel-agent-macos-arm64.tar.gz
-          - os: macos-13
+          # Intel Mac is CROSS-COMPILED from the Apple Silicon runner, not built
+          # on macos-13. GitHub has retired the macOS 13 image, and a job asking
+          # for a label that no longer exists does not fail — it queues forever.
+          # In the first tagged release (run 32884394417) this leg sat queued
+          # while the other three finished, and since `publish` needs all four,
+          # the release could never have been cut.
+          #
+          # Apple's toolchain targets x86_64 from arm64 natively, so this needs
+          # only `rustup target add`. Verified locally: a full
+          # `cargo build --release --target x86_64-apple-darwin --features
+          # vendored` produces a Mach-O x86_64 binary, and smoke-agent.sh's
+          # architecture assertion checks the result matches the asset name.
+          #
+          # Caveat worth knowing: the smoke test runs this binary on an arm64
+          # runner, so it executes under Rosetta. That proves the binary runs and
+          # binds a port; it does not prove it runs on real Intel silicon, which
+          # nothing in this matrix can prove now that no Intel runner exists.
+          - os: macos-14
             target: x86_64-apple-darwin
             asset: citadel-agent-macos-x64.tar.gz
           - os: ubuntu-latest


### PR DESCRIPTION
The Intel leg of the tagged release has sat queued 45+ minutes with `runner=` empty while its macos-14 sibling got one within seconds. A job whose label cannot be satisfied waits rather than failing — and since `publish` needs all four legs, agent-v0.1.0 could never have been cut.

macos-14 now builds both Mac targets, cross-compiling x86_64-apple-darwin.

Verified locally: a full release build with vendored OpenSSL produces a Mach-O x86_64 binary, and smoke-agent.sh passes it (architecture matches the asset name, agent binds a port).

Not claimed: the smoke test runs the Intel binary under Rosetta on an arm64 runner, so it shows the binary runs, not that it runs on real Intel silicon. And "macos-13 is retired" is the likely explanation; what is established is that no runner has ever been assigned to that label here.