### PR TITLE
fix(deploy): two reads that killed the deploy silently, and a way to deploy loaded images

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -44,6 +44,7 @@ COMPOSE_FILE="docker-compose.production.yml"
 PROFILE_ARGS=()
 TUNNEL_PROFILE_ACTIVE=false
 SKIP_PULL=false
+LOCAL_IMAGES=false
 
 # One description of the interface, printed both on request and on a mistake, so
 # the two can never drift apart.
@@ -54,6 +55,11 @@ Citadel Workspace - deploy / update the running production stack.
 Usage: $0 [--no-pull] [--tunnel] [--help]
 
   --no-pull   Skip the git pull; deploy using the compose file already checked out.
+  --local-images
+              Do not contact the registry; deploy the images already present on this
+              host (e.g. shipped with 'docker save | ssh host docker load' while the
+              GHCR packages are private). The revision gate still inspects every image,
+              so a missing one aborts before anything is restarted.
   --tunnel    Include the Cloudflare tunnel profile. Requires TUNNEL_TOKEN in .env.
   --help, -h  Print this and exit.
 
@@ -72,6 +78,9 @@ for arg in "$@"; do
     case $arg in
         --no-pull)
             SKIP_PULL=true
+            ;;
+        --local-images)
+            LOCAL_IMAGES=true
             ;;
         --tunnel)
             PROFILE_ARGS=(--profile tunnel)
@@ -118,7 +127,10 @@ fi
 # document the contract, so `cp .env.example .env` + editing only the
 # assignment would leave the marker in a comment and a whole-file grep
 # would wrongly reject a correctly-edited file.
