### PR TITLE
feat(provision): the vhost serves the loopback certificate, and loads on the nginx it is for

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -220,6 +220,11 @@ jobs:
 
       - name: Tenant provisioning refuses what it must
         run: bash scripts/test-provision-tenant.sh
+      - name: The tenant vhost is accepted by nginx 1.18 and 1.30
+        # avarok2 runs Ubuntu's 1.18; the UI image is on 1.30. `http2 on;` was rejected by the
+        # former, which no render-time check can see. Rendered with and without the loopback
+        # certificate location, nginx -t inside each official image.
+        run: bash scripts/test-nginx-vhost.sh
       - name: UI runtime config admits only what nginx can safely render
         # The validator that runs before nginx renders, and the rendered template: the CSP is
         # one map, every location references it, and LOOPBACK_AGENT_ORIGIN reaches the policy

--- a/scripts/provision-tenant.sh
+++ b/scripts/provision-tenant.sh
@@ -132,6 +132,10 @@ for p in "$SERVER_PORT" "$AGENT_PORT" "$UI_PORT"; do
 done
 
 TENANT_DIR="$ROOT/$TENANT"
+# Where the operator installs the certificate for the published loopback name (acme.sh
+# --install-cert with a reloadcmd targeting this directory); the vhost serves it at
+# /agent/. Empty without a name, and then no such location is rendered.
+LOOPBACK_DIR="${LOOPBACK_HOST:+$TENANT_DIR/loopback}"
 if [ -e "$TENANT_DIR" ] && [ "$FORCE" != true ]; then
   die "$TENANT_DIR already exists. Re-provisioning destroys its .env (and with it the
   master password that its stored root-workspace password must match). Pass --force
@@ -194,7 +198,7 @@ echo "directory   : $TENANT_DIR"
 if [ "$DRY_RUN" = true ]; then
   echo "--- .env (password redacted) ---"
   render_env "__REDACTED__"
-  [ "$INGRESS" = "nginx" ] && { echo "--- $DOMAIN.conf ---"; bash scripts/render-nginx-vhost.sh "$DOMAIN" "$UI_PORT" "$TENANT"; }
+  [ "$INGRESS" = "nginx" ] && { echo "--- $DOMAIN.conf ---"; bash scripts/render-nginx-vhost.sh "$DOMAIN" "$UI_PORT" "$TENANT" "$LOOPBACK_DIR"; }
   echo "--- dry run: nothing written ---"
   exit 0
 fi
@@ -228,7 +232,7 @@ fi
 cp deploy.sh "$TENANT_DIR/" 2>/dev/null || true
 
 if [ "$INGRESS" = "nginx" ]; then
-  bash scripts/render-nginx-vhost.sh "$DOMAIN" "$UI_PORT" "$TENANT" > "$TENANT_DIR/$DOMAIN.conf"
+  bash scripts/render-nginx-vhost.sh "$DOMAIN" "$UI_PORT" "$TENANT" "$LOOPBACK_DIR" > "$TENANT_DIR/$DOMAIN.conf"
   echo "wrote $TENANT_DIR/$DOMAIN.conf"
   echo "NEXT: obtain a cert for $DOMAIN, install the vhost, then 'nginx -t && systemctl reload nginx'."
   echo "      The existing mx.avarok.net cert does NOT cover new names; expanding it touches"

--- a/scripts/render-nginx-vhost.sh
+++ b/scripts/render-nginx-vhost.sh
@@ -4,12 +4,20 @@
 # Split out of provision-tenant.sh to keep that file inside the repo's 250-line
 # convention. One caller, no independent life.
 #
-# Usage: render-nginx-vhost.sh <domain> <ui-port>
+# Usage: render-nginx-vhost.sh <domain> <ui-port> [tenant] [loopback-dir]
 set -euo pipefail
