### PR TITLE
fix(release): the agent people download could not be reached by a browser

### DIFF
--- a/.github/workflows/release-agent.yml
+++ b/.github/workflows/release-agent.yml
@@ -87,9 +87,14 @@ jobs:
       # DOWNLOADED and run on someone else's machine, so linking against
       # whatever OpenSSL the build agent happened to have is a runtime failure
       # waiting to happen on a machine that has a different one, or none.
+      # THE BINARY THE BROWSER CAN TALK TO. citadel-workspace-internal-service (this repo)
+      # wraps the kernel in the WebSocket interface and the Origin allowlist; it is what the
+      # docker image runs. The submodule's citadel_service_bin starts the kernel on the raw
+      # TCP interface -- a browser cannot open that -- and agent-v0.1.0 shipped it: the
+      # binary bound its port, passed every smoke check, and closed the connection on the
+      # first WebSocket handshake. smoke-agent.sh now performs that handshake.
       - name: Build the agent
-        run: cargo build --release --target ${{ matrix.target }} -p citadel_service_bin --bin internal-service --features vendored
-        working-directory: citadel-internal-service
+        run: cargo build --release --target ${{ matrix.target }} -p citadel-workspace-internal-service --bin citadel-workspace-internal-service --features vendored
 
       # Packaged with the run instructions beside the binary. `--bind` has no
       # default in the agent's CLI, so a downloaded binary run bare exits with a
@@ -102,7 +107,7 @@ jobs:
         run: |
           set -euo pipefail
           staging="$(mktemp -d)"
-          cp citadel-internal-service/target/${{ matrix.target }}/release/internal-service "$staging/citadel-agent"
+          cp target/${{ matrix.target }}/release/citadel-workspace-internal-service "$staging/citadel-agent"
           cp docs/AGENT_README.md "$staging/README.md"
           tar -czf "${{ matrix.asset }}" -C "$staging" .
           shasum -a 256 "${{ matrix.asset }}" > "${{ matrix.asset }}.sha256"
@@ -113,7 +118,7 @@ jobs:
         run: |
           set -euo pipefail
           staging="$(mktemp -d)"
-          cp citadel-internal-service/target/${{ matrix.target }}/release/internal-service.exe "$staging/citadel-agent.exe"
+          cp target/${{ matrix.target }}/release/citadel-workspace-internal-service.exe "$staging/citadel-agent.exe"
           cp docs/AGENT_README.md "$staging/README.md"
           (cd "$staging" && 7z a -tzip "$OLDPWD/${{ matrix.asset }}" .)
           sha256sum "${{ matrix.asset }}" > "${{ matrix.asset }}.sha256"

--- a/citadel-workspace-internal-service/Cargo.toml
+++ b/citadel-workspace-internal-service/Cargo.toml
@@ -6,6 +6,9 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [features]
+# Statically link OpenSSL so the released agent runs on machines with a different OpenSSL, or
+# none. Forwarded to the kernel crate, which defines what "vendored" means there.
+vendored = ["citadel-internal-service/vendored"]
 deadlock-detection = ["parking_lot/deadlock_detection", "parking_lot", "lazy_static"]
 native-dialogs = ["citadel-internal-service/native-dialogs"]
 

--- a/docs/AGENT_README.md
+++ b/docs/AGENT_README.md
@@ -10,7 +10,7 @@ Nothing here phones home on its own. The agent connects where you tell it to.
 ## Running it
 
 ```bash
-./citadel-agent --bind 127.0.0.1:12345 --backend filesystem
+./citadel-agent --bind 127.0.0.1:12345 --backend filesystem --allowed-origins https://work.avarok.net
 ```
 
 Then reload Citadel Workspace in your browser.
@@ -21,6 +21,13 @@ Both flags matter:
   a usage error rather than starting. `127.0.0.1:12345` is what the web app
   expects; bind to `127.0.0.1` rather than `0.0.0.0` unless you intend other
   machines on your network to reach it.
+- **`--allowed-origins` names the web app that may drive this agent.** A
+  WebSocket is exempt from the browser's same-origin policy, so without this
+  list ANY page you visit could open a connection to your agent and act as you.
+  Put the origin you load Citadel Workspace from -- `https://work.avarok.net`
+  above; `http://localhost:5291` if you run the UI locally -- and nothing else.
+  The agent refuses to start without it. `INTERNAL_SERVICE_ALLOWED_ORIGINS` in
+  the environment does the same and takes precedence.
 - **`--backend filesystem` persists your account.** The default backend is
   in-memory, which is right for tests and wrong for you: without this flag your
   account and message history are gone the next time the agent restarts. Data
