### PR TITLE
feat(ui-image): publish a loopback agent origin, from one value, into the CSP and the page

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -220,6 +220,11 @@ jobs:
 
       - name: Tenant provisioning refuses what it must
         run: bash scripts/test-provision-tenant.sh
+      - name: UI runtime config admits only what nginx can safely render
+        # The validator that runs before nginx renders, and the rendered template: the CSP is
+        # one map, every location references it, and LOOPBACK_AGENT_ORIGIN reaches the policy
+        # and the page meta from the same value. Needs envsubst (gettext-base, on the runner).
+        run: bash scripts/test-ui-runtime-config.sh
 
 
       - name: Every administrator promotion sits behind a gate

--- a/docker-compose.local.yml
+++ b/docker-compose.local.yml
@@ -121,6 +121,8 @@ services:
       # name - which is what stops a malicious site you visit from driving your agent through your
       # own browser. A publicly-served UI must leave this off; see docker-compose.production.yml.
       - WS_PROXY_ENABLED=1
+      # None, explicitly: a locally-served page reaches its agent through the /ws proxy above.
+      - LOOPBACK_AGENT_ORIGIN=
     ports:
       # 127.0.0.1 on the LEFT is load-bearing: it publishes the UI to THIS MACHINE only. A bare
       # "8080:8080" would bind every interface and hand /ws - and the agent behind it - to anyone

--- a/docker-compose.production.yml
+++ b/docker-compose.production.yml
@@ -273,6 +273,12 @@ services:
       # P2P traffic. Users run their own agent locally instead - see docker-compose.local.yml,
       # which is where /ws is both safe and enabled.
       - WS_PROXY_ENABLED=0
+      # The agent on the VISITOR'S machine, as a bare wss://host:port (e.g. wss://local.example.com:12345),
+      # or empty. A hosted page cannot reach an agent through its own origin (the proxy above is off),
+      # so the operator points a name at 127.0.0.1, holds a certificate for it, and publishes it here:
+      # nginx puts it in the CSP and in the page meta from this one value. provision-tenant.sh
+      # --loopback-host writes it. Empty leaves both untouched.
+      - LOOPBACK_AGENT_ORIGIN=${LOOPBACK_AGENT_ORIGIN:-}
     deploy:
       resources:
         limits:

--- a/docker/ui/16-validate-runtime-vars.sh
+++ b/docker/ui/16-validate-runtime-vars.sh
@@ -62,4 +62,13 @@ listen_addr="${LISTEN_ADDR:-}"
 echo "$listen_addr" | grep -Eq '^[0-9]{1,3}(\.[0-9]{1,3}){3}$|^\[[0-9A-Fa-f:]+\]$' \
   || die "LISTEN_ADDR='$listen_addr' must be an IPv4 address (e.g. 0.0.0.0 or 127.0.0.1) or a bracketed IPv6 address."
 
-echo "[validate-runtime-vars] ok: upstream=$upstream ws_proxy=$enabled listen=$listen_addr"
+# Optional. When set it is substituted into BOTH the Content-Security-Policy and the page's
+# <meta name="citadel-loopback-agent">, so it must be a bare wss://host:port and nothing that
+# could close a quoted nginx string or an HTML attribute: no path, no query, no quotes, no
+# semicolons, no spaces. Lowercase host, because a certificate name is.
+loopback="${LOOPBACK_AGENT_ORIGIN:-}"
+if [ -n "$loopback" ]; then
+  echo "$loopback" | grep -Eq '^wss://[a-z0-9]([a-z0-9.-]*[a-z0-9])?:[0-9]{1,5}$' \
+    || die "LOOPBACK_AGENT_ORIGIN='$loopback' must be a bare wss://host:port (e.g. wss://local.example.com:12345), or empty."
+fi
+echo "[validate-runtime-vars] ok: upstream=$upstream ws_proxy=$enabled listen=$listen_addr loopback=${loopback:-<none>}"

--- a/docker/ui/17-default-runtime-vars.envsh
+++ b/docker/ui/17-default-runtime-vars.envsh
@@ -1,0 +1,15 @@
+#!/bin/sh
+# Sourced (not executed) by the nginx entrypoint, so the export reaches
+# 20-envsubst-on-templates.sh. That step substitutes only the variables that are
+# PRESENT in the environment and match NGINX_ENVSUBST_FILTER; an absent one is
+# left as the literal `${LOOPBACK_AGENT_ORIGIN}` in the rendered config, which
+# nginx then reads as its own (undefined) variable and refuses to start:
+#
+#   nginx: [emerg] unknown "loopback_agent_origin" variable
+#
+# Compose deployments always pass the variable, if only empty; a bare
+# `docker run` of the image does not. Absent means "no loopback agent origin",
+# exactly as empty does, and 16-validate-runtime-vars.sh has already validated
+# whatever value was present. The three required variables are NOT defaulted
+# here: for those, absent is a misconfiguration and the validator says so.
+export LOOPBACK_AGENT_ORIGIN="${LOOPBACK_AGENT_ORIGIN:-}"

