### PR TITLE
feat: provision a tenant in one command, with the agent pinned to loopback

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -218,6 +218,9 @@ jobs:
       - name: Third-party images are pinned
         run: node scripts/check-third-party-images-are-pinned.mjs
 
+      - name: Tenant provisioning refuses what it must
+        run: bash scripts/test-provision-tenant.sh
+
 
       - name: Every administrator promotion sits behind a gate
         run: node scripts/check-admin-promotions-are-gated.mjs

--- a/deploy.sh
+++ b/deploy.sh
@@ -145,7 +145,18 @@ fi
 origins="${origins%$'\r'}"
 origins="${origins#"${origins%%[![:space:]]*}"}"
 origins="${origins%"${origins##*[![:space:]]}"}"
-if [[ -z "$origins" ]]; then
+# ...but only when this deployment actually RUNS the internal service. A
+# server-only tenant's compose file declares just `server`: the agent is not
+# deployed at all, which is the whole point of that topology -- each user runs
+# their own, on their own machine, on loopback. Demanding an origin allowlist
+# for a service that will not exist rejected a correct deployment, and the
+# operator's only way forward was to invent a value naming a UI nobody serves.
+#
+# Asked of the compose file rather than of a flag, so this cannot disagree with
+# what gets deployed. `--services` is a metadata read; the fuller selection via
+# select-deploy-services.sh happens later and is the one source of truth for
+# pull/verify/restart.
+if [[ -z "$origins" ]] && docker compose -f "$COMPOSE_FILE" config --services 2>/dev/null | grep -qx 'internal-service'; then
     echo "ERROR: INTERNAL_SERVICE_ALLOWED_ORIGINS is unset or empty."
     echo "  Set it to the origin(s) that may drive the internal service, e.g.:"
     echo "    INTERNAL_SERVICE_ALLOWED_ORIGINS=https://yourdomain.com"

--- a/scripts/provision-tenant.sh
+++ b/scripts/provision-tenant.sh
@@ -1,0 +1,241 @@
+#!/usr/bin/env bash
+# =============================================================================
+# Provision one tenant of the Citadel Workspace stack.
+# =============================================================================
+#
+# deploy.sh UPDATES a stack that already exists. It refuses to run without a
+# populated .env, and says so. This is the step before it: create the tenant
+# directory, generate its master password, allocate its ports, and write the
+# ingress config -- so that onboarding is a command rather than a runbook.
+#
+# WHY A TENANT IS A WHOLE SERVER INSTANCE
+#
+# `WORKSPACE_ROOT_ID` is the constant "workspace-root", used in 92 places in
+# citadel-workspace-server-kernel. One server process owns exactly one root
+# workspace, and WORKSPACE_MASTER_PASSWORD is the operator credential that
+# claims it -- "first user with master password becomes admin". Two tenants
+# sharing a server would therefore share a root workspace and its admin, which
+# is not multi-tenancy. So the unit of provisioning is a server instance:
+# its own compose project, data volumes, ports and password.
+#
+# FUTURE INTENT, recorded here because the constant does not say it: supporting
+# several workspaces per server means giving the root a tenant-scoped id rather
+# than a constant, and threading that id through the 92 call sites and the
+# backend key space. Nothing here forecloses that -- a tenant would simply stop
+# being one-to-one with a server process.
+#
+# WHAT THIS DELIBERATELY DOES NOT HOST
+#
+# `--topology full` runs the agent (internal-service) alongside the server. The
+# agent is the P2P ratchet ENDPOINT, not a relay: peer_channel_created.rs takes
+# already-decrypted messages off the stream and forwards the plaintext to the
+# browser. Running it for OTHER people puts their P2P plaintext on this host.
+# Hosting the workspace server has no such property -- it sees only C2S traffic,
+# under a bundle distinct from any peer-to-peer one. So `server-only` is the
+# default, and `full` is for a host whose agent serves its own operator.
+#
+# Usage:
+#   ./scripts/provision-tenant.sh --tenant acme [options]
+#
+#   --tenant NAME        Required. [a-z0-9-], becomes the compose project name.
+#   --ingress MODE       nginx | tunnel | none   (default: none)
+#   --topology MODE      server-only | full      (default: server-only)
+#   --domain FQDN        Required unless --ingress none.
+#   --base-port N        First port of this tenant's block (default: auto).
+#   --root DIR           Where tenants live (default: /srv/citadel-tenants).
+#   --dry-run            Print what would be written; touch nothing.
+#   --force              Overwrite an existing tenant directory.
+# =============================================================================
+set -euo pipefail
+
+TENANT="" ; INGRESS="none" ; TOPOLOGY="server-only" ; DOMAIN=""
+BASE_PORT="" ; ROOT="/srv/citadel-tenants" ; DRY_RUN=false ; FORCE=false
+
+die() { echo "ERROR: $*" >&2; exit 1; }
+usage() { sed -n '/^# Usage:/,/^# ===/p' "$0" | sed 's/^# \{0,1\}//'; }
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --tenant)    TENANT="${2:?--tenant needs a value}"; shift 2 ;;
+    --ingress)   INGRESS="${2:?--ingress needs a value}"; shift 2 ;;
+    --topology)  TOPOLOGY="${2:?--topology needs a value}"; shift 2 ;;
+    --domain)    DOMAIN="${2:?--domain needs a value}"; shift 2 ;;
+    --base-port) BASE_PORT="${2:?--base-port needs a value}"; shift 2 ;;
+    --root)      ROOT="${2:?--root needs a value}"; shift 2 ;;
+    --dry-run)   DRY_RUN=true; shift ;;
+    --force)     FORCE=true; shift ;;
+    --help|-h)   usage; exit 0 ;;
+    *)           usage >&2; die "unknown argument: $1" ;;
+  esac
+done
+
+[ -n "$TENANT" ] || { usage >&2; die "--tenant is required"; }
+# The name becomes a compose project, a directory and a volume prefix. Anything
+# outside this set would either be rejected downstream or, worse, traverse.
+[[ "$TENANT" =~ ^[a-z0-9][a-z0-9-]{0,30}$ ]] || die "--tenant must match [a-z0-9][a-z0-9-]{0,30}"
+case "$INGRESS" in nginx|tunnel|none) ;; *) die "--ingress must be nginx, tunnel or none" ;; esac
+case "$TOPOLOGY" in server-only|full) ;; *) die "--topology must be server-only or full" ;; esac
+if [ "$INGRESS" != "none" ] && [ -z "$DOMAIN" ]; then
+  die "--domain is required when --ingress is $INGRESS"
+fi
+# Ingress serves the UI. Without the UI there is nothing for it to point at, and
+# pointing it at the agent instead is the exact mistake the compose file's
+# capitalised warning exists to prevent.
+if [ "$INGRESS" != "none" ] && [ "$TOPOLOGY" = "server-only" ]; then
+  die "--ingress $INGRESS needs --topology full: a server-only tenant serves no UI to route to"
+fi
+
+# --- port allocation ---------------------------------------------------------
+# A tenant owns a contiguous block of 10: +0 server, +1 agent, +2 UI. The block
+# is spaced so adding a fourth service later does not collide with the next
+# tenant. Ports are checked against what is actually listening, not against a
+# registry file that can drift from reality.
+# A port check that cannot see is worse than none: it reports every port free
+# and hands out one already in use. `ss` is Linux-only, so pick a tool that
+# exists and REFUSE if none does, rather than silently approving everything.
+# Caught by a control: --base-port 443 was accepted on a host without `ss`.
+if command -v ss >/dev/null 2>&1; then
+  port_busy() { ss -tlnH 2>/dev/null | awk '{print $4}' | grep -qE "[:.]$1\$"; }
+elif command -v lsof >/dev/null 2>&1; then
+  port_busy() { lsof -nP -iTCP:"$1" -sTCP:LISTEN >/dev/null 2>&1; }
+elif command -v netstat >/dev/null 2>&1; then
+  port_busy() { netstat -an 2>/dev/null | grep -E "^tcp.*[:.]$1[[:space:]].*LISTEN" -q; }
+else
+  port_busy() { die "no ss, lsof or netstat: cannot tell whether port $1 is free"; }
+fi
+
+if [ -z "$BASE_PORT" ]; then
+  for candidate in $(seq 12400 10 12990); do
+    if ! port_busy "$candidate" && ! port_busy $((candidate+1)) && ! port_busy $((candidate+2)); then
+      BASE_PORT="$candidate"; break
+    fi
+  done
+  [ -n "$BASE_PORT" ] || die "no free 3-port block between 12400 and 12990"
+fi
+SERVER_PORT="$BASE_PORT"; AGENT_PORT=$((BASE_PORT+1)); UI_PORT=$((BASE_PORT+2))
+
+for p in "$SERVER_PORT" "$AGENT_PORT" "$UI_PORT"; do
+  port_busy "$p" && die "port $p is already in use; pass --base-port to choose another block"
+done
+
+TENANT_DIR="$ROOT/$TENANT"
+if [ -e "$TENANT_DIR" ] && [ "$FORCE" != true ]; then
+  die "$TENANT_DIR already exists. Re-provisioning destroys its .env (and with it the
+  master password that its stored root-workspace password must match). Pass --force
+  only if you intend that, and expect the kernel to ROTATE -- anyone holding the old
+  password loses access."
+fi
+
+# --- the values --------------------------------------------------------------
+# openssl, not $RANDOM: the latter is seeded from pid+time and is not a CSPRNG.
+MASTER_PASSWORD="$(openssl rand -hex 32)"
+
+if [ "$TOPOLOGY" = "full" ]; then
+  # Both spellings: a proxy may present either, and the binary refuses to start
+  # on an empty value rather than accepting every page on the internet.
+  ORIGINS="https://$DOMAIN"
+  [ "$INGRESS" = "none" ] && ORIGINS="http://localhost:$UI_PORT,http://127.0.0.1:$UI_PORT"
+else
+  ORIGINS=""
+fi
+
+# The WORKSPACE SERVER binds publicly so each user's own agent can dial in. That
+# is the supported topology and the protocol is E2E encrypted between client and
+# server.
+BIND_ADDR="0.0.0.0:$SERVER_PORT"
+
+# The AGENT IS LOOPBACK ONLY, always, in every topology. It is the P2P ratchet
+# ENDPOINT -- peer_channel_created.rs forwards already-decrypted plaintext to the
+# browser -- and its WebSocket is an unauthenticated control plane that an Origin
+# check cannot defend (no CORS preflight; a non-browser client forges the header).
+# So this is written as a constant, never derived from an argument, and asserted
+# below so a future edit that parameterises it fails here instead of in production.
+AGENT_BIND_HOST="127.0.0.1"
+[ "$AGENT_BIND_HOST" = "127.0.0.1" ] || die "the agent must bind loopback only; refusing to provision"
+
+render_env() {
+  cat <<EOF
+# Generated by scripts/provision-tenant.sh for tenant "$TENANT".
+# Regenerating this file rotates the root workspace password. See --force.
+WORKSPACE_MASTER_PASSWORD=$1
+WORKSPACE_BIND_ADDR=$BIND_ADDR
+INTERNAL_SERVICE_PORT=$AGENT_PORT
+INTERNAL_SERVICE_BIND_HOST=$AGENT_BIND_HOST
+INTERNAL_SERVICE_ALLOWED_ORIGINS=$ORIGINS
+IMAGE_TAG=${IMAGE_TAG:-latest}
+EOF
+  [ "$INGRESS" = "tunnel" ] && echo "TUNNEL_TOKEN=${TUNNEL_TOKEN:-__SET_ME__}"
+  return 0
+}
+
+render_vhost() {
+  cat <<EOF
+# $DOMAIN -> tenant $TENANT UI on 127.0.0.1:$UI_PORT
+server {
+    listen 80; listen [::]:80;
+    server_name $DOMAIN;
+    return 301 https://\$server_name\$request_uri;
+}
+server {
+    listen 443 ssl; listen [::]:443 ssl;
+    server_name $DOMAIN;
+    http2 on;
+    ssl_certificate     /etc/letsencrypt/live/$DOMAIN/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/$DOMAIN/privkey.pem;
+    ssl_protocols TLSv1.2 TLSv1.3;
+    client_max_body_size 500m;
+    location / {
+        proxy_pass http://127.0.0.1:$UI_PORT;
+        proxy_set_header Host \$host;
+        proxy_set_header X-Forwarded-For \$proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto https;
+        # The UI reaches its agent over a WebSocket. Without these two the
+        # connection is downgraded to a plain request and the app loads but
+        # never connects -- which looks like an application bug, not an
+        # ingress one, and is why they are here rather than left to a default.
+        proxy_set_header Upgrade \$http_upgrade;
+        proxy_set_header Connection "upgrade";
+        proxy_read_timeout 180s;
+        proxy_buffering off;
+    }
+}
+EOF
+}
+
+# --- emit --------------------------------------------------------------------
+echo "tenant      : $TENANT"
+echo "topology    : $TOPOLOGY"
+echo "ingress     : $INGRESS${DOMAIN:+ ($DOMAIN)}"
+echo "ports       : server=$SERVER_PORT agent=$AGENT_PORT ui=$UI_PORT"
+echo "directory   : $TENANT_DIR"
+
+if [ "$DRY_RUN" = true ]; then
+  echo "--- .env (password redacted) ---"
+  render_env "__REDACTED__"
+  [ "$INGRESS" = "nginx" ] && { echo "--- $DOMAIN.conf ---"; render_vhost; }
+  echo "--- dry run: nothing written ---"
+  exit 0
+fi
+
+mkdir -p "$TENANT_DIR"
+# 0600 before content: never exists world-readable, even momentarily.
+umask 077
+render_env "$MASTER_PASSWORD" > "$TENANT_DIR/.env"
+chmod 600 "$TENANT_DIR/.env"
+cp docker-compose.production.yml "$TENANT_DIR/"
+cp -r scripts "$TENANT_DIR/scripts" 2>/dev/null || true
+cp deploy.sh "$TENANT_DIR/" 2>/dev/null || true
+
+if [ "$INGRESS" = "nginx" ]; then
+  render_vhost > "$TENANT_DIR/$DOMAIN.conf"
+  echo "wrote $TENANT_DIR/$DOMAIN.conf"
+  echo "NEXT: obtain a cert for $DOMAIN, install the vhost, then 'nginx -t && systemctl reload nginx'."
+  echo "      The existing mx.avarok.net cert does NOT cover new names; expanding it touches"
+  echo "      every other name on it, so a separate cert is the lower-risk choice."
+fi
+if [ "$INGRESS" = "tunnel" ] && [ -z "${TUNNEL_TOKEN:-}" ]; then
+  echo "NEXT: set TUNNEL_TOKEN in $TENANT_DIR/.env (currently __SET_ME__)."
+  echo "      Route the tunnel to the UI on 127.0.0.1:$UI_PORT ONLY -- never to the agent."
+fi
+
+echo "provisioned. Deploy with:  cd $TENANT_DIR && ./deploy.sh --no-pull$([ "$INGRESS" = tunnel ] && echo ' --tunnel')"

