### PR TITLE
ci: gate that a failed SDK disconnect is not reported as a sign-out

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -218,6 +218,10 @@ jobs:
       - name: Third-party images are pinned
         run: node scripts/check-third-party-images-are-pinned.mjs
 
+      - name: A disconnect that did not happen is not reported as one
+        # The map entry is removed BEFORE the SDK disconnect, so a failure there leaves the SDK
+        # holding a session the map does not have and the account unreachable until a restart.
+        run: node scripts/check-disconnect-reports-failure.mjs
       - name: Tenant provisioning refuses what it must
         run: bash scripts/test-provision-tenant.sh
 

--- a/scripts/check-disconnect-reports-failure.mjs
+++ b/scripts/check-disconnect-reports-failure.mjs
@@ -1,0 +1,65 @@
+/**
+ * A disconnect that did not happen must not be reported as one.
+ *
+ * The connection map entry is removed BEFORE the SDK disconnect, so RAII cleanup cannot fire
+ * mid-call. When that disconnect then fails or times out, the SDK may still hold the session —
+ * and both failure branches used to log "Proceeding anyway" and return a
+ * DisconnectNotification, i.e. success. The result is a session the SDK has and the map does
+ * not: the next Connect for that username finds no entry, goes straight to `remote.connect()`,
+ * and is refused because the SDK still has one. The account is unreachable until the agent
+ * restarts, and the person was told they had signed out.
+ *
+ * This reads each failure arm's OWN body — brace-matched, not a fixed window, because a window
+ * wide enough to reach the next arm made an earlier version of this gate unable to fail.
+ */
+import { readFileSync } from 'node:fs';
+
+const FILE =
+  'citadel-internal-service/citadel-internal-service/src/kernel/requests/peer/disconnect.rs';
+const source = readFileSync(FILE, 'utf8');
+const problems = [];
+
+/** The body of the match arm introduced by `marker`, from its `{` to the matching `}`. */
+function armBody(text, marker) {
+  const at = text.indexOf(marker);
+  if (at === -1) return null;
+  const open = text.indexOf('{', at);
+  if (open === -1) return null;
+  let depth = 0;
+  for (let i = open; i < text.length; i++) {
+    if (text[i] === '{') depth++;
+    else if (text[i] === '}') {
+      depth -= 1;
+      if (depth === 0) return text.slice(open, i + 1);
+    }
+  }
+  return null;
+}
+
+for (const arm of ['Ok(Err(', 'Err(_elapsed)']) {
+  const body = armBody(source, arm);
+  if (body === null) {
+    problems.push(`the \`${arm}\` arm has gone — this gate is reading a shape that no longer exists`);
+    continue;
+  }
+  if (!/restore_and_report/.test(body)) {
+    problems.push(`the \`${arm}\` arm no longer restores state and reports failure`);
+  }
+}
+
+// The wording that marked the defect, in CODE only: the doc comment on
+// `restore_and_report` quotes it deliberately, to explain what it replaced.
+const code = source
+  .split('\n')
+  .filter((line) => !/^\s*(\/\/|\*|\/\*)/.test(line))
+  .join('\n');
+if (/Proceeding anyway/.test(code)) {
+  problems.push('a failure branch still says "Proceeding anyway" — that wording marked the defect');
+}
+
+if (problems.length) {
+  problems.forEach((p) => console.error(`::error file=${FILE}::${p}`));
+  console.error('FAIL: a disconnect that did not happen must not be reported as one.');
+  process.exit(1);
+}
+console.log('OK: both SDK-disconnect failure branches restore state and report failure.');


### PR DESCRIPTION
Guards citadel-agent's fix: both failure arms in the disconnect handler must
restore the state that was removed before the SDK call and answer a failure,
rather than logging "Proceeding anyway" and returning a success notification.

The gate reads each arm's OWN body, brace-matched. That is not incidental: the
first version used a fixed 900-character window from the arm marker, which
reached into the NEXT arm, so deleting the first arm's handling left it green.
The control caught it. Now each arm fails on its own, and the old wording is
matched in code only, since the fix's doc comment quotes it deliberately.

Pairs with the citadel-agent fix on the `feat/loopback-tls` branch (PR #60).

https://claude.ai/code/session_01CQKcBi2QVjvJBEA8StPfN7