### PR TITLE
fix: bump openssl and rustls-webpki off six known-vulnerable versions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3142,15 +3142,14 @@ checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
 name = "openssl"
-version = "0.10.75"
+version = "0.10.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08838db121398ad17ab8531ce9de97b244589089e290a384c900cb9ff7434328"
+checksum = "bf0b434746ee2832f4f0baf10137e1cabb18cbe6912c69e2e33263c45250f542"
 dependencies = [
  "bitflags 2.11.0",
  "cfg-if 1.0.4",
  "foreign-types",
  "libc",
- "once_cell",
  "openssl-macros",
  "openssl-sys",
 ]
@@ -3174,9 +3173,9 @@ checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.111"
+version = "0.9.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82cab2d520aa75e3c58898289429321eb788c3106963d0dc886ec7a5f4adc321"
+checksum = "b47e7e6bb2c38cd930d25a23b40fa52e068c10e85f3e03a7f5ba5aaca5713695"
 dependencies = [
  "cc",
  "libc",
@@ -3986,9 +3985,9 @@ checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.9"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7df23109aa6c1567d1c575b9952556388da57401e4ace1d15f79eedad0d8f53"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "ring",
  "rustls-pki-types",


### PR DESCRIPTION
Six of the eleven remaining **high**-severity Dependabot alerts on this repo, in one lockfile bump. Five are memory-safety defects in `openssl`, reached through the TLS path:

| Advisory | Package |
|---|---|
| `MdCtxRef::digest_final()` writes past a caller-supplied buffer | openssl |
| `Deriver::derive` / `PkeyCtxRef::derive` can overflow | openssl |
| Undefined behaviour in `X509Ref::ocsp_resp` | openssl |
| Unchecked callback length in the PSK/cookie trampolines | openssl |
| Incorrect bounds assertion in AES key wrap | openssl |
| Panic on a malformed CRL — denial of service | rustls-webpki |

## The change

Lockfile only. Every move is patch-level within the same minor, so there is no API surface change:

- `openssl` 0.10.75 → **0.10.79**
- `openssl-sys` 0.9.111 → **0.9.117**
- `rustls-webpki` 0.103.9 → **0.103.13**

Both are transitive; neither appears in any `Cargo.toml` here, so the lockfile is the only place to pin them.

## Why this reaches the images

Before round 526 a lockfile bump here would have stopped at the host build — the images resolved their own dependencies, and `.dockerignore` excluded `Cargo.lock` outright. #79 added `COPY ./Cargo.lock` to both Dockerfiles, removed those exclusions, and registered a gate to keep both in place. So this bump lands in the built `internal-service` and `server` images, which is the point.

## Companion PR

The same two crates are pinned at the same vulnerable versions in the `citadel-internal-service` submodule's own lockfile: Avarok-Cybersecurity/citadel-internal-service#59. That one merges first, then the pointer here follows — this PR is the parent-repo half and is self-contained without it.

## Verification

Not built locally, deliberately: `cargo check` in this tree has previously clobbered tracked generated WASM artifacts, and the internal-service build script regenerates committed files under `pkg/`. CI compiles and runs the suite against the bumped lockfile — that is the verification being claimed, and it is the one that matters for a dependency bump.

## Not fixed here

Five high alerts remain, all in JavaScript tooling that never ships to a user:

- `minimatch` ×2 and `flatted` — transitive under `eslint` / `@typescript-eslint`, i.e. lint tooling running over our own source in CI. npm's own advisory database does not yet flag these versions, so neither `npm update` nor `npm audit fix` will move them; the only mechanism is a manual `overrides` block, which I attempted and backed out after it required deleting and re-resolving a tracked lockfile — churn out of proportion to a ReDoS in a glob matcher that only ever sees our own file paths.
- `vite` — the fix is 6.4.3 against 5.4.21 installed, a major-version bump; the advisory is a `server.fs.deny` bypass on Windows alternate paths, which affects the dev server, not the static assets that get deployed.
- `extract-zip` — **no patched version exists**. It arrives via `lighthouse` → `puppeteer-core` → `@puppeteer/browsers`, and the zip it extracts is Chrome's own signed download.

Each is real; none is reachable from deployed code. Stating them rather than letting a lower alert count imply they were handled.

https://claude.ai/code/session_01CQKcBi2QVjvJBEA8StPfN7