--- a/docker/ui/Dockerfile
+++ b/docker/ui/Dockerfile
@@ -247,7 +247,7 @@ ENV LISTEN_ADDR=0.0.0.0
 # That makes this an injection guard: whoever can set env vars on the container could
 # otherwise alter the proxy's behaviour, including the headers it forwards. The smoke
 # test asserts the property directly by starting the image with a colliding variable.
-ENV NGINX_ENVSUBST_FILTER=^(AGENT_UPSTREAM|WS_PROXY_ENABLED|LISTEN_ADDR)$
+ENV NGINX_ENVSUBST_FILTER=^(AGENT_UPSTREAM|WS_PROXY_ENABLED|LISTEN_ADDR|LOOPBACK_AGENT_ORIGIN)$
 
 # The entrypoint renders templates into /etc/nginx/conf.d at start-up, and we run as
 # the unprivileged `nginx` user - so that directory must be writable by it. Without

--- a/docker/ui/Dockerfile
+++ b/docker/ui/Dockerfile
@@ -207,6 +207,13 @@ COPY docker/ui/nginx.conf.template /etc/nginx/templates/default.conf.template
 # Numbered 16 so it runs after the base image's own scripts and before 20-envsubst-on-templates.sh.
 COPY docker/ui/16-validate-runtime-vars.sh /docker-entrypoint.d/16-validate-runtime-vars.sh
 RUN chmod +x /docker-entrypoint.d/16-validate-runtime-vars.sh
+# Sourced by the entrypoint between validation (16-) and rendering (20-): defaults the one
+# OPTIONAL runtime variable to empty, because envsubst substitutes only variables present in
+# the environment and nginx refuses a config with the literal `${LOOPBACK_AGENT_ORIGIN}` left in.
+COPY docker/ui/17-default-runtime-vars.envsh /docker-entrypoint.d/17-default-runtime-vars.envsh
+# The entrypoint sources an .envsh only if it is executable, and IGNORES it otherwise -- a
+# file that is merely present changes nothing, silently.
+RUN chmod +x /docker-entrypoint.d/17-default-runtime-vars.envsh
 
 # Where the agent lives. Default suits host networking (and the dev stack). Override
 # with `-e AGENT_UPSTREAM=internal-service:12345` on a bridge network, or

--- a/docker/ui/nginx.conf.template
+++ b/docker/ui/nginx.conf.template
@@ -3,8 +3,8 @@
 #
 # Rendered at CONTAINER START by the nginx image's envsubst entrypoint
 # (/docker-entrypoint.d/20-envsubst-on-templates.sh), which writes the result to
-# /etc/nginx/conf.d/. Exactly three variables are substituted - ${AGENT_UPSTREAM},
-# ${WS_PROXY_ENABLED} and ${LISTEN_ADDR} - because NGINX_ENVSUBST_FILTER in the
+# /etc/nginx/conf.d/. Exactly four variables are substituted - ${AGENT_UPSTREAM},
+# ${WS_PROXY_ENABLED}, ${LISTEN_ADDR} and ${LOOPBACK_AGENT_ORIGIN} - because NGINX_ENVSUBST_FILTER in the
 # Dockerfile pins the list to those names.
 #
 # That pinning is an INJECTION GUARD, not (as one might assume) protection against
@@ -85,6 +85,23 @@ map $http_host $ws_host_allowed {
     "~*^0\.0\.0\.0(:[0-9]+)?$"         1;
 }
 
