### PR TITLE
fix(kernel): document bodies were pushed to every connected socket, entitled or not

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -218,6 +218,8 @@ jobs:
       - name: Third-party images are pinned
         run: node scripts/check-third-party-images-are-pinned.mjs
 
+      - name: Node content is not broadcast to every socket
+        run: node scripts/check-node-content-is-not-broadcast-to-everyone.mjs
       - name: Tenant provisioning refuses what it must
         run: bash scripts/test-provision-tenant.sh
 

--- a/citadel-workspace-server-kernel/src/kernel/async_kernel.rs
+++ b/citadel-workspace-server-kernel/src/kernel/async_kernel.rs
@@ -100,6 +100,14 @@ pub enum BroadcastAudience {
     Everyone,
     /// Only sessions whose user may view the node owning this chat channel.
     Group(String),
+    /// Only sessions whose user may VIEW THIS NODE.
+    ///
+    /// Node content and node records went out as `Everyone`, so every connected socket
+    /// received the full `mdx_content` of any document anyone saved — including a member who
+    /// had just been removed, whose socket stays open, and (where one server holds several
+    /// workspaces) sessions belonging to a different one. The pull path has always checked
+    /// `ViewContent`; the push path never did.
+    Node(String),
 }
 
 /// Message for broadcasting workspace updates to connected clients
@@ -325,6 +333,16 @@ impl<R: Ratchet + Send + Sync + 'static> AsyncWorkspaceServerKernel<R> {
     /// Broadcast a response to all connected clients (except the excluded CID)
     pub fn broadcast(&self, response: WorkspaceProtocolResponse, exclude_cid: Option<u64>) {
         self.broadcast_to(response, exclude_cid, BroadcastAudience::Everyone)
+    }
+
+    /// Broadcast a response only to sessions entitled to VIEW `node_id`.
+    pub fn broadcast_to_node(
+        &self,
+        response: WorkspaceProtocolResponse,
+        exclude_cid: Option<u64>,
+        node_id: String,
+    ) {
+        self.broadcast_to(response, exclude_cid, BroadcastAudience::Node(node_id))
     }
 
     /// Broadcast a response only to sessions entitled to see `group_id`'s chat.
@@ -1701,6 +1719,22 @@ impl<R: Ratchet + Send + Sync + 'static> citadel_sdk::prelude::NetKernel<R>
                                         if let BroadcastAudience::Group(ref group_id) = broadcast_msg.audience {
                                             use crate::kernel::group_access::authorize_group_read;
                                             if authorize_group_read(&this, &user_id, group_id).await.is_none() {
+                                                continue;
+                                            }
+                                        }
+                                        // A node-scoped broadcast reaches only sessions that
+                                        // may view that node. Same reasoning as the group case
+                                        // above, and the same single place that knows whose
+                                        // socket this is.
+                                        if let BroadcastAudience::Node(ref node_id) = broadcast_msg.audience {
+                                            use crate::handlers::domain::async_ops::AsyncPermissionOperations;
+                                            use citadel_workspace_types::structs::Permission;
+                                            let may_view = this
+                                                .domain_operations
+                                                .check_entity_permission(&user_id, node_id, Permission::ViewContent)
+                                                .await
+                                                .unwrap_or(false);
+                                            if !may_view {
                                                 continue;
                                             }
                                         }

--- a/citadel-workspace-server-kernel/src/kernel/command_processor/async_process_command.rs
+++ b/citadel-workspace-server-kernel/src/kernel/command_processor/async_process_command.rs
@@ -993,7 +993,11 @@ pub async fn process_command_with_user_and_cid<R: Ratchet + Send + Sync + 'stati
                     // stayed invisible to every other user until they signed in
                     // again. The client handler for this variant already exists;
                     // it just never fired for anyone but the requester.