--- a/scripts/provision-tenant.sh
+++ b/scripts/provision-tenant.sh
@@ -3,10 +3,10 @@
 # Provision one tenant of the Citadel Workspace stack.
 # =============================================================================
 #
-# deploy.sh UPDATES a stack that already exists. It refuses to run without a
-# populated .env, and says so. This is the step before it: create the tenant
-# directory, generate its master password, allocate its ports, and write the
-# ingress config -- so that onboarding is a command rather than a runbook.
+# deploy.sh UPDATES a stack that exists and refuses to run without a populated
+# .env. This is the step before it: create the tenant directory, generate its
+# master password, allocate ports, write the ingress config -- so that
+# onboarding is a command rather than a runbook.
 #
 # WHY A TENANT IS A WHOLE SERVER INSTANCE
 #
@@ -18,33 +18,31 @@
 # is not multi-tenancy. So the unit of provisioning is a server instance:
 # its own compose project, data volumes, ports and password.
 #
-# FUTURE INTENT, recorded here because the constant does not say it: supporting
-# several workspaces per server means giving the root a tenant-scoped id rather
-# than a constant, and threading that id through the 92 call sites and the
-# backend key space. Nothing here forecloses that -- a tenant would simply stop
-# being one-to-one with a server process.
+# FUTURE INTENT, recorded because the constant does not say it: several
+# workspaces per server means a tenant-scoped root id rather than a constant,
+# threaded through those 92 call sites and the backend key space. Nothing here
+# forecloses it; a tenant would stop being one-to-one with a server process.
 #
 # WHAT THIS DELIBERATELY DOES NOT HOST
 #