+# The Content-Security-Policy, defined ONCE.
+#
+# `add_header` does not inherit into a block that declares its own, so six locations each
+# carried a byte-identical copy of this string and any change had to land in all six -- the
+# kind of duplication that lets one copy drift silently. A map evaluates per request, so every
+# `add_header Content-Security-Policy $csp` below emits the same policy.
+#
+# ${LOOPBACK_AGENT_ORIGIN} is the ONE off-origin socket a hosted page may open: the agent on
+# the VISITOR'S OWN machine, reached through a name the operator points at 127.0.0.1 and holds
+# a real certificate for (e.g. wss://local.example.com:12345). The same value is written into
+# the page's <meta name="citadel-loopback-agent"> below, so what the app dials and what the
+# policy permits cannot disagree. Empty (the default) leaves `connect-src 'self'` alone.
+# 16-validate-runtime-vars.sh admits only a bare wss://host:port here.
+map $host $csp {
+    default "default-src 'self'; script-src 'self' 'wasm-unsafe-eval' 'unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; font-src 'self' data:; connect-src 'self' ${LOOPBACK_AGENT_ORIGIN}; worker-src 'self' blob:; object-src 'none'; frame-ancestors 'none'; base-uri 'self'; form-action 'self'";
+}
+
 server {
     # LISTEN_ADDR is 0.0.0.0 by default, which is what a bridge-networked container
     # needs for `-p 8080:8080` to reach it. Under HOST networking, though, 0.0.0.0
@@ -154,7 +171,7 @@ server {
     add_header X-Content-Type-Options "nosniff" always;
     add_header Referrer-Policy "strict-origin-when-cross-origin" always;
     add_header Permissions-Policy "geolocation=(), microphone=(self), camera=(self), display-capture=(self)" always;
-    add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'wasm-unsafe-eval' 'unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; font-src 'self' data:; connect-src 'self'; worker-src 'self' blob:; object-src 'none'; frame-ancestors 'none'; base-uri 'self'; form-action 'self'" always;
+    add_header Content-Security-Policy $csp always;
 
     # -------------------------------------------------------------------------
     # The agent socket.
@@ -279,7 +296,7 @@ server {
         add_header X-Content-Type-Options "nosniff" always;
         add_header Referrer-Policy "strict-origin-when-cross-origin" always;
         add_header Permissions-Policy "geolocation=(), microphone=(self), camera=(self), display-capture=(self)" always;
-        add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'wasm-unsafe-eval' 'unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; font-src 'self' data:; connect-src 'self'; worker-src 'self' blob:; object-src 'none'; frame-ancestors 'none'; base-uri 'self'; form-action 'self'" always;
+        add_header Content-Security-Policy $csp always;
     }
 
     # WASM files
@@ -302,7 +319,7 @@ server {
         add_header X-Content-Type-Options "nosniff" always;
         add_header Referrer-Policy "strict-origin-when-cross-origin" always;
         add_header Permissions-Policy "geolocation=(), microphone=(self), camera=(self), display-capture=(self)" always;
-        add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'wasm-unsafe-eval' 'unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; font-src 'self' data:; connect-src 'self'; worker-src 'self' blob:; object-src 'none'; frame-ancestors 'none'; base-uri 'self'; form-action 'self'" always;
+        add_header Content-Security-Policy $csp always;
     }
 
     # ---------------------------------------------------------------------------
@@ -329,7 +346,7 @@ server {
         add_header X-Content-Type-Options "nosniff" always;
         add_header Referrer-Policy "strict-origin-when-cross-origin" always;
         add_header Permissions-Policy "geolocation=(), microphone=(self), camera=(self), display-capture=(self)" always;
-        add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'wasm-unsafe-eval' 'unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; font-src 'self' data:; connect-src 'self'; worker-src 'self' blob:; object-src 'none'; frame-ancestors 'none'; base-uri 'self'; form-action 'self'" always;
+        add_header Content-Security-Policy $csp always;
     }
 
     location = /manifest.webmanifest {
@@ -340,7 +357,7 @@ server {
         add_header X-Content-Type-Options "nosniff" always;
         add_header Referrer-Policy "strict-origin-when-cross-origin" always;
         add_header Permissions-Policy "geolocation=(), microphone=(self), camera=(self), display-capture=(self)" always;
-        add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'wasm-unsafe-eval' 'unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; font-src 'self' data:; connect-src 'self'; worker-src 'self' blob:; object-src 'none'; frame-ancestors 'none'; base-uri 'self'; form-action 'self'" always;
+        add_header Content-Security-Policy $csp always;
     }
 
     # SPA fallback - serve index.html for all non-file routes.
@@ -375,11 +392,15 @@ server {
     # security header set is repeated here - see the note at the top of the server block.
     location / {
         try_files $uri $uri/ /index.html;
+        # Hand the page the loopback agent origin the policy above permits. index.html ships
+        # the meta empty; this fills it in. Same variable as the CSP, so the two cannot drift.
+        sub_filter 'name="citadel-loopback-agent" content=""' 'name="citadel-loopback-agent" content="${LOOPBACK_AGENT_ORIGIN}"';
+        sub_filter_once on;
         add_header Cache-Control "public, no-cache" always;
         add_header X-Frame-Options "DENY" always;
         add_header X-Content-Type-Options "nosniff" always;
         add_header Referrer-Policy "strict-origin-when-cross-origin" always;
         add_header Permissions-Policy "geolocation=(), microphone=(self), camera=(self), display-capture=(self)" always;
-        add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'wasm-unsafe-eval' 'unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; font-src 'self' data:; connect-src 'self'; worker-src 'self' blob:; object-src 'none'; frame-ancestors 'none'; base-uri 'self'; form-action 'self'" always;
+        add_header Content-Security-Policy $csp always;
     }
 }

--- a/scripts/provision-tenant.sh
+++ b/scripts/provision-tenant.sh
@@ -39,6 +39,10 @@
 #   --ingress MODE  nginx | tunnel | none        (default: none)
 #   --topology MODE server-only | full           (default: server-only)
 #   --domain FQDN   Required unless --ingress none.
+#   --loopback-host NAME
+#                   A name that resolves to 127.0.0.1 (e.g. local.example.com) and holds a
+#                   certificate; the hosted UI dials the visitor's OWN agent at
+#                   wss://NAME:12345. Needs --topology full. See docker-compose.production.yml.
 #   --base-port N   First port of this tenant's block (default: auto).
 #   --root DIR      Where tenants live (default: /srv/citadel-tenants).
 #   --dry-run       Print what would be written; touch nothing.
@@ -58,6 +62,7 @@ while [ $# -gt 0 ]; do
     --ingress)   INGRESS="${2:?--ingress needs a value}"; shift 2 ;;
     --topology)  TOPOLOGY="${2:?--topology needs a value}"; shift 2 ;;
     --domain)    DOMAIN="${2:?--domain needs a value}"; shift 2 ;;
+    --loopback-host) LOOPBACK_HOST="${2:?--loopback-host needs a value}"; shift 2 ;;
     --base-port) BASE_PORT="${2:?--base-port needs a value}"; shift 2 ;;
     --root)      ROOT="${2:?--root needs a value}"; shift 2 ;;
     --dry-run)   DRY_RUN=true; shift ;;
