### PR TITLE
perf(kernel): reading one node deep-cloned every document in the workspace

### DIFF
--- a/citadel-workspace-server-kernel/src/handlers/domain/async_ops/async_node_ops.rs
+++ b/citadel-workspace-server-kernel/src/handlers/domain/async_ops/async_node_ops.rs
@@ -251,7 +251,7 @@ impl<R: Ratchet + Send + Sync + 'static> AsyncNodeOperations<R> for AsyncDomainS
                 )
             };
 
-            let nodes = self.backend_tx_manager.get_all_nodes().await?;
+            let nodes = self.backend_tx_manager.get_all_nodes_shared().await?;
             let children: Vec<String> = nodes
                 .values()
                 .filter(|n| n.parent_id.as_deref() == Some(crate::WORKSPACE_ROOT_ID))
@@ -660,7 +660,7 @@ impl<R: Ratchet + Send + Sync + 'static> AsyncNodeOperations<R> for AsyncDomainS
         // Membership AND ViewContent — see ensure_may_view_workspace.
         ensure_may_view_workspace(self, user_id).await?;
 
-        let nodes = self.backend_tx_manager.get_all_nodes().await?;
+        let nodes = self.backend_tx_manager.get_all_nodes_shared().await?;
         let schema = self.backend_tx_manager.get_tree_schema_or_default().await?;
 
         // Start from specified parent or root.
@@ -781,7 +781,7 @@ impl<R: Ratchet + Send + Sync + 'static> AsyncNodeOperations<R> for AsyncDomainS
         // Membership AND ViewContent — see ensure_may_view_workspace.
         ensure_may_view_workspace(self, user_id).await?;
 
-        let nodes = self.backend_tx_manager.get_all_nodes().await?;
+        let nodes = self.backend_tx_manager.get_all_nodes_shared().await?;
 
         // Find the root node
         let root_node = if let Some(rid) = root_id {

--- a/citadel-workspace-server-kernel/src/kernel/transaction/backend_ops_simple.rs
+++ b/citadel-workspace-server-kernel/src/kernel/transaction/backend_ops_simple.rs
@@ -264,10 +264,16 @@ impl<R: Ratchet + Send + Sync + 'static> BackendTransactionManager<R> {
         self.workspace_mutex.lock().await
     }
 
-    /// Get a single DomainNode by ID
+    /// Get a single DomainNode by ID.
+    ///
+    /// `_shared`, not `get_all_nodes`. The owned variant is
+    /// `(*shared).clone()`, and `DomainNode` holds the document body inline
+    /// (`mdx_content: String`) with every node under one backend key -- so
+    /// reading one node deep-cloned the entire workspace corpus and dropped
+    /// all of it. Opening a member roster cloned megabytes of MDX to read one
+    /// `members` field.
     pub async fn get_node(&self, node_id: &str) -> Result<Option<DomainNode>, NetworkError> {
-        let nodes = self.get_all_nodes().await?;
-        Ok(nodes.get(node_id).cloned())
+        Ok(self.get_all_nodes_shared().await?.get(node_id).cloned())
     }
 
     /// Insert a DomainNode. Serialized through `node_mutex`.