-# `--topology full` runs the agent (internal-service) alongside the server. The
-# agent is the P2P ratchet ENDPOINT, not a relay: peer_channel_created.rs takes
-# already-decrypted messages off the stream and forwards the plaintext to the
-# browser. Running it for OTHER people puts their P2P plaintext on this host.
-# Hosting the workspace server has no such property -- it sees only C2S traffic,
-# under a bundle distinct from any peer-to-peer one. So `server-only` is the
-# default, and `full` is for a host whose agent serves its own operator.
+# `--topology full` runs the agent alongside the server. The agent is the P2P
+# ratchet ENDPOINT, not a relay: peer_channel_created.rs takes already-decrypted
+# messages off the stream and forwards plaintext to the browser, so running it
+# for OTHER people puts their P2P plaintext on this host. The workspace server
+# has no such property -- only C2S traffic, under a distinct bundle. Hence
+# `server-only` by default; `full` is for a host whose agent serves its operator.
 #
 # Usage:
 #   ./scripts/provision-tenant.sh --tenant acme [options]
 #
-#   --tenant NAME        Required. [a-z0-9-], becomes the compose project name.
-#   --ingress MODE       nginx | tunnel | none   (default: none)
-#   --topology MODE      server-only | full      (default: server-only)
-#   --domain FQDN        Required unless --ingress none.
-#   --base-port N        First port of this tenant's block (default: auto).
-#   --root DIR           Where tenants live (default: /srv/citadel-tenants).
-#   --dry-run            Print what would be written; touch nothing.
-#   --force              Overwrite an existing tenant directory.
+#   --tenant NAME   Required. [a-z0-9-]; becomes the compose project name.
+#   --ingress MODE  nginx | tunnel | none        (default: none)
+#   --topology MODE server-only | full           (default: server-only)
+#   --domain FQDN   Required unless --ingress none.
+#   --base-port N   First port of this tenant's block (default: auto).
+#   --root DIR      Where tenants live (default: /srv/citadel-tenants).
+#   --dry-run       Print what would be written; touch nothing.
+#   --force         Overwrite an existing tenant directory.
 # =============================================================================
 set -euo pipefail
 