@@ -82,6 +87,17 @@ fi
 if [ "$INGRESS" != "none" ] && [ "$TOPOLOGY" = "server-only" ]; then
   die "--ingress $INGRESS needs --topology full: a server-only tenant serves no UI to route to"
 fi
+LOOPBACK_HOST="${LOOPBACK_HOST:-}"
+if [ -n "$LOOPBACK_HOST" ]; then
+  [ "$TOPOLOGY" = "full" ] || die "--loopback-host needs --topology full: only a served UI dials a visitor's agent"
+  # Lowercase DNS label(s) only: this value is substituted into the UI's CSP and page meta, and
+  # 16-validate-runtime-vars.sh in the image refuses anything else at container start -- but a
+  # refusal there is a failed deploy, and a refusal here is a failed provision, which is cheaper.
+  echo "$LOOPBACK_HOST" | grep -Eq '^[a-z0-9]([a-z0-9.-]*[a-z0-9])?$' \
+    || die "--loopback-host '$LOOPBACK_HOST' must be a lowercase DNS name (no scheme, port or path)"
+fi
+# The port the published agent binary binds by convention (docs/AGENT_README.md).
+LOOPBACK_AGENT_ORIGIN="${LOOPBACK_HOST:+wss://$LOOPBACK_HOST:12345}"
 
 # --- port allocation ---------------------------------------------------------
 # A tenant owns a block of 10: +0 server, +1 agent, +2 UI -- spaced so a fourth
@@ -159,6 +175,7 @@ WORKSPACE_BIND_ADDR=$BIND_ADDR
 INTERNAL_SERVICE_PORT=$AGENT_PORT
 INTERNAL_SERVICE_BIND_HOST=$AGENT_BIND_HOST
 INTERNAL_SERVICE_ALLOWED_ORIGINS=$ORIGINS
+LOOPBACK_AGENT_ORIGIN=$LOOPBACK_AGENT_ORIGIN
 IMAGE_TAG=${IMAGE_TAG:-latest}
 EOF
   [ "$INGRESS" = "tunnel" ] && echo "TUNNEL_TOKEN=${TUNNEL_TOKEN:-__SET_ME__}"
@@ -170,6 +187,7 @@ EOF
 echo "tenant      : $TENANT"
 echo "topology    : $TOPOLOGY"
 echo "ingress     : $INGRESS${DOMAIN:+ ($DOMAIN)}"
+echo "loopback    : ${LOOPBACK_AGENT_ORIGIN:-none}"
 echo "ports       : server=$SERVER_PORT agent=$AGENT_PORT ui=$UI_PORT"
 echo "directory   : $TENANT_DIR"
 