@@ -29,7 +36,7 @@ Both flags matter:
 ## Windows
 
 ```powershell
-.\citadel-agent.exe --bind 127.0.0.1:12345 --backend filesystem
+.\citadel-agent.exe --bind 127.0.0.1:12345 --backend filesystem --allowed-origins https://work.avarok.net
 ```
 
 ## Checking it is up

--- a/scripts/smoke-agent.sh
+++ b/scripts/smoke-agent.sh
@@ -69,7 +69,10 @@ fi
 # real agent already running on the machine doing the release.
 PORT="$(python3 -c 'import socket;s=socket.socket();s.bind(("127.0.0.1",0));print(s.getsockname()[1]);s.close()')"
 
-"$BIN" --bind "127.0.0.1:$PORT" --backend in-memory >"$WORK/agent.log" 2>&1 &
+# The allowlist is REQUIRED by the WebSocket agent (it refuses to start without one); the
+# handshake below presents this origin, and a foreign one, to prove the policy shipped.
+INTERNAL_SERVICE_ALLOWED_ORIGINS="http://localhost:5291" \
+  "$BIN" --bind "127.0.0.1:$PORT" >"$WORK/agent.log" 2>&1 &
 AGENT_PID=$!
 
 for _ in $(seq 1 60); do
@@ -84,6 +87,30 @@ s=socket.socket(); s.settimeout(0.4)
 sys.exit(0 if s.connect_ex(('127.0.0.1',$PORT))==0 else 1)
 " 2>/dev/null; then
     echo "  agent listens on 127.0.0.1:$PORT"
+    # Listening is not speaking. agent-v0.1.0 listened, and was the raw-TCP kernel binary:
+    # a browser's WebSocket handshake got the connection closed. So: a real handshake, with
+    # the allowed Origin, must be answered 101 -- and one with a foreign Origin must be
+    # refused 403, which proves the allowlist is in the shipped binary and not only in the
+    # docker image.
+    handshake() { # <origin> -> first response line
+      curl -s -i --max-time 5 -H "Connection: Upgrade" -H "Upgrade: websocket" \
+        -H "Sec-WebSocket-Version: 13" -H "Sec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==" \
+        -H "Origin: $1" "http://127.0.0.1:$PORT/" 2>/dev/null | head -n1 | tr -d '\r' || true
+      # `|| true`: a closed connection makes curl exit non-zero, and under pipefail + set -e
+      # that killed this script before the assertion below could name the failure. The
+      # empty result IS the finding; the case statement reports it.
+    }
+    got="$(handshake http://localhost:5291)"
+    case "$got" in
+      *" 101 "*) echo "  WebSocket handshake from the allowed origin: $got" ;;
+      *) echo "::error::the agent does not speak WebSocket: handshake from the allowed origin got '${got:-<connection closed>}' (a browser cannot use this binary)" >&2
+         tail -20 "$WORK/agent.log" >&2; exit 1 ;;
+    esac
+    got="$(handshake http://evil.example)"
+    case "$got" in
+      *" 403 "*) echo "  handshake from a foreign origin refused: $got" ;;
+      *) echo "::error::the agent accepted (or did not refuse with 403) a handshake from a foreign origin: '${got:-<connection closed>}'. The Origin allowlist is not in this binary." >&2; exit 1 ;;
+    esac
     echo "== $ARCHIVE is runnable =="
     exit 0
   fi


### PR DESCRIPTION
release-agent.yml built the submodule's citadel_service_bin, which starts the
kernel on the raw TCP interface. The docker image runs this repo's
citadel-workspace-internal-service, which wraps the kernel in the WebSocket
interface and the Origin allowlist. agent-v0.1.0 shipped the TCP one: it
bound its port, passed every smoke assertion (executable, refuses without
--bind, right architecture, listens) and closed the connection on the first
WebSocket handshake. Measured against the published macos-arm64 asset: the
handshake gets '<connection closed>'; the docker agent answers 101.

The workflow now builds and packages citadel-workspace-internal-service,
with a `vendored` feature forwarded to the kernel crate so OpenSSL is
static, as before. smoke-agent.sh performs a real handshake: the allowed
origin must be answered 101 and a foreign origin refused 403, which proves
the allowlist is in the shipped binary. Its curl pipeline had to tolerate a
closed connection -- under pipefail + set -e the control died before the
assertion could name the failure. Control: the v0.1.0 archive now fails at
the handshake; a package of the WebSocket binary passes.

docs/AGENT_README.md gains --allowed-origins, which this binary requires
and the README's bare invocation would have tripped on.

A release build with `--features vendored` is running locally; result to follow in a comment.

https://claude.ai/code/session_01CQKcBi2QVjvJBEA8StPfN7