### PR TITLE
fix(provision): a re-provision kept the old gate scripts, the domain was unvalidated, and a dry run printed a live token

### DIFF
--- a/scripts/provision-tenant.sh
+++ b/scripts/provision-tenant.sh
@@ -73,6 +73,14 @@ done
 [[ "$TENANT" =~ ^[a-z0-9][a-z0-9-]{0,30}$ ]] || die "--tenant must match [a-z0-9][a-z0-9-]{0,30}"
 case "$INGRESS" in nginx|tunnel|none) ;; *) die "--ingress must be nginx, tunnel or none" ;; esac
 case "$TOPOLOGY" in server-only|full) ;; *) die "--topology must be server-only or full" ;; esac
+# The domain is substituted into an nginx server_name, a certificate path, a filename and the
+# agent's Origin allowlist. Every other operator input here is validated and says why; this one
+# was not, so `https://work.example` produced INTERNAL_SERVICE_ALLOWED_ORIGINS=https://https://...
+# (which the agent refuses at start), a trailing slash never matched any browser Origin, and a
+# `;` or `..` reached a root-owned nginx config or wrote outside the tenant directory.
+if [ -n "$DOMAIN" ] && ! echo "$DOMAIN" | grep -Eq '^[a-z0-9]([a-z0-9.-]*[a-z0-9])?$'; then
+  die "--domain '$DOMAIN' must be a lowercase DNS name (no scheme, port, slash or path)"
+fi
 if [ "$INGRESS" != "none" ] && [ -z "$DOMAIN" ]; then
   die "--domain is required when --ingress is $INGRESS"
 fi
@@ -161,7 +169,11 @@ INTERNAL_SERVICE_BIND_HOST=$AGENT_BIND_HOST
 INTERNAL_SERVICE_ALLOWED_ORIGINS=$ORIGINS
 IMAGE_TAG=${IMAGE_TAG:-latest}
 EOF
-  [ "$INGRESS" = "tunnel" ] && echo "TUNNEL_TOKEN=${TUNNEL_TOKEN:-__SET_ME__}"
+  # Redacted on a dry run for the same reason the master password is: a dry run is what an
+  # operator pastes where others can see it, and TUNNEL_TOKEN is a live credential.
+  if [ "$INGRESS" = "tunnel" ]; then
+    if [ "$1" = "__REDACTED__" ]; then echo "TUNNEL_TOKEN=__REDACTED__"; else echo "TUNNEL_TOKEN=${TUNNEL_TOKEN:-__SET_ME__}"; fi
+  fi
   return 0
 }
 
@@ -198,7 +210,13 @@ if [ "$TOPOLOGY" = "server-only" ]; then
 else
   cp docker-compose.production.yml "$TENANT_DIR/"
 fi
-cp -r scripts "$TENANT_DIR/scripts" 2>/dev/null || true
+# `rm -rf` first, and NO error suppression. `cp -r src dst` copies INTO dst when dst exists,
+# so a --force re-provision put the fresh scripts at scripts/scripts/ and left the PREVIOUS
+# revision's select-deploy-services.sh and verify-image-revisions.sh exactly where the
+# freshly-copied deploy.sh calls them -- a fix to the revision gate never reaching the tenant,
+# silently, because of the `|| true`.
+rm -rf "$TENANT_DIR/scripts"
+cp -r scripts "$TENANT_DIR/scripts"
 # Prove the generated file says what the topology claims, before anyone deploys
 # it: a trim that silently kept the agent would put a hosted agent on a public
 # host, the one thing this topology exists to prevent.
@@ -207,7 +225,7 @@ if [ "$TOPOLOGY" = "server-only" ]; then
   [ "${d% }" = "server" ] || die "server-only tenant declares '${d% }'; expected exactly 'server'"
   echo "verified   : compose declares exactly [server]"
 fi
-cp deploy.sh "$TENANT_DIR/" 2>/dev/null || true
+cp deploy.sh "$TENANT_DIR/deploy.sh"
 
 if [ "$INGRESS" = "nginx" ]; then
   bash scripts/render-nginx-vhost.sh "$DOMAIN" "$UI_PORT" "$TENANT" > "$TENANT_DIR/$DOMAIN.conf"