-master_pw=$(grep -E '^[[:space:]]*WORKSPACE_MASTER_PASSWORD=' .env | tail -n1 | cut -d= -f2-)
+# `|| true`, for the same reason as the origins read below: without it a .env that lacks
+# the key makes grep exit 1 under pipefail and `set -e` exits here, silently -- BEFORE the
+# "unset" message two lines down can ever print. The check must be reachable.
+master_pw=$(grep -E '^[[:space:]]*WORKSPACE_MASTER_PASSWORD=' .env | tail -n1 | cut -d= -f2- || true)
 master_pw="${master_pw%$'\r'}"                                # strip CR
 master_pw="${master_pw#"${master_pw%%[![:space:]]*}"}"       # trim leading ws
 master_pw="${master_pw%"${master_pw##*[![:space:]]}"}"       # trim trailing ws
@@ -140,7 +152,11 @@ fi
 # scripts/test-deploy-services.sh does, and how this check first failed.
 origins="${INTERNAL_SERVICE_ALLOWED_ORIGINS:-}"
 if [[ -z "$origins" ]]; then
-    origins=$(grep -E '^[[:space:]]*INTERNAL_SERVICE_ALLOWED_ORIGINS=' .env | tail -n1 | cut -d= -f2-)
+    # `|| true`: with pipefail, a .env that simply lacks this key makes grep exit 1, the
+    # pipeline exit 1, and `set -e` kill the deploy right here -- after the banner, with
+    # no message at all. A server-only tenant has every reason to omit the key. Empty is
+    # handled two lines down; absent must mean empty, not "abort silently".
+    origins=$(grep -E '^[[:space:]]*INTERNAL_SERVICE_ALLOWED_ORIGINS=' .env | tail -n1 | cut -d= -f2- || true)
 fi
 origins="${origins%$'\r'}"
 origins="${origins#"${origins%%[![:space:]]*}"}"
@@ -538,7 +554,14 @@ in_deployment() {
     printf '%s\n' "${DEPLOY_SERVICES[@]}" | grep -qx "$1"
 }
 
-if ! docker compose -f "$COMPOSE_FILE" ${PROFILE_ARGS[@]+"${PROFILE_ARGS[@]}"} pull "${DEPLOY_SERVICES[@]}"; then
+# --local-images: the images were placed on this host by other means (docker load over
+# ssh, a local build). Skipping the pull is safe ONLY because the revision gate below
+# runs `docker image inspect` on every image in DEPLOY_SERVICES and exits non-zero for
+# one it cannot find -- so "the image was never loaded" still stops the deploy here,
+# before any container is touched, instead of surfacing as a failed `up`.
+if [ "$LOCAL_IMAGES" = true ]; then
+    echo "  --local-images: not contacting the registry; using the images already on this host."
+elif ! docker compose -f "$COMPOSE_FILE" ${PROFILE_ARGS[@]+"${PROFILE_ARGS[@]}"} pull "${DEPLOY_SERVICES[@]}"; then
     echo "" >&2
     echo "ERROR: failed to pull images (tag: ${IMAGE_TAG:-latest})." >&2
     echo "  Common causes:" >&2

--- a/deploy.sh
+++ b/deploy.sh
@@ -719,7 +719,14 @@ wait_for_port() {
     # old one — the mixed-version state the ordering exists to avoid on a
     # build/pull failure, but which a STARTUP failure lands in anyway. Say so,
     # rather than leaving an exit 1 that reads like "nothing happened".
-    echo "The stack is now MIXED-VERSION: ${svc} is on the new image, later services are not."
+    # Only a mixed stack is mixed. When ${svc} was the LAST (or only) service, the honest
+    # statement is that it is on the new image and unhealthy -- a server-only tenant was
+    # told "later services are not" about services it does not have.
+    if [ "${DEPLOY_SERVICES[${#DEPLOY_SERVICES[@]}-1]}" = "$svc" ]; then
+        echo "${svc} is on the new image and did not become healthy; no other service was touched."
+    else
+        echo "The stack is now MIXED-VERSION: ${svc} is on the new image, later services are not."
+    fi
     rollback_hint "${PREVIOUS_TAGS:-}"
     exit 1
 }
@@ -777,8 +784,17 @@ rollback_hint() {
 # silently re-compile on the host and defeat the whole point of the registry.
 echo "  Restarting server..."
 docker compose -f "$COMPOSE_FILE" ${PROFILE_ARGS[@]+"${PROFILE_ARGS[@]}"} up -d --no-deps server
-echo "  Waiting for server to be healthy..."
-wait_for_port server 12349
+# The port the server was told to bind, from the same .env the container reads. Health
+# itself comes from Docker (the compose healthcheck derives its port the same way); this
+# is the port the messages name, and "did not become healthy on port 12349" for a tenant
+# on 12400 sent an operator to look at the wrong socket. The default matches the
+# compose file's own, so an .env that omits the key reports the port it actually uses.
+server_bind=$(grep -E '^[[:space:]]*WORKSPACE_BIND_ADDR=' .env | tail -n1 | cut -d= -f2- || true)
+server_bind="${server_bind%$'\r'}"
+server_port="${server_bind##*:}"
+[ -n "$server_port" ] || server_port=12349
+echo "  Waiting for server to be healthy (port ${server_port})..."
+wait_for_port server "$server_port"
 echo "  Server is up."
 
 # Internal service next, when this deployment includes one.

--- a/docker-compose.production.yml
+++ b/docker-compose.production.yml
@@ -128,7 +128,12 @@ services:
           cpus: '2.0'
     restart: unless-stopped
     healthcheck:
-      test: ["CMD", "nc", "-z", "127.0.0.1", "12349"]
+      # Probe the port the server was TOLD to bind, not a literal. A tenant provisioned on
+      # any other port (provision-tenant.sh allocates them) ran forever "unhealthy" against
+      # 12349 while answering registrations on its real port, and deploy.sh's health wait
+      # timed out on a working server. `$$` keeps Compose from interpolating at parse time;
+      # the container's shell expands WORKSPACE_BIND_ADDR (host:port) to its port.
+      test: ["CMD-SHELL", "nc -z 127.0.0.1 $${WORKSPACE_BIND_ADDR##*:}"]
       interval: 15s
       timeout: 5s
       retries: 5

--- a/scripts/test-deploy-services.sh
+++ b/scripts/test-deploy-services.sh
@@ -183,6 +183,7 @@ run_deploy() { # <name> <service>...
   {
     [ -n "${NO_MASTER_PW:-}" ] || printf 'WORKSPACE_MASTER_PASSWORD=test-password-not-a-placeholder\n'
     [ -n "${NO_ORIGINS:-}" ] || printf 'INTERNAL_SERVICE_ALLOWED_ORIGINS=https://tenant.example\n'
+    [ -z "${BIND_PORT:-}" ] || printf 'WORKSPACE_BIND_ADDR=0.0.0.0:%s\n' "$BIND_PORT"
   } > "$dir/.env"
   export CALLS="$dir/calls.txt"
   export PREEXISTING="${PREEXISTING:-}"
@@ -333,6 +334,14 @@ assert_failed "$d"
 grep -q "WORKSPACE_MASTER_PASSWORD is unset" "$d/out.txt" \
   || fail "a .env without the master password was refused without saying why (see $d/out.txt)"
 echo "  no-master   -> refused, and says so (was a silent exit)"; pass_count=$((pass_count+1))
+
+# The health wait names the port the .env binds, not a literal 12349. A tenant on any
+# other port was told to look at the wrong socket when the server did not come up.
+d=$(BIND_PORT=12400 run_deploy bind-port server)
+assert_succeeded "$d"
+grep -q "healthy (port 12400)" "$d/out.txt" || fail "the health wait did not name the .env port (see $d/out.txt)"
+if grep -q "12349" "$d/out.txt"; then fail "the health wait still names 12349 for a tenant bound to 12400 (see $d/out.txt)"; fi
+echo "  bind-port   -> the health wait names the port from .env"; pass_count=$((pass_count+1))
 
 # --- slimming an EXISTING full stack: refuse, do not half-apply --------------
 # `docker compose up` leaves containers for undeclared services running and merely warns, so

--- a/scripts/test-deploy-services.sh
+++ b/scripts/test-deploy-services.sh
@@ -142,6 +142,8 @@ fi
 
 # verify-image-revisions.sh calls `docker image inspect --format ... <ref>`
 if [ "${1:-}" = "image" ] && [ "${2:-}" = "inspect" ]; then
+  for ref; do :; done   # last argument: the image reference
+  case " ${IMAGE_INSPECT_FAILS:-} " in *" $ref "*) exit 1 ;; esac
   echo "testrevision0000"
   exit 0
 fi
@@ -174,7 +176,14 @@ run_deploy() { # <name> <service>...
   cp "$REPO_ROOT/scripts/select-deploy-services.sh" "$REPO_ROOT/scripts/verify-image-revisions.sh" "$dir/scripts/"
   cp "$REPO_ROOT/deploy.sh" "$dir/deploy.sh"
   # deploy.sh requires a .env with a real master password.
-  printf 'WORKSPACE_MASTER_PASSWORD=test-password-not-a-placeholder\n' > "$dir/.env"
+  # The .env a real tenant has. Origins are required whenever internal-service is
+  # deployed, so every fixture carries them unless a case says otherwise (NO_ORIGINS=1
+  # for the server-only case that must succeed without them). CI exports the variable in
+  # its own environment; deploy.sh is run with it unset below so the FILE is what is tested.
+  {
+    [ -n "${NO_MASTER_PW:-}" ] || printf 'WORKSPACE_MASTER_PASSWORD=test-password-not-a-placeholder\n'
+    [ -n "${NO_ORIGINS:-}" ] || printf 'INTERNAL_SERVICE_ALLOWED_ORIGINS=https://tenant.example\n'
+  } > "$dir/.env"
   export CALLS="$dir/calls.txt"
   export PREEXISTING="${PREEXISTING:-}"
   export PREEXISTING_ONEOFF="${PREEXISTING_ONEOFF:-}"
@@ -182,6 +191,7 @@ run_deploy() { # <name> <service>...
   export PREEXISTING_LATENT="${PREEXISTING_LATENT:-}"
   export PREEXISTING_PAUSED="${PREEXISTING_PAUSED:-}"
   export INSPECT_FAILS="${INSPECT_FAILS:-}"
+  export IMAGE_INSPECT_FAILS="${IMAGE_INSPECT_FAILS:-}"
   export PS_ID_FAILS="${PS_ID_FAILS:-}"
   : > "$CALLS"
   # --no-pull skips step 1 (git pull); the fixture dir is deliberately not a git repo, and the
@@ -210,7 +220,7 @@ run_deploy() { # <name> <service>...
     flock -n 8 || fail "test harness could not take the lock it is meant to hold"
   fi
   ( cd "$dir" && HOME="$dir" PATH="$WORK/bin:$PATH" \
-      bash ./deploy.sh --no-pull >"$dir/out.txt" 2>&1 ) || status=$?
+      env -u INTERNAL_SERVICE_ALLOWED_ORIGINS bash ./deploy.sh --no-pull ${DEPLOY_ARGS:-} >"$dir/out.txt" 2>&1 ) || status=$?
   [ -n "${HOLD_LOCK:-}" ] && exec 8>&-
   [ -n "${HOLD_CHECKOUT:-}" ] && exec 7<&-
   echo "$status" > "$dir/status.txt"
@@ -283,6 +293,46 @@ assert_pulled "$d" "server internal-service"
 assert_restarted "$d" server internal-service
 assert_never_mentions "$d" ui
 echo "  server-is   -> never touched ui"; pass_count=$((pass_count+1))
+
+# --local-images: no registry contact, and a missing image still stops the deploy
+# before anything is restarted. The second case is the control for the first: if
+# the revision gate stopped inspecting, or ran after `up`, it goes red.
+d=$(DEPLOY_ARGS=--local-images run_deploy local-images server)
+assert_succeeded "$d"
+if grep -qE '^compose .* pull ' "$d/calls.txt"; then
+  fail "--local-images still ran 'compose pull' (see $d/out.txt)"
+fi
+grep -qE '^image inspect .*citadel-workspace-server' "$d/calls.txt" \
+  || fail "--local-images skipped the pull but never inspected the image it is about to run (see $d/out.txt)"
+assert_restarted "$d" server
+echo "  local-images -> no pull; inspected and restarted server"; pass_count=$((pass_count+1))
+
+d=$(DEPLOY_ARGS=--local-images IMAGE_INSPECT_FAILS="ghcr.io/avarok-cybersecurity/citadel-workspace-server:latest" run_deploy local-images-missing server)
+assert_failed "$d"
+if grep -qE 'up -d' "$d/calls.txt"; then
+  fail "--local-images with a missing image still ran 'up -d' - the gate must stop it first (see $d/out.txt)"
+fi
+echo "  local-images -> a missing image aborts before any restart (control)"; pass_count=$((pass_count+1))
+
+# A .env WITHOUT INTERNAL_SERVICE_ALLOWED_ORIGINS (the harness never writes one) on a
+# server-only deploy must succeed. It used to die silently after the banner: grep found
+# no key, pipefail made the pipeline fail, set -e exited. CI exported the variable in
+# its environment, so deploy.sh never reached the file read there and this was never
+# measured. The harness now runs deploy.sh with the variable unset, always.
+d=$(NO_ORIGINS=1 run_deploy no-origins-key server)
+assert_succeeded "$d"
+assert_restarted "$d" server
+echo "  no-origins  -> a .env without the origins key deploys server-only (was a silent exit)"; pass_count=$((pass_count+1))
+
+# A .env without the master password must be refused WITH the message that says so.
+# The read had the same shape as the origins one: grep exit 1, pipefail, set -e, and
+# the deploy died before the "unset" branch could speak. An operator got a banner and
+# exit 1, and nothing to act on.
+d=$(NO_MASTER_PW=1 run_deploy no-master-password server)
+assert_failed "$d"
+grep -q "WORKSPACE_MASTER_PASSWORD is unset" "$d/out.txt" \
+  || fail "a .env without the master password was refused without saying why (see $d/out.txt)"
+echo "  no-master   -> refused, and says so (was a silent exit)"; pass_count=$((pass_count+1))
 
 # --- slimming an EXISTING full stack: refuse, do not half-apply --------------
 # `docker compose up` leaves containers for undeclared services running and merely warns, so

--- a/scripts/test-provision-tenant.sh
+++ b/scripts/test-provision-tenant.sh
@@ -77,5 +77,15 @@ for topo in server-only full; do
   fi
 done
 
+# The compose the provisioner ships must probe the port the server was TOLD to bind.
+# A literal port in the server healthcheck made every tenant on a non-default port run
+# "unhealthy" forever while answering registrations, and deploy.sh's health wait timed
+# out on a working server. Asserted on the trimmed file, which is what a tenant gets.
+if python3 "$ROOT/scripts/trim-compose.py" "$ROOT/docker-compose.production.yml" server \
+     | awk '/^  server:/{f=1} f' | grep -qE 'nc -z 127\.0\.0\.1 \$\$\{WORKSPACE_BIND_ADDR##\*:\}'; then
+  echo "  ok: server healthcheck derives its port from WORKSPACE_BIND_ADDR"
+else
+  echo "  FAIL: server healthcheck does not derive its port from WORKSPACE_BIND_ADDR"; fails=$((fails+1))
+fi
 if [ "$fails" -ne 0 ]; then echo "FAIL: $fails assertion(s)"; exit 1; fi
 echo "provision-tenant: all guards refuse, all valid inputs accepted."

--- a/scripts/test-provision-tenant.sh
+++ b/scripts/test-provision-tenant.sh
@@ -81,7 +81,7 @@ done
 # A literal port in the server healthcheck made every tenant on a non-default port run
 # "unhealthy" forever while answering registrations, and deploy.sh's health wait timed
 # out on a working server. Asserted on the trimmed file, which is what a tenant gets.
-if python3 "$ROOT/scripts/trim-compose.py" "$ROOT/docker-compose.production.yml" server \
+if python3 scripts/trim-compose.py docker-compose.production.yml server \
      | awk '/^  server:/{f=1} f' | grep -qE 'nc -z 127\.0\.0\.1 \$\$\{WORKSPACE_BIND_ADDR##\*:\}'; then
   echo "  ok: server healthcheck derives its port from WORKSPACE_BIND_ADDR"
 else


### PR DESCRIPTION
Two lines in deploy.sh had the shape

    value=$(grep -E '^KEY=' .env | tail -n1 | cut -d= -f2-)

Under `set -euo pipefail` a .env that lacks KEY makes grep exit 1, the
pipeline exit 1, and the script exit -- after the banner, with no message. For
INTERNAL_SERVICE_ALLOWED_ORIGINS that is a server-only tenant, which has every
reason to omit the key; for WORKSPACE_MASTER_PASSWORD it meant the "is unset"
branch two lines down could never be reached. Both reads now tolerate absence
and let the checks that follow do the refusing, with words.

The harness never saw either because validate.yml exports
INTERNAL_SERVICE_ALLOWED_ORIGINS in its own environment, so deploy.sh took the
env branch and never read the file. The harness now runs deploy.sh with the
variable unset, its fixtures write the .env a real tenant has (origins present
unless a case says NO_ORIGINS=1, password present unless NO_MASTER_PW=1), and
two cases cover the two reads. Controls: removing either `|| true` turns its
case red -- the first by exiting, the second by refusing without the message.

--local-images: deploy the images already on this host without contacting the
registry. Needed while the GHCR packages are private and the host has no
token: `docker save | ssh host docker load`, then deploy. Safe only because
the revision gate inspects every image and stops before any restart when one
is missing; the harness proves both halves (no pull recorded; a missing image
aborts with no `up -d`).

https://claude.ai/code/session_01CQKcBi2QVjvJBEA8StPfN7