-DOMAIN="${1:?usage: render-nginx-vhost.sh <domain> <ui-port>}"
-UI_PORT="${2:?usage: render-nginx-vhost.sh <domain> <ui-port>}"
+DOMAIN="${1:?usage: render-nginx-vhost.sh <domain> <ui-port> [tenant] [loopback-dir]}"
+UI_PORT="${2:?usage: render-nginx-vhost.sh <domain> <ui-port> [tenant] [loopback-dir]}"
 # Named in the heredoc's comment line only; the caller does not pass it.
 TENANT="${3:-this tenant}"
+# The directory holding loopback.pem and loopback.key for the tenant's published
+# loopback name (provision-tenant.sh --loopback-host). Served at /agent/ so each
+# user's agent can fetch the current certificate at start: it is a ninety-day
+# certificate, and an agent that carried its own would expire in the field. The
+# key is public by construction -- the name resolves to 127.0.0.1 -- so serving
+# it protects nothing that was protected and enables the only socket a hosted
+# page may open. Empty: no such location.
+LOOPBACK_DIR="${4:-}"
 
 render_vhost() {
   cat <<EOF
@@ -20,9 +28,11 @@ server {
     return 301 https://\$server_name\$request_uri;
 }
 server {
-    listen 443 ssl; listen [::]:443 ssl;
+    # \`http2\` as a listen parameter, not the \`http2 on;\` directive: the directive is nginx
+    # 1.25.1+, and the host this runs on (avarok2) is Ubuntu's 1.18, where it is an unknown
+    # directive and the vhost cannot be enabled at all. The parameter form works on both.
+    listen 443 ssl http2; listen [::]:443 ssl http2;
     server_name $DOMAIN;
-    http2 on;
     ssl_certificate     /etc/letsencrypt/live/$DOMAIN/fullchain.pem;
     ssl_certificate_key /etc/letsencrypt/live/$DOMAIN/privkey.pem;
     ssl_protocols TLSv1.2 TLSv1.3;
@@ -41,6 +51,21 @@ server {
         proxy_read_timeout 180s;
         proxy_buffering off;
     }
+EOF
+  if [ -n "$LOOPBACK_DIR" ]; then
+    cat <<EOF
+    # The loopback certificate for the agent on each visitor's machine. Exactly the two
+    # files, by name; no listing, no other file in the directory. no-cache, because a
+    # renewed certificate must reach the next agent start, not a cached copy.
+    location ~ ^/agent/loopback\.(pem|key)\$ {
+        root $LOOPBACK_DIR;
+        rewrite ^/agent/(.*)\$ /\$1 break;
+        default_type application/x-pem-file;
+        add_header Cache-Control "no-cache" always;
+    }
+EOF
+  fi
+  cat <<EOF
 }
 EOF
 }

--- a/scripts/test-nginx-vhost.sh
+++ b/scripts/test-nginx-vhost.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+#
+# The rendered tenant vhost must be accepted by the nginx that will load it. Two versions
+# matter: 1.18 (Ubuntu's, on avarok2, where `http2 on;` was an unknown directive and the
+# vhost could not be enabled) and 1.30 (the UI image's base). Rendered with and without a
+# loopback directory, then `nginx -t` inside each official image with a throwaway
+# certificate mounted where the vhost expects Let's Encrypt's.
+#
+# Usage: scripts/test-nginx-vhost.sh   (from the repo root; needs docker and openssl)
+set -euo pipefail
+WORK="$(mktemp -d)"; trap 'rm -rf "$WORK"' EXIT
+fail() { echo "::error::$*"; exit 1; }
+DOMAIN=w.example
+mkdir -p "$WORK/le" "$WORK/loopback"
+openssl req -x509 -newkey ec -pkeyopt ec_paramgen_curve:prime256v1 -nodes \
+  -keyout "$WORK/le/privkey.pem" -out "$WORK/le/fullchain.pem" -subj "/CN=$DOMAIN" -days 1 >/dev/null 2>&1
+bash scripts/render-nginx-vhost.sh "$DOMAIN" 12402 t "/srv/citadel-tenants/t/loopback" > "$WORK/with.conf"
+bash scripts/render-nginx-vhost.sh "$DOMAIN" 12402 t > "$WORK/without.conf"
+grep -q '/agent/loopback' "$WORK/with.conf"    || fail "the vhost with a loopback dir has no /agent/ location"
+grep -q '/agent/' "$WORK/without.conf" && fail "the vhost without a loopback dir has an /agent/ location"
+passes=0
+for image in nginx:1.18-alpine nginx:1.30-alpine; do
+  for conf in with without; do
+    out=$(docker run --rm --platform linux/amd64 \
+      -v "$WORK/$conf.conf:/etc/nginx/conf.d/$DOMAIN.conf:ro" \
+      -v "$WORK/le:/etc/letsencrypt/live/$DOMAIN:ro" \
+      -v "$WORK/loopback:/srv/citadel-tenants/t/loopback:ro" \
+      "$image" nginx -t 2>&1) || { echo "$out" | tail -3; fail "$image rejected the vhost rendered $conf a loopback dir"; }
+    passes=$((passes+1))
+  done
+  echo "  $image accepts the vhost, with and without the loopback location"
+done
+echo "nginx-vhost: all $passes renders accepted."