--- a/scripts/render-nginx-vhost.sh
+++ b/scripts/render-nginx-vhost.sh
@@ -26,6 +26,13 @@ server {
     ssl_certificate     /etc/letsencrypt/live/$DOMAIN/fullchain.pem;
     ssl_certificate_key /etc/letsencrypt/live/$DOMAIN/privkey.pem;
     ssl_protocols TLSv1.2 TLSv1.3;
+    ssl_prefer_server_ciphers off;
+    # HSTS. Without it only the :80 redirect protects the first request, and a network attacker
+    # on that one plaintext hop serves their own page on this name -- which then talks to the
+    # visitor's own agent. The agent refuses the wrong Origin, so the symptom is "the agent is
+    # broken", not "you were attacked". A year, and subdomains, because local.<domain> is one.
+    add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
+    add_header X-Content-Type-Options "nosniff" always;
     client_max_body_size 500m;
     location / {
         proxy_pass http://127.0.0.1:$UI_PORT;

--- a/scripts/test-provision-tenant.sh
+++ b/scripts/test-provision-tenant.sh
@@ -77,5 +77,46 @@ for topo in server-only full; do
   fi
 done
 
+refuses "domain with a scheme"        $S --tenant a --topology full --ingress nginx --domain https://w.example --dry-run
+refuses "domain with a trailing slash" $S --tenant a --topology full --ingress nginx --domain w.example/ --dry-run
+refuses "domain with a semicolon"     $S --tenant a --topology full --ingress nginx --domain "w.example;return 200" --dry-run
+refuses "uppercase domain"            $S --tenant a --topology full --ingress nginx --domain W.example --dry-run
+
+# A dry run is what an operator pastes where others can see it. The master password has always
+# been redacted there; the tunnel token was printed in full.
+out=$(TUNNEL_TOKEN=tunnel-token-not-a-placeholder $S --tenant ok9 --topology full --ingress tunnel --domain w.example --dry-run 2>/dev/null || true)
+if echo "$out" | grep -q "tunnel-token-not-a-placeholder"; then
+  echo "  FAIL: --dry-run printed the live TUNNEL_TOKEN"; fails=$((fails+1))
+else
+  echo "  ok: --dry-run redacts the tunnel token"
+fi
+
+# A --force re-provision must REPLACE the tenant's scripts, not nest a copy inside the old one.
+# `cp -r src dst` copies INTO dst when dst exists, so the previous revision's gate scripts kept
+# running while the fresh ones sat unused at scripts/scripts/.
+FROOT="$(mktemp -d)"
+$S --tenant reprov --topology server-only --base-port 21400 --root "$FROOT" >/dev/null 2>&1 || true
+if [ -d "$FROOT/reprov/scripts" ]; then
+  echo "STALE" > "$FROOT/reprov/scripts/verify-image-revisions.sh"
+  $S --tenant reprov --topology server-only --base-port 21400 --root "$FROOT" --force >/dev/null 2>&1 || true
+  if [ -d "$FROOT/reprov/scripts/scripts" ]; then
+    echo "  FAIL: a --force re-provision nested scripts/scripts inside the tenant"; fails=$((fails+1))
+  elif grep -q "^STALE$" "$FROOT/reprov/scripts/verify-image-revisions.sh" 2>/dev/null; then
+    echo "  FAIL: a --force re-provision left the previous revision's verify-image-revisions.sh in place"; fails=$((fails+1))
+  else
+    echo "  ok: --force replaces the tenant's scripts rather than nesting a copy"
+  fi
+else
+  echo "  FAIL: the first provision wrote no scripts directory"; fails=$((fails+1))
+fi
+rm -rf "$FROOT"
+
+# The public vhost must carry HSTS: only the :80 redirect protects a first request otherwise.
+if bash scripts/render-nginx-vhost.sh w.example 12402 t | grep -q "Strict-Transport-Security"; then
+  echo "  ok: the TLS vhost sends HSTS"
+else
+  echo "  FAIL: the TLS vhost sends no Strict-Transport-Security"; fails=$((fails+1))
+fi
+
 if [ "$fails" -ne 0 ]; then echo "FAIL: $fails assertion(s)"; exit 1; fi
 echo "provision-tenant: all guards refuse, all valid inputs accepted."


### PR DESCRIPTION
Three defects on the deployment surface, found by an inspection wave and each
reproduced before being fixed.

`cp -r scripts "$TENANT_DIR/scripts" 2>/dev/null || true` copies INTO the
destination when it already exists, which is every `--force` re-provision: the
fresh scripts landed at scripts/scripts/ while the PREVIOUS revision's
select-deploy-services.sh and verify-image-revisions.sh stayed exactly where
the freshly-copied deploy.sh calls them. A fix to the deploy gates never
reached a re-provisioned tenant, and `|| true` meant nothing said so.
Reproduced in a temp directory, then fixed with an rm -rf and no suppression.

`--domain` was the only operator input with no validation, and it is
substituted into an nginx server_name, a certificate path, a filename and the
agent's Origin allowlist. `https://work.example` produced
INTERNAL_SERVICE_ALLOWED_ORIGINS=https://https://... which the agent refuses at
start; a trailing slash never matches a browser Origin; `..` writes outside the
tenant and `;` reaches a root-owned config. Same shape of check as
--loopback-host, which already explained why cheap refusals belong here.

`--dry-run` redacted the master password and printed TUNNEL_TOKEN in full. A
dry run is what an operator pastes where others can see it.

The vhost also gained HSTS and nosniff: only the :80 redirect protected a
first request, and a stripped-TLS page on this name talks to the visitor's own
agent -- which refuses the wrong Origin, so the symptom reads as "the agent is
broken" rather than "you were attacked".

Eight assertions with controls: restoring the original provisioner fails six
of them; removing the domain check alone fails four; removing the rm -rf
brings the nesting back; deleting the HSTS line fails its own check.

https://claude.ai/code/session_01CQKcBi2QVjvJBEA8StPfN7