@@ -86,14 +84,13 @@ if [ "$INGRESS" != "none" ] && [ "$TOPOLOGY" = "server-only" ]; then
 fi
 
 # --- port allocation ---------------------------------------------------------
-# A tenant owns a contiguous block of 10: +0 server, +1 agent, +2 UI. The block
-# is spaced so adding a fourth service later does not collide with the next
-# tenant. Ports are checked against what is actually listening, not against a
-# registry file that can drift from reality.
-# A port check that cannot see is worse than none: it reports every port free
-# and hands out one already in use. `ss` is Linux-only, so pick a tool that
-# exists and REFUSE if none does, rather than silently approving everything.
-# Caught by a control: --base-port 443 was accepted on a host without `ss`.
+# A tenant owns a block of 10: +0 server, +1 agent, +2 UI -- spaced so a fourth
+# service later cannot collide with the next tenant. Checked against what is
+# actually listening, not a registry file that drifts from reality.
+# A port check that cannot see is worse than none: it calls every port free and
+# hands out one in use. `ss` is Linux-only, so pick a tool that exists and
+# REFUSE if none does. Caught by a control: --base-port 443 was accepted on a
+# host with no `ss`.
 if command -v ss >/dev/null 2>&1; then
   port_busy() { ss -tlnH 2>/dev/null | awk '{print $4}' | grep -qE "[:.]$1\$"; }
 elif command -v lsof >/dev/null 2>&1; then