--- a/scripts/smoke-ui-ws.sh
+++ b/scripts/smoke-ui-ws.sh
@@ -224,7 +224,7 @@ done
 echo "  opt-in: only the literal WS_PROXY_ENABLED=1 enables the proxy; unset, '', 0, false, off, no, on, yes and true all disable it while still serving the SPA."
 
 # ---------------------------------------------------------------------------
-# 3. envsubst is pinned to our three variables (NGINX_ENVSUBST_FILTER).
+# 3. envsubst is pinned to our four variables (NGINX_ENVSUBST_FILTER).
 # ---------------------------------------------------------------------------
 # Unfiltered, envsubst is eligible to replace EVERY environment variable - so an env var
 # whose name collides with an nginx variable rewrites the config. Start the image with a
@@ -250,7 +250,8 @@ echo "  envsubst: pinned - colliding env vars (host, http_upgrade) cannot rewrit
 # entrypoint validator must now refuse to start instead.
 for bad_var in "AGENT_UPSTREAM=127.0.0.1:12345/; return 200 \"X\"; #" \
                "WS_PROXY_ENABLED=1\"; return 200 \"X\"; #" \
-               "LISTEN_ADDR=0.0.0.0; return 200 \"X\"; #"; do
+               "LISTEN_ADDR=0.0.0.0; return 200 \"X\"; #" \
+               "LOOPBACK_AGENT_ORIGIN=wss://local.example.com:12345\"; return 200 \"X\"; #"; do
   vc="smoke-ui-inject"
   docker rm -f "$vc" >/dev/null 2>&1 || true
   docker run -d --name "$vc" -e WS_PROXY_ENABLED=1 -e AGENT_UPSTREAM=127.0.0.1:12345 \
@@ -265,4 +266,28 @@ for bad_var in "AGENT_UPSTREAM=127.0.0.1:12345/; return 200 \"X\"; #" \
 done
 echo "  injection: runtime variables containing nginx metacharacters are rejected at startup."
 
+# ---------------------------------------------------------------------------
+# 5. A published loopback agent origin reaches the page AND the policy, from one value.
+# ---------------------------------------------------------------------------
+# This is the rendered container, not the template: the meta must be filled in the HTML
+# nginx actually serves (a build step that rewrote the placeholder would break it silently),
+# and the CSP header the browser enforces must carry the same origin. Without the variable
+# both must be exactly as before -- an empty meta and `connect-src 'self'`.
+LOOP="wss://local.example.com:12345"
+cleanup
+docker run -d --name "$CTR" -e WS_PROXY_ENABLED=0 -e "LOOPBACK_AGENT_ORIGIN=$LOOP" \
+  -p "127.0.0.1:${PORT}:8080" "$IMAGE" >/dev/null
+for ((i = 1; i <= 30; i++)); do curl -sf -o /dev/null "$BASE/" 2>/dev/null && break; sleep 1; done
+curl -sf "$BASE/" | grep -q "name=\"citadel-loopback-agent\" content=\"$LOOP\"" \
+  || fail "the served index.html does not carry the loopback origin in <meta name=\"citadel-loopback-agent\">."
+curl -s -D - -o /dev/null "$BASE/" | grep -i '^content-security-policy' | grep -q "connect-src 'self' $LOOP;" \
+  || fail "the Content-Security-Policy header does not permit the loopback origin the page was told to dial."
+cleanup
+docker run -d --name "$CTR" -e WS_PROXY_ENABLED=0 -p "127.0.0.1:${PORT}:8080" "$IMAGE" >/dev/null
+for ((i = 1; i <= 30; i++)); do curl -sf -o /dev/null "$BASE/" 2>/dev/null && break; sleep 1; done
+curl -sf "$BASE/" | grep -q 'name="citadel-loopback-agent" content=""' \
+  || fail "without LOOPBACK_AGENT_ORIGIN the meta is not present-and-empty; the app would dial something other than same-origin /ws, or nothing."
+curl -s -D - -o /dev/null "$BASE/" | grep -i '^content-security-policy' | grep -q "connect-src 'self' ;" \
+  || fail "without LOOPBACK_AGENT_ORIGIN connect-src changed."
+echo "  loopback: the published origin lands in the served meta and the CSP; absent, both are untouched."
 echo "== all /ws smoke assertions passed =="