-                    kernel.broadcast(WorkspaceProtocolResponse::Node(node.clone()), requester_cid);
+                    kernel.broadcast_to_node(
+                        WorkspaceProtocolResponse::Node(node.clone()),
+                        requester_cid,
+                        node.id.clone(),
+                    );
                     Ok(WorkspaceProtocolResponse::Node(node))
                 }
                 Err(e) => Ok(WorkspaceProtocolResponse::Error(format!(
@@ -1057,7 +1061,12 @@ pub async fn process_command_with_user_and_cid<R: Ratchet + Send + Sync + 'stati
                             timestamp,
                         };
 
-                        kernel.broadcast(broadcast_response, requester_cid);
+                        // Node-scoped: this carries the document body.
+                        kernel.broadcast_to_node(
+                            broadcast_response,
+                            requester_cid,
+                            node_id.clone(),
+                        );
                         info!(
                             target: "citadel",
                             "[ASYNC_PROCESS_COMMAND] Broadcast NodeContentUpdated for node {}",
@@ -1093,9 +1102,12 @@ pub async fn process_command_with_user_and_cid<R: Ratchet + Send + Sync + 'stati
                         *chat_enabled,
                         *is_default,
                     ) {
-                        kernel.broadcast(
+                        // Node-scoped, like the content update above: a structural edit
+                        // carries the whole DomainNode, name, rules and all.
+                        kernel.broadcast_to_node(
                             WorkspaceProtocolResponse::Node(node.clone()),
                             requester_cid,
+                            node.id.clone(),
                         );
                     }
 

--- a/citadel-workspace-server-kernel/tests/a_broadcast_is_not_a_permission.rs
+++ b/citadel-workspace-server-kernel/tests/a_broadcast_is_not_a_permission.rs
@@ -1,0 +1,104 @@
+//! Node content goes only to sessions that may view that node.
+//!
+//! `NodeContentUpdated` carries the document body, and it was broadcast with
+//! `BroadcastAudience::Everyone`. The per-connection forwarding loop — the one place that
+//! knows whose socket it is writing to — gated only `Group`, so every connected session
+//! received the full `mdx_content` of anything anyone saved: a member removed a moment ago
+//! whose socket is still open, and, where one server holds several workspaces, sessions
+//! belonging to a different one. The pull path (`GetNode`) has always checked `ViewContent`.
+//!
+//! The forwarding loop itself needs a live SDK session, so what is asserted here is the
+//! decision the loop makes: the same `check_entity_permission(user, node, ViewContent)` call,
+//! against real users and a real node, plus the audience the command processor now attaches.
+use citadel_workspace_server_kernel::handlers::domain::async_ops::{
+    AsyncPermissionOperations, AsyncUserManagementOperations,
+};
+use citadel_workspace_server_kernel::handlers::domain::node_ops::AsyncNodeOperations;
+use citadel_workspace_server_kernel::kernel::async_kernel::BroadcastAudience;
+use citadel_workspace_types::structs::{NodeEntityType, Permission, UserRole};
+use common::member_test_utils::{insert_user_with_role, join_root, GateKernel as Kernel};
+use common::workspace_test_utils::{create_test_kernel, TEST_ADMIN_USER_ID};
+
+const ROOT: &str = citadel_workspace_server_kernel::WORKSPACE_ROOT_ID;
+
+async fn office(kernel: &Kernel) -> String {
+    kernel
+        .domain_operations
+        .create_node(
+            TEST_ADMIN_USER_ID,
+            Some(ROOT),
+            &NodeEntityType::Child("Office".to_string()),
+            "Ops",
+            "",
+        )
+        .await
+        .expect("an admin may create an office")
+        .id
+}
+
+async fn may_view(kernel: &Kernel, user: &str, node: &str) -> bool {
+    kernel
+        .domain_operations
+        .check_entity_permission(user, node, Permission::ViewContent)
+        .await
+        .unwrap_or(false)
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn a_member_of_the_office_may_receive_its_content() {
+    let kernel = create_test_kernel().await;
+    insert_user_with_role(&kernel, "insider", UserRole::Member).await;
+    join_root(&kernel, "insider").await;
+    let node = office(&kernel).await;
+    kernel
+        .domain_operations
+        .add_user_to_domain(TEST_ADMIN_USER_ID, "insider", &node, UserRole::Member)
+        .await
+        .expect("an admin may add a member to an office");
+
+    assert!(
+        may_view(&kernel, "insider", &node).await,
+        "a member of the office must still receive its content",
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn a_banned_account_may_not_receive_node_content() {
+    // The case the old broadcast could not express: still connected, no longer entitled.
+    let kernel = create_test_kernel().await;
+    insert_user_with_role(&kernel, "outcast", UserRole::Member).await;
+    join_root(&kernel, "outcast").await;
+    let node = office(&kernel).await;
+    kernel
+        .domain_operations
+        .add_user_to_domain(TEST_ADMIN_USER_ID, "outcast", &node, UserRole::Member)
+        .await
+        .expect("an admin may add a member to an office");
+    assert!(may_view(&kernel, "outcast", &node).await, "precondition");
+
+    kernel
+        .domain_operations
+        .add_user_to_domain(TEST_ADMIN_USER_ID, "outcast", ROOT, UserRole::Banned)
+        .await
+        .expect("an admin may ban");
+
+    assert!(
+        !may_view(&kernel, "outcast", &node).await,
+        "a banned account must not receive the document body of a node it can no longer view",
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn the_node_audience_is_distinct_from_everyone() {
+    // The audience is what carries the decision to the forwarding loop; if a future edit
+    // sends content as `Everyone` again, the gate has nothing to act on.
+    let node = "node-42".to_string();
+    assert_ne!(
+        BroadcastAudience::Node(node.clone()),
+        BroadcastAudience::Everyone
+    );
+    assert_eq!(
+        BroadcastAudience::Node(node.clone()),
+        BroadcastAudience::Node(node)
+    );
+}

--- a/scripts/check-node-content-is-not-broadcast-to-everyone.mjs
+++ b/scripts/check-node-content-is-not-broadcast-to-everyone.mjs
@@ -1,0 +1,51 @@
+/**
+ * Node content must not be broadcast to every connected socket.
+ *
+ * `NodeContentUpdated` carries the document body and `Node` carries the whole record. Both
+ * went out with `BroadcastAudience::Everyone`, and the per-connection forwarding loop gated
+ * only `Group` — so a member removed a moment ago, whose socket is still open, received the
+ * body of every document anyone saved afterwards, and where one server holds several
+ * workspaces, so did the other one's members. The pull path has always checked `ViewContent`.
+ *
+ * The forwarding loop's decision is covered by tests/a_broadcast_is_not_a_permission.rs. This
+ * guards the other half — that these two responses keep going out node-scoped — because
+ * `kernel.broadcast(...)` is the easier call to reach for and nothing else would notice.
+ */
+import { readFileSync } from 'node:fs';
+
+const FILE =
+  'citadel-workspace-server-kernel/src/kernel/command_processor/async_process_command.rs';
+const source = readFileSync(FILE, 'utf8');
+const problems = [];
+
+// Exactly the two payloads that carry content, and the call each must go out on. Written as
+// the statement rather than a proximity search: `Node` is a prefix of `NodeContentUpdated`,
+// and an earlier version of this gate matched the wrong one and then failed in every state,
+// including the correct one — a gate that is always red teaches people to ignore it.
+const REQUIRED = [
+  {
+    what: 'the document body (NodeContentUpdated)',
+    good: /kernel\.broadcast_to_node\(\s*broadcast_response\s*,/,
+    bad: /kernel\.broadcast\(\s*broadcast_response\s*,/,
+  },
+  {
+    what: 'the node record (WorkspaceProtocolResponse::Node)',
+    good: /kernel\.broadcast_to_node\(\s*WorkspaceProtocolResponse::Node\(/,
+    bad: /kernel\.broadcast\(\s*WorkspaceProtocolResponse::Node\(/,
+  },
+];
+
+for (const { what, good, bad } of REQUIRED) {
+  if (bad.test(source)) {
+    problems.push(`${what} is sent with kernel.broadcast — audience Everyone — and must be node-scoped`);
+  } else if (!good.test(source)) {
+    problems.push(`${what} is no longer sent with broadcast_to_node; this gate is reading a shape that has gone`);
+  }
+}
+
+if (problems.length) {
+  problems.forEach((p) => console.error(`::error file=${FILE}::${p}`));
+  console.error('FAIL: node content must reach only sessions entitled to view that node.');
+  process.exit(1);
+}
+console.log('OK: the document body and the node record are both broadcast node-scoped.');


### PR DESCRIPTION
`NodeContentUpdated` carries the full `mdx_content` and `Node` carries the
whole `DomainNode`. All three sites broadcast them with
`BroadcastAudience::Everyone`, and the per-connection forwarding loop — the
one place that knows whose socket it is writing to — gated only `Group`. So
every save reached every connected session: a member removed a moment ago
whose socket is still open, and, where one server holds several workspaces,
the other workspace's members. The pull path (`GetNode`) has always checked
`ViewContent`; the push path never did.

`BroadcastAudience::Node(id)` is gated in the forwarding loop by the same
`check_entity_permission(user, node, ViewContent)` the pull path uses, and the
three content-carrying broadcasts now use it.

Three tests: a member of the office still receives its content; a banned
account does not (still connected, no longer entitled — the case the old
audience could not express); the Node audience is distinct from Everyone, so a
future edit that reverts to Everyone leaves the gate nothing to act on.

The CI gate that guards the call sites earned its place: my first version
matched `WorkspaceProtocolResponse::Node` by proximity, which also matched
`NodeContentUpdated`, and failed in every state including the correct one — a
gate that is always red teaches people to ignore it. Rewritten as exact
statements, it then found a THIRD broadcast site I had missed, a structural
edit sending the whole node record to everyone. Both controls now fail it,
one per payload.

Whole kernel suite green, 77 test binaries; clippy clean.

Found by the robustness inspection wave.

https://claude.ai/code/session_01CQKcBi2QVjvJBEA8StPfN7