@@ -168,39 +165,6 @@ EOF
   return 0
 }
 
-render_vhost() {
-  cat <<EOF
-# $DOMAIN -> tenant $TENANT UI on 127.0.0.1:$UI_PORT
-server {
-    listen 80; listen [::]:80;
-    server_name $DOMAIN;
-    return 301 https://\$server_name\$request_uri;
-}
-server {
-    listen 443 ssl; listen [::]:443 ssl;
-    server_name $DOMAIN;
-    http2 on;
-    ssl_certificate     /etc/letsencrypt/live/$DOMAIN/fullchain.pem;
-    ssl_certificate_key /etc/letsencrypt/live/$DOMAIN/privkey.pem;
-    ssl_protocols TLSv1.2 TLSv1.3;
-    client_max_body_size 500m;
-    location / {
-        proxy_pass http://127.0.0.1:$UI_PORT;
-        proxy_set_header Host \$host;
-        proxy_set_header X-Forwarded-For \$proxy_add_x_forwarded_for;
-        proxy_set_header X-Forwarded-Proto https;
-        # The UI reaches its agent over a WebSocket. Without these two the
-        # connection is downgraded to a plain request and the app loads but
-        # never connects -- which looks like an application bug, not an
-        # ingress one, and is why they are here rather than left to a default.
-        proxy_set_header Upgrade \$http_upgrade;
-        proxy_set_header Connection "upgrade";
-        proxy_read_timeout 180s;
-        proxy_buffering off;
-    }
-}
-EOF
-}
 
 # --- emit --------------------------------------------------------------------
 echo "tenant      : $TENANT"
@@ -212,7 +176,7 @@ echo "directory   : $TENANT_DIR"
 if [ "$DRY_RUN" = true ]; then
   echo "--- .env (password redacted) ---"
   render_env "__REDACTED__"
-  [ "$INGRESS" = "nginx" ] && { echo "--- $DOMAIN.conf ---"; render_vhost; }
+  [ "$INGRESS" = "nginx" ] && { echo "--- $DOMAIN.conf ---"; bash scripts/render-nginx-vhost.sh "$DOMAIN" "$UI_PORT" "$TENANT"; }
   echo "--- dry run: nothing written ---"
   exit 0
 fi
@@ -222,12 +186,31 @@ mkdir -p "$TENANT_DIR"
 umask 077
 render_env "$MASTER_PASSWORD" > "$TENANT_DIR/.env"
 chmod 600 "$TENANT_DIR/.env"