--- a/scripts/test-provision-tenant.sh
+++ b/scripts/test-provision-tenant.sh
@@ -40,6 +40,10 @@ refuses "no port tool available"      env PATH=/nonexistent bash $S --tenant a -
 accepts "server-only, no ingress"     $S --tenant ok1 --dry-run
 accepts "full + tunnel"               $S --tenant ok2 --topology full --ingress tunnel --domain w.example --dry-run
 accepts "full + nginx"                $S --tenant ok3 --topology full --ingress nginx --domain w.example --dry-run
+refuses "loopback-host on server-only" $S --tenant a --loopback-host local.w.example --dry-run
+refuses "loopback-host with a scheme"  $S --tenant a --topology full --loopback-host wss://local.w.example --dry-run
+refuses "loopback-host with a port"    $S --tenant a --topology full --loopback-host local.w.example:12345 --dry-run
+accepts "full + nginx + loopback-host" $S --tenant ok4 --topology full --ingress nginx --domain w.example --loopback-host local.w.example --dry-run
 
 # An occupied port must be rejected. Bind one here rather than trusting that
 # some well-known port happens to be busy on the runner -- a port that is free
@@ -77,5 +81,19 @@ for topo in server-only full; do
   fi
 done
 
+# The .env a --loopback-host tenant gets carries the origin the UI will dial, and one without
+# the flag carries the key empty -- present, so the compose default never silently applies.
+out=$($S --tenant ok5 --topology full --ingress nginx --domain w.example --loopback-host local.w.example --dry-run 2>/dev/null || true)
+if echo "$out" | grep -q "^LOOPBACK_AGENT_ORIGIN=wss://local.w.example:12345$"; then
+  echo "  ok: --loopback-host lands in .env as wss://host:12345"
+else
+  echo "  FAIL: --loopback-host did not produce LOOPBACK_AGENT_ORIGIN=wss://local.w.example:12345"; fails=$((fails+1))
+fi
+out=$($S --tenant ok6 --topology full --ingress nginx --domain w.example --dry-run 2>/dev/null || true)
+if echo "$out" | grep -q "^LOOPBACK_AGENT_ORIGIN=$"; then
+  echo "  ok: without --loopback-host the key is present and empty"
+else
+  echo "  FAIL: without --loopback-host the key is missing or non-empty"; fails=$((fails+1))
+fi
 if [ "$fails" -ne 0 ]; then echo "FAIL: $fails assertion(s)"; exit 1; fi
 echo "provision-tenant: all guards refuse, all valid inputs accepted."