--- a/scripts/test-provision-tenant.sh
+++ b/scripts/test-provision-tenant.sh
@@ -95,5 +95,19 @@ if echo "$out" | grep -q "^LOOPBACK_AGENT_ORIGIN=$"; then
 else
   echo "  FAIL: without --loopback-host the key is missing or non-empty"; fails=$((fails+1))
 fi
+# The vhost serves the loopback certificate ONLY for a tenant with a published name, at
+# exactly /agent/loopback.pem|key, from that tenant's loopback directory, uncached.
+out=$($S --tenant ok7 --topology full --ingress nginx --domain w.example --loopback-host local.w.example --dry-run 2>/dev/null || true)
+if echo "$out" | grep -q 'location ~ ^/agent/loopback' && echo "$out" | grep -q "no-cache" && echo "$out" | grep -qE "root .*/ok7/loopback"; then
+  echo "  ok: --loopback-host renders the /agent/loopback.{pem,key} location from the tenant's loopback dir"
+else
+  echo "  FAIL: --loopback-host did not render the /agent/ certificate location correctly"; fails=$((fails+1))
+fi
+out=$($S --tenant ok8 --topology full --ingress nginx --domain w.example --dry-run 2>/dev/null || true)
+if echo "$out" | grep -q "/agent/"; then
+  echo "  FAIL: a tenant without --loopback-host got an /agent/ location"; fails=$((fails+1))
+else
+  echo "  ok: without --loopback-host the vhost has no /agent/ location"
+fi
 if [ "$fails" -ne 0 ]; then echo "FAIL: $fails assertion(s)"; exit 1; fi
 echo "provision-tenant: all guards refuse, all valid inputs accepted."


### PR DESCRIPTION
A tenant with --loopback-host has a certificate for that name (acme.sh,
installed under <tenant>/loopback/). Each user's agent fetches it at start
from https://<domain>/agent/loopback.pem and .key, so the vhost now serves
exactly those two files from that directory, uncached -- a renewed
certificate must reach the next agent start. No listing, nothing else in the
directory, and no such location for a tenant without a published name. The
key is public by construction: the name resolves to 127.0.0.1.

Checking the render under the nginx it targets found a pre-existing defect:
`http2 on;` is a 1.25.1+ directive, and avarok2 runs Ubuntu's 1.18, where it
is unknown and the vhost cannot be enabled at all. `listen 443 ssl http2;`
works on both. scripts/test-nginx-vhost.sh renders with and without the
loopback directory and runs nginx -t inside nginx:1.18-alpine and 1.30-alpine
with a throwaway certificate mounted; it runs in CI. Control: the directive
put back is rejected by 1.18.

Stacked on #91.

https://claude.ai/code/session_01CQKcBi2QVjvJBEA8StPfN7