-cp docker-compose.production.yml "$TENANT_DIR/"
+# A server-only tenant gets a compose file declaring only `server`: that is how
+# deploy.sh expresses a slimmed deployment (it intersects the deployable set
+# with what the file declares), and it is why this topology needs no
+# INTERNAL_SERVICE_ALLOWED_ORIGINS -- the agent is not deployed here at all,
+# which is the point. Users run their own, on their own machine, on loopback.
+# Generated from the canonical file, never maintained as a second one.
+if [ "$TOPOLOGY" = "server-only" ]; then
+  python3 scripts/trim-compose.py docker-compose.production.yml server \
+    > "$TENANT_DIR/docker-compose.production.yml" || die "could not trim the compose file"
+else
+  cp docker-compose.production.yml "$TENANT_DIR/"
+fi
 cp -r scripts "$TENANT_DIR/scripts" 2>/dev/null || true
+# Prove the generated file says what the topology claims, before anyone deploys
+# it: a trim that silently kept the agent would put a hosted agent on a public
+# host, the one thing this topology exists to prevent.
+if [ "$TOPOLOGY" = "server-only" ]; then
+  d=$(cd "$TENANT_DIR" && docker compose -f docker-compose.production.yml config --services 2>/dev/null | sort | tr '\n' ' ')
+  [ "${d% }" = "server" ] || die "server-only tenant declares '${d% }'; expected exactly 'server'"
+  echo "verified   : compose declares exactly [server]"
+fi
 cp deploy.sh "$TENANT_DIR/" 2>/dev/null || true
 
 if [ "$INGRESS" = "nginx" ]; then
-  render_vhost > "$TENANT_DIR/$DOMAIN.conf"
+  bash scripts/render-nginx-vhost.sh "$DOMAIN" "$UI_PORT" "$TENANT" > "$TENANT_DIR/$DOMAIN.conf"
   echo "wrote $TENANT_DIR/$DOMAIN.conf"
   echo "NEXT: obtain a cert for $DOMAIN, install the vhost, then 'nginx -t && systemctl reload nginx'."
   echo "      The existing mx.avarok.net cert does NOT cover new names; expanding it touches"

--- a/scripts/render-nginx-vhost.sh
+++ b/scripts/render-nginx-vhost.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+# Render an nginx vhost for a tenant's UI.
+#
+# Split out of provision-tenant.sh to keep that file inside the repo's 250-line
+# convention. One caller, no independent life.
+#
+# Usage: render-nginx-vhost.sh <domain> <ui-port>
+set -euo pipefail
+DOMAIN="${1:?usage: render-nginx-vhost.sh <domain> <ui-port>}"
+UI_PORT="${2:?usage: render-nginx-vhost.sh <domain> <ui-port>}"
+# Named in the heredoc's comment line only; the caller does not pass it.
+TENANT="${3:-this tenant}"
+
+render_vhost() {
+  cat <<EOF
+# $DOMAIN -> tenant $TENANT UI on 127.0.0.1:$UI_PORT
+server {
+    listen 80; listen [::]:80;
+    server_name $DOMAIN;
+    return 301 https://\$server_name\$request_uri;
+}
+server {
+    listen 443 ssl; listen [::]:443 ssl;
+    server_name $DOMAIN;
+    http2 on;
+    ssl_certificate     /etc/letsencrypt/live/$DOMAIN/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/$DOMAIN/privkey.pem;
+    ssl_protocols TLSv1.2 TLSv1.3;
+    client_max_body_size 500m;
+    location / {
+        proxy_pass http://127.0.0.1:$UI_PORT;
+        proxy_set_header Host \$host;
+        proxy_set_header X-Forwarded-For \$proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto https;
+        # The UI reaches its agent over a WebSocket. Without these two the
+        # connection is downgraded to a plain request and the app loads but
+        # never connects -- which looks like an application bug, not an
+        # ingress one, and is why they are here rather than left to a default.
+        proxy_set_header Upgrade \$http_upgrade;
+        proxy_set_header Connection "upgrade";
+        proxy_read_timeout 180s;
+        proxy_buffering off;
+    }
+}
+EOF
+}
+render_vhost