--- a/scripts/test-ui-runtime-config.sh
+++ b/scripts/test-ui-runtime-config.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+#
+# The UI image's runtime configuration, tested WITHOUT the image: the validator that runs
+# before nginx renders anything, and the rendered template itself.
+#
+# Two things have to hold. LOOPBACK_AGENT_ORIGIN is substituted into a quoted nginx string
+# (the CSP) and into an HTML attribute (the page meta), so the validator must admit only a
+# bare wss://host:port -- a value that reaches the template is configuration, and a quote or
+# semicolon in it is an injection. And the CSP is defined once, as a map: every location
+# must reference it, and the origin must land in connect-src and in the meta, from the same
+# variable, so what the app dials and what the policy permits cannot disagree.
+#
+# Usage: scripts/test-ui-runtime-config.sh   (from the repo root; needs envsubst from gettext)
+set -euo pipefail
+V=docker/ui/16-validate-runtime-vars.sh
+T=docker/ui/nginx.conf.template
+fails=0
+passes=0
+ok()   { echo "  ok: $1"; passes=$((passes+1)); }
+bad()  { echo "  FAIL: $1"; fails=$((fails+1)); }
+base=(AGENT_UPSTREAM=127.0.0.1:12345 WS_PROXY_ENABLED=0 LISTEN_ADDR=0.0.0.0)
+
+accepts() { # <label> <LOOPBACK value or __unset__>
+  local label="$1" val="$2"; local -a e=("${base[@]}")
+  [ "$val" = "__unset__" ] || e+=("LOOPBACK_AGENT_ORIGIN=$val")
+  if env -i "${e[@]}" sh "$V" >/dev/null 2>&1; then ok "validator accepts $label"; else bad "validator refused $label"; fi
+}
+refuses() { # <label> <LOOPBACK value>
+  if env -i "${base[@]}" "LOOPBACK_AGENT_ORIGIN=$2" sh "$V" >/dev/null 2>&1; then bad "validator ACCEPTED $1"; else ok "validator refuses $1"; fi
+}
+accepts "no loopback origin"              __unset__
+accepts "an empty loopback origin"        ""
+accepts "a bare wss origin"               "wss://local.example.com:12345"
+refuses "a plain ws scheme"               "ws://local.example.com:12345"
+refuses "a path on the origin"            "wss://local.example.com:12345/ws"
+refuses "a missing port"                  "wss://local.example.com"
+refuses "an nginx string breakout"        'wss://local.example.com:12345"; return 200 "X"; #'
+refuses "an HTML attribute breakout"      'wss://local.example.com:12345"><script>'
+refuses "a semicolon (CSP directive end)" "wss://local.example.com:12345; default-src *"
+refuses "an uppercase host"               "wss://Local.Example.com:12345"
+
+render() { # <LOOPBACK value> -> rendered config on stdout, only the filtered variables substituted
+  # env -i so nothing else in the caller's environment can leak into the render -- but keep
+  # PATH, or envsubst itself cannot be found.
+  env -i PATH="$PATH" "${base[@]}" "LOOPBACK_AGENT_ORIGIN=$1" envsubst '${AGENT_UPSTREAM} ${WS_PROXY_ENABLED} ${LISTEN_ADDR} ${LOOPBACK_AGENT_ORIGIN}' < "$T"
+}
+r=$(render "wss://local.example.com:12345")
+[ "$(echo "$r" | grep -c '^map \$host \$csp')" = "1" ] && ok "the CSP is defined once, as a map" || bad "the CSP map is missing or duplicated"
+[ "$(echo "$r" | grep -cE 'add_header Content-Security-Policy "')" = "0" ] && ok "no location carries its own CSP string" || bad "a location still carries a literal CSP"
+[ "$(echo "$r" | grep -c 'add_header Content-Security-Policy $csp always;')" -ge 6 ] && ok "every location references the map" || bad "fewer than six locations reference \$csp"
+echo "$r" | grep -q "connect-src 'self' wss://local.example.com:12345;" && ok "the origin lands in connect-src" || bad "connect-src does not carry the origin"
+echo "$r" | grep -q 'name="citadel-loopback-agent" content="wss://local.example.com:12345"' && ok "the origin lands in the page meta" || bad "the meta substitution does not carry the origin"
+r0=$(render "")
+echo "$r0" | grep -q "connect-src 'self' ;" && ok "empty origin leaves connect-src 'self' alone" || bad "empty origin changed connect-src"
+echo "$r0" | grep -q 'content=""' && ok "empty origin leaves the meta empty" || bad "empty origin filled the meta"
+# The validator runs BEFORE the template is rendered: the nginx image runs /docker-entrypoint.d
+# in name order, and the envsubst step is 20-*. A validator named later would validate a config
+# already written.
+[ "$(basename "$V")" \< "20-envsubst-on-templates.sh" ] && ok "validator runs before envsubst (16- < 20-)" || bad "validator would run after envsubst"
+
+if [ "$fails" -ne 0 ]; then echo "FAIL: $fails assertion(s)"; exit 1; fi
+echo "ui-runtime-config: all $passes assertions passed."

--- a/scripts/test-ui-runtime-config.sh
+++ b/scripts/test-ui-runtime-config.sh
@@ -39,11 +39,35 @@ refuses "an HTML attribute breakout"      'wss://local.example.com:12345"><scrip
 refuses "a semicolon (CSP directive end)" "wss://local.example.com:12345; default-src *"
 refuses "an uppercase host"               "wss://Local.Example.com:12345"
 
-render() { # <LOOPBACK value> -> rendered config on stdout, only the filtered variables substituted
-  # env -i so nothing else in the caller's environment can leak into the render -- but keep
-  # PATH, or envsubst itself cannot be found.
-  env -i PATH="$PATH" "${base[@]}" "LOOPBACK_AGENT_ORIGIN=$1" envsubst '${AGENT_UPSTREAM} ${WS_PROXY_ENABLED} ${LISTEN_ADDR} ${LOOPBACK_AGENT_ORIGIN}' < "$T"
+# Mirror the nginx entrypoint exactly: 20-envsubst-on-templates.sh substitutes ONLY the
+# variables PRESENT in the environment whose names match NGINX_ENVSUBST_FILTER, after sourcing
+# every *.envsh in /docker-entrypoint.d. A test that hands envsubst a fixed variable list
+# cannot see what an absent variable does -- and an absent one is left as the literal
+# `${LOOPBACK_AGENT_ORIGIN}`, which nginx reads as its own undefined variable and dies on.
+ENVSH=docker/ui/17-default-runtime-vars.envsh
+FILTER='^(AGENT_UPSTREAM|WS_PROXY_ENABLED|LISTEN_ADDR|LOOPBACK_AGENT_ORIGIN)$'
+render() { # [LOOPBACK value | __absent__] -> rendered config on stdout
+  local -a e=("${base[@]}")
+  [ "${1:-__absent__}" = "__absent__" ] || e+=("LOOPBACK_AGENT_ORIGIN=$1")
+  # SKIP_ENVSH is the control's switch: it must cross env -i explicitly or the control cannot
+  # skip anything and reads green for nothing.
+  env -i PATH="$PATH" SKIP_ENVSH="${SKIP_ENVSH:-}" "${e[@]}" sh -c '
+    [ -z "${SKIP_ENVSH:-}" ] && . "$1"
+    defined=$(env | cut -d= -f1 | grep -E "$2" | sed "s/^/\${/; s/$/}/" | tr "\n" " ")
+    envsubst "$defined" < "$3"' sh "$ENVSH" "$FILTER" "$T"
 }
+grep -q "17-default-runtime-vars.envsh /docker-entrypoint.d/17-default-runtime-vars.envsh" docker/ui/Dockerfile \
+  && ok "the Dockerfile installs the default-variables envsh" || bad "the Dockerfile does not install 17-default-runtime-vars.envsh"
+# Present is not enough: the nginx entrypoint sources an .envsh only when it is executable and
+# otherwise ignores it. An image with the file copied and no chmod rendered the literal and
+# died at start -- with this assertion green. It must see the exec bit being set.
+grep -q "chmod +x /docker-entrypoint.d/17-default-runtime-vars.envsh" docker/ui/Dockerfile \
+  && ok "the Dockerfile makes the envsh executable, which is what makes the entrypoint source it" || bad "the Dockerfile never chmods 17-default-runtime-vars.envsh; the entrypoint will ignore it"
+[ "16-validate-runtime-vars.sh" \< "17-default-runtime-vars.envsh" ] && [ "17-default-runtime-vars.envsh" \< "20-envsubst-on-templates.sh" ] \
+  && ok "the default is applied after validation and before rendering (16- < 17- < 20-)" || bad "17-default-runtime-vars.envsh does not sort between 16- and 20-"
+rabs=$(render __absent__)
+if echo "$rabs" | grep -q 'LOOPBACK_AGENT_ORIGIN'; then bad "with the variable ABSENT the literal \${LOOPBACK_AGENT_ORIGIN} survived into the config (nginx: unknown variable)"; else ok "absent variable renders as empty, not as a literal nginx variable"; fi
+echo "$rabs" | grep -q "connect-src 'self' ;" && ok "absent variable leaves connect-src 'self' alone" || bad "absent variable changed connect-src"
 r=$(render "wss://local.example.com:12345")
 [ "$(echo "$r" | grep -c '^map \$host \$csp')" = "1" ] && ok "the CSP is defined once, as a map" || bad "the CSP map is missing or duplicated"
 [ "$(echo "$r" | grep -cE 'add_header Content-Security-Policy "')" = "0" ] && ok "no location carries its own CSP string" || bad "a location still carries a literal CSP"


### PR DESCRIPTION
A hosted page cannot reach the agent on a visitor's machine: it derives its
socket as same-origin /ws and the public stack keeps that proxy off, because
one shared agent would hold every user's ratchet keys. The way through is the
one certified.sh uses: a name the operator points at 127.0.0.1 and holds a
certificate for, so the page dials wss://local.example.com:12345 and lands on
the visitor's own loopback.

LOOPBACK_AGENT_ORIGIN is the fourth runtime variable the UI image renders.
16-validate-runtime-vars.sh admits only a bare wss://host:port -- the value is
substituted into a quoted nginx string and an HTML attribute, so a quote or a
semicolon is an injection, not a typo -- and the template writes it into the
CSP's connect-src and into <meta name="citadel-loopback-agent"> from the same
variable, so what the app dials and what the policy permits cannot disagree.

The CSP was six byte-identical copies, one per location, because add_header
does not inherit; it is now one map that every location references.

provision-tenant.sh --loopback-host NAME writes the origin (needs --topology
full: only a served UI dials a visitor's agent); without the flag the key is
present and empty, so the compose default never applies silently.

Guards: scripts/test-ui-runtime-config.sh (18 assertions, no image needed;
runs in CI) -- validator accepts/refuses, CSP defined once, six references,
origin in connect-src and meta, empty leaves both alone. Controls: validator
check removed admits every breakout; a seventh literal CSP fails; the
sub_filter removed fails. test-provision-tenant.sh: four new cases plus the
.env contents, control on the topology refusal.

Pairs with citadel-workspace-ui #23, which reads the meta.

https://claude.ai/code/session_01CQKcBi2QVjvJBEA8StPfN7