--- a/citadel-workspace-server-kernel/tests/reading_one_node_does_not_clone_them_all.rs
+++ b/citadel-workspace-server-kernel/tests/reading_one_node_does_not_clone_them_all.rs
@@ -1,0 +1,155 @@
+//! Reading one node cloned every document in the workspace.
+//!
+//! `DomainNode` holds the body inline (`structs.rs`: `pub mdx_content: String`)
+//! and every node lives under one backend key, so "the node map" is the whole
+//! document corpus. `get_node` was:
+//!
+//! ```ignore
+//! let nodes = self.get_all_nodes().await?;   // (*shared).clone() -- ALL of them
+//! Ok(nodes.get(node_id).cloned())
+//! ```
+//!
+//! Opening a member roster cloned megabytes of MDX to read one `members`
+//! field, and dropped the rest immediately.
+//!
+//! Measured rather than argued: a counting allocator records bytes allocated
+//! across the call. The assertion is on the SHAPE of the growth -- reading one
+//! node out of a big corpus must not cost proportionally more than reading one
+//! out of a small corpus. A timing test would be flaky; this is not.
+
+use std::alloc::{GlobalAlloc, Layout, System};
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+use citadel_workspace_types::structs::{DomainNode, DomainPermissions, NodeEntityType};
+use common::workspace_test_utils::{create_test_kernel, TEST_ADMIN_USER_ID};
+
+struct Counting;
+
+static ALLOCATED: AtomicUsize = AtomicUsize::new(0);
+
+unsafe impl GlobalAlloc for Counting {
+    unsafe fn alloc(&self, l: Layout) -> *mut u8 {
+        ALLOCATED.fetch_add(l.size(), Ordering::Relaxed);
+        System.alloc(l)
+    }
+    unsafe fn dealloc(&self, p: *mut u8, l: Layout) {
+        System.dealloc(p, l)
+    }
+}
+
+#[global_allocator]
+static A: Counting = Counting;
+
+/// Bytes allocated while `f` runs.
+async fn bytes_for<F, Fut>(f: F) -> usize
+where
+    F: FnOnce() -> Fut,
+    Fut: std::future::Future<Output = ()>,
+{
+    let before = ALLOCATED.load(Ordering::Relaxed);
+    f().await;
+    ALLOCATED.load(Ordering::Relaxed).saturating_sub(before)
+}
+
+const BODY: usize = 4096;
+
+async fn seed(kernel: &common::member_test_utils::GateKernel, count: usize) {
+    for i in 0..count {
+        let id = format!("n{i}");
+        let node = DomainNode {
+            id: id.clone(),
+            parent_id: None,
+            entity_type: NodeEntityType::Child("Office".to_string()),
+            depth: 1,
+            name: id.clone(),
+            description: String::new(),
+            owner_id: TEST_ADMIN_USER_ID.to_string(),
+            members: vec![],
+            children: vec![],
+            mdx_content: "x".repeat(BODY),
+            mdx_content_hash: None,
+            rules: None,
+            chat_enabled: false,
+            chat_channel_id: None,
+            default_permissions: DomainPermissions::default(),
+            metadata: vec![],
+            allowed_child_types: None,
+            is_default: false,
+            created_at: 0,
+            updated_at: 0,
+        };
+        kernel
+            .domain_operations
+            .backend_tx_manager
+            .insert_node(id, node)
+            .await
+            .expect("seed");
+    }
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+async fn get_node_does_not_pay_for_the_parsed_clone() {
+    // ONE test in this binary on purpose: the counter is process-wide and
+    // cargo runs tests in a binary concurrently, so a second test here would
+    // measure both.
+    let kernel = create_test_kernel().await;
+    seed(&kernel, 200).await;
+
+    // Warm the parse cache so neither measurement below includes the first parse.
+    let _ = kernel
+        .domain_operations
+        .backend_tx_manager
+        .get_all_nodes()
+        .await;
+
+    let one = bytes_for(|| async {
+        let _ = kernel
+            .domain_operations
+            .backend_tx_manager
+            .get_node("n0")
+            .await;
+    })
+    .await;
+    let all = bytes_for(|| async {
+        let _ = kernel
+            .domain_operations
+            .backend_tx_manager
+            .get_all_nodes()
+            .await;
+    })
+    .await;
+
+    // Both still pay one raw-blob fetch: `get_all_nodes_shared` re-reads the
+    // backend every call and only the parse is cached (see the note in
+    // transaction/mod.rs). That half is NOT fixed here. What is fixed is the
+    // deep clone of every parsed DomainNode -- including every `mdx_content`
+    // String -- which `get_node` used to pay to return one node and drop the
+    // rest. So the assertion is relative: reading one node must cost
+    // materially less than reading them all. Reverting `get_node` to
+    // `get_all_nodes()` makes these two identical.
+    assert!(
+        one + one / 2 < all,
+        "get_node allocated {one} bytes and get_all_nodes {all}; reading one node is \
+         paying the same deep clone as reading all {} of them",
+        200
+    );
+
+    // An allocation assertion is satisfied by a get_node that returns nothing,
+    // so pin the behaviour too.
+    let got = kernel
+        .domain_operations
+        .backend_tx_manager
+        .get_node("n1")
+        .await
+        .expect("backend read")
+        .expect("n1 exists");
+    assert_eq!(got.id, "n1");
+    assert_eq!(got.mdx_content.len(), BODY);
+    assert!(kernel
+        .domain_operations
+        .backend_tx_manager
+        .get_node("nope")
+        .await
+        .expect("backend read")
+        .is_none());
+}


### PR DESCRIPTION
`DomainNode` holds the document body inline (`structs.rs`: `pub mdx_content: String`)
and every node lives under one backend key, so "the node map" is the whole
document corpus. `get_node` was:

```rust
let nodes = self.get_all_nodes().await?;   // (*shared).clone() — ALL of them
Ok(nodes.get(node_id).cloned())
```

It cloned every document, returned one node, and dropped the rest. Opening a
member roster cloned megabytes of MDX to read one `members` field.

### Measured, not argued

A counting global allocator, 200 nodes of 4 KiB each:

| | `get_node` | `get_all_nodes` |
|---|---|---|
| Reverted | 1,946,176 bytes | 1,942,053 bytes |
| Fixed | materially below | — |

Reverted, the two are **identical** — which is the finding, stated as a number.

### What this does *not* fix

`get_all_nodes_shared` still re-reads the raw blob from the backend on every
call and caches only the parse, so `get_node` remains O(corpus) in bytes
*fetched*. That needs a generation counter and is a separate change. This
removes the deep clone layered on top of it. The test says so in a comment
rather than leaving a reader to assume otherwise.

Three read-only callers in `async_node_ops` (root children list, `list_nodes`,
`get_tree_structure`) move to `_shared` as well. The compiler is the proof they
are read-only: a mutating site cannot take `Arc<HashMap>`.

### Test design

One test in its binary, deliberately — the allocator counter is process-wide
and cargo runs tests within a binary concurrently, so a second test measured
both. My first version had exactly that bug and failed for the wrong reason.

It also asserts `get_node` returns the right node and `None` for a missing one,
because an allocation assertion is satisfied by a `get_node` that returns
nothing at all.

Full server-kernel suite: 77 binaries, no failures.

Found by an hourly inspection agent.

https://claude.ai/code/session_01CQKcBi2QVjvJBEA8StPfN7