--- a/scripts/test-provision-tenant.sh
+++ b/scripts/test-provision-tenant.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+# Every guard in provision-tenant.sh must actually refuse.
+#
+# A provisioning script that accepts bad input does not fail loudly -- it
+# creates a tenant that is subtly wrong: a directory outside its root, a port
+# already serving something else, an agent exposed where the design says it
+# must not be. So each refusal is asserted here, and so is the acceptance of
+# valid input, because a script that refuses everything would pass a
+# refusal-only suite.
+#
+# The port check earned its test: `ss` is Linux-only, and the first version
+# returned "free" for every port on a host without it. It reported safety it
+# could not establish, which is the failure mode this file exists to catch.
+set -uo pipefail
+cd "$(dirname "$0")/.."
+S=./scripts/provision-tenant.sh
+fails=0
+
+refuses() {
+  local what="$1"; shift
+  if "$@" >/dev/null 2>&1; then echo "  FAIL: $what was ACCEPTED"; fails=$((fails+1))
+  else echo "  ok: refused $what"; fi
+}
+accepts() {
+  local what="$1"; shift
+  if "$@" >/dev/null 2>&1; then echo "  ok: accepted $what"
+  else echo "  FAIL: $what was REFUSED"; fails=$((fails+1)); fi
+}
+
+refuses "missing --tenant"            $S --dry-run
+refuses "path traversal in name"      $S --tenant ../etc --dry-run
+refuses "uppercase/underscore name"   $S --tenant Bad_Name --dry-run
+refuses "unknown ingress"             $S --tenant a --ingress ftp --dry-run
+refuses "unknown topology"            $S --tenant a --topology weird --dry-run
+refuses "ingress without domain"      $S --tenant a --topology full --ingress nginx --dry-run
+refuses "ingress on server-only"      $S --tenant a --ingress nginx --domain x.io --dry-run
+refuses "unknown flag"                $S --tenant a --nope --dry-run
+refuses "no port tool available"      env PATH=/nonexistent bash $S --tenant a --dry-run
+
+accepts "server-only, no ingress"     $S --tenant ok1 --dry-run
+accepts "full + tunnel"               $S --tenant ok2 --topology full --ingress tunnel --domain w.example --dry-run
+accepts "full + nginx"                $S --tenant ok3 --topology full --ingress nginx --domain w.example --dry-run
+
+# An occupied port must be rejected. Bind one here rather than trusting that
+# some well-known port happens to be busy on the runner -- a port that is free
+# would make this assertion pass without testing anything.
+PORTFILE=$(mktemp)
+python3 -c "
+import socket, sys, time
+s = socket.socket(); s.bind(('127.0.0.1', 0)); s.listen(1)
+open(sys.argv[1], 'w').write(str(s.getsockname()[1]))
+time.sleep(10)
+" "$PORTFILE" &
+BINDER=$!
+for _ in $(seq 1 20); do [ -s "$PORTFILE" ] && break; sleep 0.2; done
+PORT=$(cat "$PORTFILE" 2>/dev/null || true)
+if [ -n "$PORT" ]; then
+  refuses "port already in use ($PORT)" $S --tenant a --base-port "$PORT" --dry-run
+else
+  echo "  FAIL: could not bind a port, so the occupied-port guard went untested"
+  fails=$((fails+1))
+fi
+kill "$BINDER" 2>/dev/null || true
+wait "$BINDER" 2>/dev/null || true   # suppress the shell's "Terminated" job notice
+rm -f "$PORTFILE"
+
+# The agent bind must be loopback in EVERY topology. Asserted on the rendered
+# output, not on the source text: a comment saying 127.0.0.1 is not the same as
+# an .env that carries it.
+for topo in server-only full; do
+  out=$($S --tenant a --topology "$topo" --dry-run 2>/dev/null || true)
+  if echo "$out" | grep -q "^INTERNAL_SERVICE_BIND_HOST=127.0.0.1$"; then
+    echo "  ok: agent binds loopback ($topo)"
+  else
+    echo "  FAIL: agent is not pinned to loopback in $topo"
+    fails=$((fails+1))
+  fi
+done
+
+if [ "$fails" -ne 0 ]; then echo "FAIL: $fails assertion(s)"; exit 1; fi
+echo "provision-tenant: all guards refuse, all valid inputs accepted."

--- a/scripts/trim-compose.py
+++ b/scripts/trim-compose.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env python3
+"""Emit a compose file that declares only the named service.
+
+deploy.sh deploys every service its compose file declares, and
+select-deploy-services.sh intersects that with the deployable set. A
+server-only tenant is therefore expressed as a compose file that declares
+only `server` -- which is the path deploy.sh already anticipates, in its own
+words, when it looks for "the services a slimmed deployment DROPPED".
+
+Generated from the canonical file rather than maintained as a second one:
+two hand-kept compose files drift, and the direction they drift in is a
+production service configured differently from the one anybody reviews.
+
+Anything outside the `services:` map is passed through untouched, including
+`volumes:`. An unused volume declaration costs nothing; dropping one that a
+later topology change needs would silently orphan its data.
+"""
+import re
+import sys
+
+SERVICE_KEY = re.compile(r"^  ([A-Za-z0-9_.-]+):\s*$")
+
+
+def trim(text: str, keep: str) -> str:
+    out: list[str] = []
+    in_services = False
+    mode = "head"
+    for line in text.split("\n"):
+        if line.rstrip() == "services:":
+            in_services, mode = True, "head"
+            out.append(line)
+            continue
+        if in_services:
+            match = SERVICE_KEY.match(line)
+            if match:
+                mode = "keep" if match.group(1) == keep else "drop"
+            # A non-indented, non-comment line ends the services map.
+            if line and not line.startswith(" ") and not line.startswith("#"):
+                in_services, mode = False, "head"
+                out.append(line)
+                continue
+            if mode != "drop":
+                out.append(line)
+            continue
+        out.append(line)
+    return "\n".join(out)
+
+
+def main() -> int:
+    if len(sys.argv) != 3:
+        print("usage: trim-compose.py <compose-file> <service-to-keep>", file=sys.stderr)
+        return 2
+    path, keep = sys.argv[1], sys.argv[2]
+    text = open(path, encoding="utf-8").read()
+    result = trim(text, keep)
+    # A trim that kept nothing is a silent, total failure: deploy.sh would then
+    # report "nothing to deploy" as a successful no-op. Refuse instead.
+    if not re.search(rf"^  {re.escape(keep)}:\s*$", result, re.M):
+        print(f"trim-compose: '{keep}' is not a service in {path}", file=sys.stderr)
+        return 1
+    sys.stdout.write(result)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
`deploy.sh` **updates** a stack that already exists — it refuses to run without a populated `.env` and tells you to copy `.env.example`. This adds the step before it, so onboarding is a command rather than a runbook.

```
./scripts/provision-tenant.sh --tenant acme --topology full --ingress tunnel --domain work.example.com
```

## A tenant is a server instance

`WORKSPACE_ROOT_ID` is the constant `"workspace-root"`, used in **92 places**. One server process owns exactly one root workspace, and `WORKSPACE_MASTER_PASSWORD` is the operator credential that claims it — *"first user with master password becomes admin"*. Two tenants sharing a server would share a root workspace **and its admin**, which is not multi-tenancy. So the unit of provisioning is a server instance: its own compose project, volumes, ports and password.

The future intent is recorded in the script's header, because the constant doesn't say it: supporting several workspaces per server means giving the root a tenant-scoped id and threading it through those 92 sites and the backend key space. Nothing here forecloses that.

## The agent is loopback only

`AGENT_BIND_HOST` is a **constant**, never derived from an argument, asserted before anything is written, and emitted as `INTERNAL_SERVICE_BIND_HOST=127.0.0.1` in every topology.

It is the **P2P ratchet endpoint, not a relay**: `peer_channel_created.rs` takes messages the SDK has already decrypted off the stream and forwards the plaintext to the browser. Its WebSocket is additionally an unauthenticated control plane that an `Origin` check cannot defend — WebSockets carry no CORS preflight and a non-browser client forges the header with one curl flag.

The test asserts this on the **rendered `.env`**, not the source text. A comment saying `127.0.0.1` is not the same as a file that carries it.

Relatedly, `--ingress` on a `server-only` tenant is refused: ingress exists to serve the UI, and a tenant with no UI would leave someone pointing it at the agent instead.

## Ingress is a parameter, not a fork

| Mode | Emits |
|---|---|
| `none` (default) | nothing — server-only tenants need no HTTP ingress |
| `tunnel` | `TUNNEL_TOKEN` in `.env`, deploy with `--tunnel` |
| `nginx` | a vhost with the **WebSocket upgrade headers** the existing site configs lack |

`none` is first-class: it is the tier that can be hosted for customers without holding their P2P plaintext.

## A control caught a real defect

`--base-port 443` was **ACCEPTED**. The port check used `ss`, which does not exist on macOS, so `port_busy` returned "free" for *every* port and would have handed out one already in use. It now selects `ss`/`lsof`/`netstat` and **refuses** when none exists, rather than reporting a safety it cannot establish.

The test binds a real ephemeral port rather than assuming some well-known port is busy on the runner — a free port would have made that assertion pass while testing nothing.

`scripts/test-provision-tenant.sh` runs in CI: 10 refusals, 3 acceptances, and the loopback assertion in both topologies. The acceptances are there because a script that refused everything would pass a refusal-only suite.

https://claude.ai/code/session_01CQKcBi2QVjvJBEA8StPfN7