### PR TITLE
feat(agent): TLS on loopback for a hosted UI — name, certificate source, and the wiring

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -759,6 +759,7 @@ dependencies = [
  "parking_lot",
  "serde",
  "serde_json",
+ "tokio-rustls",
  "tokio-tungstenite 0.21.0",
  "tungstenite 0.21.0",
  "uuid",
@@ -3926,6 +3927,7 @@ version = "0.23.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c665f33d38cea657d9614f766881e4d510e0eda4239891eea56b4cadcf01801b"
 dependencies = [
+ "log",
  "once_cell",
  "ring",
  "rustls-pki-types",

--- a/citadel-workspace-internal-service/src/loopback.rs
+++ b/citadel-workspace-internal-service/src/loopback.rs
@@ -47,6 +47,12 @@ pub struct TlsInputs<'a> {
 
 impl<'a> TlsInputs<'a> {
     /// Nothing configured; fill in what the caller has.
+    ///
+    /// `#[cfg(test)]` because its only caller is `loopback_tests.rs`, which is
+    /// itself `#[cfg(test)]`. Without the gate clippy fails the non-test build
+    /// with "associated function `none` is never used" -- and CI runs clippy
+    /// with `-D warnings`, so this is a hard error rather than a note.
+    #[cfg(test)]
     pub fn none(cache_root: &'a Path) -> Self {
         Self {
             env_host: None,

--- a/citadel-workspace-internal-service/src/loopback.rs
+++ b/citadel-workspace-internal-service/src/loopback.rs
@@ -1,0 +1,234 @@
+//! The agent's loopback TLS identity: what was configured, and where the certificate comes from.
+//!
+//! A hosted UI reaches the agent on the user's own machine as `wss://<name>:<port>`, where the
+//! operator points `<name>` at 127.0.0.1 and holds a real certificate for it (see the connector's
+//! io_interface/tls.rs for why a certificate at all). The certificate is ninety-day and is never
+//! embedded in the binary: it is either handed in as files or fetched from the hosting site at
+//! start and cached beside the agent's data, so an installed copy keeps working across renewals
+//! and works offline once it has fetched once.
+//!
+//! Resolution is pure and tested; only `obtain` touches the network and the filesystem.
+use std::path::{Path, PathBuf};
+
+/// What the operator asked for. No `Default`: plain WebSocket is the absence of all of it.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum TlsChoice {
+    /// Plain `ws://` on loopback, behind the UI's own proxy. The existing behaviour.
+    Plain,
+    /// TLS from PEM files on disk.
+    Files {
+        cert: PathBuf,
+        key: PathBuf,
+        name: Option<String>,
+    },
+    /// TLS from `<url>/loopback.pem` and `<url>/loopback.key`, cached under `cache_dir`.
+    Fetch {
+        url: String,
+        cache_dir: PathBuf,
+        name: Option<String>,
+    },
+}
+
+/// Inputs, env first then CLI, matching `select_backend_type` and `resolve_origin_policy`:
+/// a docker operator changes behaviour without rebuilding. Empty strings are unset.
+#[derive(Debug, Clone)]
+pub struct TlsInputs<'a> {
+    pub env_host: Option<&'a str>,
+    pub env_cert_url: Option<&'a str>,
+    pub env_cert: Option<&'a str>,
+    pub env_key: Option<&'a str>,
+    pub cli_host: Option<&'a str>,
+    pub cli_cert_url: Option<&'a str>,
+    pub cli_cert: Option<&'a str>,
+    pub cli_key: Option<&'a str>,
+    /// Where a fetched certificate is cached: the data dir when there is one.
+    pub cache_root: &'a Path,
+}
+
+impl<'a> TlsInputs<'a> {
+    /// Nothing configured; fill in what the caller has.
+    pub fn none(cache_root: &'a Path) -> Self {
+        Self {
+            env_host: None,
+            env_cert_url: None,
+            env_cert: None,
+            env_key: None,
+            cli_host: None,
+            cli_cert_url: None,
+            cli_cert: None,
+            cli_key: None,
+            cache_root,
+        }
+    }
+}
+
+fn pick<'a>(env: Option<&'a str>, cli: Option<&'a str>) -> Option<&'a str> {
+    env.filter(|s| !s.trim().is_empty())
+        .or(cli.filter(|s| !s.trim().is_empty()))
+        .map(str::trim)
+}
+
+/// Decide, or say what is inconsistent. A published name without a certificate source is
+/// refused: the name only means something as a TLS name, and "you set --loopback-host and it
+/// silently ran plain" is the failure this exists to prevent. Files and a URL together are
+/// refused too -- two sources is one too many to be sure which one is serving.
+pub fn choose_tls(inputs: &TlsInputs<'_>) -> Result<TlsChoice, String> {
+    let name = pick(inputs.env_host, inputs.cli_host).map(|n| n.to_ascii_lowercase());
+    if let Some(n) = &name {
+        if !n
+            .bytes()
+            .all(|b| b.is_ascii_lowercase() || b.is_ascii_digit() || b == b'.' || b == b'-')
+            || n.starts_with('.')
+            || n.ends_with('.')
+        {
+            return Err(format!(
+                "loopback host {n:?} must be a bare DNS name (letters, digits, dots, hyphens); no scheme, port or path"
+            ));
+        }
+    }
+    let url = pick(inputs.env_cert_url, inputs.cli_cert_url);
+    let cert = pick(inputs.env_cert, inputs.cli_cert);
+    let key = pick(inputs.env_key, inputs.cli_key);
+    match (url, cert, key) {
+        (None, None, None) => match name {
+            None => Ok(TlsChoice::Plain),
+            Some(n) => Err(format!(
+                "loopback host {n:?} was given but no certificate source: pass --loopback-cert-url \
+                 (INTERNAL_SERVICE_LOOPBACK_CERT_URL) or --tls-cert/--tls-key"
+            )),
+        },
+        (Some(_), Some(_), _) | (Some(_), _, Some(_)) => Err(
+            "both a certificate URL and certificate files were given; use one source".to_string(),
+        ),
+        (Some(url), None, None) => {
+            if !url.starts_with("https://") {
+                return Err(format!(
+                    "loopback certificate URL {url:?} must be https:// -- the private key travels over it"
+                ));
+            }
+            Ok(TlsChoice::Fetch {
+                url: url.trim_end_matches('/').to_string(),
+                cache_dir: inputs.cache_root.join("loopback"),
+                name,
+            })
+        }
+        (None, Some(cert), Some(key)) => Ok(TlsChoice::Files {
+            cert: PathBuf::from(cert),
+            key: PathBuf::from(key),
+            name,
+        }),
+        (None, Some(_), None) | (None, None, Some(_)) => {
+            Err("--tls-cert and --tls-key go together; one was given without the other".to_string())
+        }
+    }
+}
+
+/// A certificate and its key, PEM.
+pub struct Pem {
+    pub certificate: Vec<u8>,
+    pub key: Vec<u8>,
+}
+
+/// Lengths only. The key is public by construction, but a panic message or a log line is
+/// still not where it belongs.
+impl std::fmt::Debug for Pem {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Pem")
+            .field("certificate_bytes", &self.certificate.len())
+            .field("key_bytes", &self.key.len())
+            .finish()
+    }
+}
+
+/// Obtain the PEM pair the choice names. Files are read; a URL is fetched (the network first,
+/// then whatever was cached) and the fresh copy written back so the next start works offline
+/// and a replaced certificate does not outlive its usefulness.
+pub fn obtain(choice: &TlsChoice) -> Result<Option<Pem>, String> {
+    match choice {
+        TlsChoice::Plain => Ok(None),
+        TlsChoice::Files { cert, key, .. } => Ok(Some(Pem {
+            certificate: std::fs::read(cert)
+                .map_err(|e| format!("reading {}: {e}", cert.display()))?,
+            key: std::fs::read(key).map_err(|e| format!("reading {}: {e}", key.display()))?,
+        })),
+        TlsChoice::Fetch { url, cache_dir, .. } => match fetch_pair(url) {
+            Ok(fresh) => {
+                if let Err(e) = store(cache_dir, &fresh) {
+                    citadel_logging::warn!(target: "citadel", "could not cache the loopback certificate under {}: {e}", cache_dir.display());
+                }
+                Ok(Some(fresh))
+            }
+            Err(fetch_err) => match load(cache_dir) {
+                Some(cached) => {
+                    citadel_logging::warn!(target: "citadel", "could not fetch the loopback certificate ({fetch_err}); using the cached copy");
+                    Ok(Some(cached))
+                }
+                None => Err(format!(
+                    "{fetch_err}, and nothing is cached under {}",
+                    cache_dir.display()
+                )),
+            },
+        },
+    }
+}
+
+/// One GET, via the system `curl`: the agent has no HTTP client of its own, and one call at
+/// start does not justify a client crate in a binary people download. HTTPS only, TLS 1.2+,
+/// a short timeout so an offline start is delayed by seconds, not minutes.
+fn fetch_one(url: &str) -> Result<Vec<u8>, String> {
+    let out = std::process::Command::new("curl")
+        .args([
+            "-fsSL",
+            "--proto",
+            "=https",
+            "--tlsv1.2",
+            "--max-time",
+            "4",
+            url,
+        ])
+        .output()
+        .map_err(|e| format!("running curl for {url}: {e}"))?;
+    if !out.status.success() {
+        return Err(format!("fetching {url}: curl exited {}", out.status));
+    }
+    // A site that answers a missing file with a page of HTML would otherwise be handed to the
+    // TLS stack as a certificate and fail later and less clearly.
+    if !out.stdout.starts_with(b"-----BEGIN") {
+        return Err(format!("{url} did not return PEM"));
+    }
+    Ok(out.stdout)
+}
+
+fn fetch_pair(base: &str) -> Result<Pem, String> {
+    Ok(Pem {
+        certificate: fetch_one(&format!("{base}/loopback.pem"))?,
+        key: fetch_one(&format!("{base}/loopback.key"))?,
+    })
+}
+
+fn load(dir: &Path) -> Option<Pem> {
+    let pem = Pem {
+        certificate: std::fs::read(dir.join("loopback.pem")).ok()?,
+        key: std::fs::read(dir.join("loopback.key")).ok()?,
+    };
+    (!pem.certificate.is_empty() && !pem.key.is_empty()).then_some(pem)
+}
+
+fn store(dir: &Path, pem: &Pem) -> std::io::Result<()> {
+    std::fs::create_dir_all(dir)?;
+    std::fs::write(dir.join("loopback.pem"), &pem.certificate)?;
+    let key = dir.join("loopback.key");
+    std::fs::write(&key, &pem.key)?;
+    // 0600. The key is published on a website, so this protects nothing from a determined
+    // reader -- but a world-readable private key on a shared machine is what scanners report.
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        std::fs::set_permissions(&key, std::fs::Permissions::from_mode(0o600))?;
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+#[path = "loopback_tests.rs"]
+mod tests;

--- a/citadel-workspace-internal-service/src/loopback_tests.rs
+++ b/citadel-workspace-internal-service/src/loopback_tests.rs
@@ -1,0 +1,134 @@
+//! Tests for loopback.rs: the pure resolver, and the cache round-trip.
+use super::*;
+
+fn inputs(root: &Path) -> TlsInputs<'_> {
+    TlsInputs::none(root)
+}
+
+#[test]
+fn nothing_configured_is_plain() {
+    assert_eq!(
+        choose_tls(&inputs(Path::new("/d"))).unwrap(),
+        TlsChoice::Plain
+    );
+}
+
+#[test]
+fn a_name_without_a_certificate_source_is_refused_not_silently_plain() {
+    let mut i = inputs(Path::new("/d"));
+    i.cli_host = Some("local.example.com");
+    let err = choose_tls(&i).unwrap_err();
+    assert!(err.contains("no certificate source"), "{err}");
+}
+
+#[test]
+fn a_url_fetches_and_caches_under_the_data_dir_and_env_wins_over_cli() {
+    let mut i = inputs(Path::new("/data"));
+    i.cli_cert_url = Some("https://cli.example/agent/");
+    i.env_cert_url = Some("https://env.example/agent/");
+    i.cli_host = Some("Local.Example.com");
+    assert_eq!(
+        choose_tls(&i).unwrap(),
+        TlsChoice::Fetch {
+            url: "https://env.example/agent".into(),
+            cache_dir: PathBuf::from("/data/loopback"),
+            name: Some("local.example.com".into())
+        }
+    );
+}
+
+#[test]
+fn files_go_together_and_a_plain_http_url_is_refused() {
+    let mut i = inputs(Path::new("/d"));
+    i.cli_cert = Some("/c.pem");
+    assert!(choose_tls(&i).unwrap_err().contains("go together"));
+    i.cli_key = Some("/k.pem");
+    assert_eq!(
+        choose_tls(&i).unwrap(),
+        TlsChoice::Files {
+            cert: "/c.pem".into(),
+            key: "/k.pem".into(),
+            name: None
+        }
+    );
+    let mut j = inputs(Path::new("/d"));
+    j.cli_cert_url = Some("http://insecure.example/agent");
+    assert!(choose_tls(&j).unwrap_err().contains("https://"));
+}
+
+#[test]
+fn two_sources_and_a_malformed_name_are_refused() {
+    let mut i = inputs(Path::new("/d"));
+    i.cli_cert_url = Some("https://x.example/agent");
+    i.cli_cert = Some("/c.pem");
+    i.cli_key = Some("/k.pem");
+    assert!(choose_tls(&i).unwrap_err().contains("one source"));
+    for bad in [
+        "wss://local.example.com",
+        "local.example.com:12345",
+        "local.example.com/ws",
+        ".local",
+        "lo cal",
+    ] {
+        let mut j = inputs(Path::new("/d"));
+        j.cli_host = Some(bad);
+        j.cli_cert_url = Some("https://x.example/agent");
+        assert!(
+            choose_tls(&j).unwrap_err().contains("bare DNS name"),
+            "{bad}"
+        );
+    }
+}
+
+#[test]
+fn empty_strings_are_unset() {
+    let mut i = inputs(Path::new("/d"));
+    i.env_cert_url = Some("  ");
+    i.cli_cert_url = Some("https://cli.example/agent");
+    assert!(
+        matches!(choose_tls(&i).unwrap(), TlsChoice::Fetch { url, .. } if url == "https://cli.example/agent")
+    );
+}
+
+#[test]
+fn the_cache_round_trips_and_the_key_is_private() {
+    let dir = std::env::temp_dir().join(format!("citadel-loopback-test-{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&dir);
+    let pem = Pem {
+        certificate: b"-----BEGIN CERTIFICATE-----\nx\n".to_vec(),
+        key: b"-----BEGIN PRIVATE KEY-----\ny\n".to_vec(),
+    };
+    store(&dir, &pem).unwrap();
+    let back = load(&dir).expect("cached pair loads");
+    assert_eq!(back.certificate, pem.certificate);
+    assert_eq!(back.key, pem.key);
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        assert_eq!(
+            std::fs::metadata(dir.join("loopback.key"))
+                .unwrap()
+                .permissions()
+                .mode()
+                & 0o777,
+            0o600
+        );
+    }
+    std::fs::write(dir.join("loopback.key"), b"").unwrap();
+    assert!(
+        load(&dir).is_none(),
+        "an empty key file is not a cached pair"
+    );
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn files_that_do_not_exist_are_named() {
+    let err = obtain(&TlsChoice::Files {
+        cert: "/nonexistent/c.pem".into(),
+        key: "/nonexistent/k.pem".into(),
+        name: None,
+    })
+    .unwrap_err();
+    assert!(err.contains("/nonexistent/c.pem"), "{err}");
+}

--- a/citadel-workspace-internal-service/src/main.rs
+++ b/citadel-workspace-internal-service/src/main.rs
@@ -3,6 +3,8 @@ use citadel_internal_service::OriginPolicy;
 use citadel_sdk::prelude::{BackendType, NodeBuilder, NodeType, StackedRatchet};
 use std::error::Error;
 use std::net::SocketAddr;
+mod loopback;
+
 use structopt::StructOpt;
 
 #[tokio::main]
@@ -40,7 +42,47 @@ async fn main() -> Result<(), Box<dyn Error>> {
         );
     }
 
-    let service = CitadelWorkspaceService::new_websocket(opts.bind, origins).await?;
+    // TLS on loopback, for a UI served from elsewhere: see loopback.rs. Resolved before the
+    // backend so a misconfiguration is refused before any account store is opened.
+    let cache_root: std::path::PathBuf = std::env::var("INTERNAL_SERVICE_DATA_DIR")
+        .ok()
+        .filter(|d| !d.is_empty())
+        .or_else(|| opts.data_dir.clone())
+        .map(std::path::PathBuf::from)
+        .unwrap_or_else(|| std::path::PathBuf::from("./data"));
+    let tls_choice = loopback::choose_tls(&loopback::TlsInputs {
+        env_host: std::env::var("INTERNAL_SERVICE_LOOPBACK_HOST")
+            .ok()
+            .as_deref(),
+        env_cert_url: std::env::var("INTERNAL_SERVICE_LOOPBACK_CERT_URL")
+            .ok()
+            .as_deref(),
+        env_cert: std::env::var("INTERNAL_SERVICE_TLS_CERT").ok().as_deref(),
+        env_key: std::env::var("INTERNAL_SERVICE_TLS_KEY").ok().as_deref(),
+        cli_host: opts.loopback_host.as_deref(),
+        cli_cert_url: opts.loopback_cert_url.as_deref(),
+        cli_cert: opts.tls_cert.as_deref(),
+        cli_key: opts.tls_key.as_deref(),
+        cache_root: &cache_root,
+    })?;
+    let service = match loopback::obtain(&tls_choice)? {
+        None => CitadelWorkspaceService::new_websocket(opts.bind, origins).await?,
+        Some(pem) => {
+            let acceptor = citadel_internal_service::acceptor_from_pem(&pem.certificate, &pem.key)?;
+            let name: Option<&str> = match &tls_choice {
+                loopback::TlsChoice::Files { name, .. }
+                | loopback::TlsChoice::Fetch { name, .. } => name.as_deref(),
+                loopback::TlsChoice::Plain => None,
+            };
+            citadel_logging::info!(
+                target: "citadel",
+                "TLS on loopback: reachable as wss://{}:{} (and 127.0.0.1 / localhost / [::1])",
+                name.unwrap_or("<no published name>"),
+                opts.bind.port()
+            );
+            CitadelWorkspaceService::new_websocket_tls(opts.bind, origins, name, acceptor).await?
+        }
+    };
 
     // Backend selection precedence:
     //   1. INTERNAL_SERVICE_BACKEND / INTERNAL_SERVICE_DATA_DIR env vars
@@ -100,6 +142,22 @@ struct Options {
     /// INTERNAL_SERVICE_ALLOWED_ORIGINS, which takes precedence.
     #[structopt(long)]
     allowed_origins: Option<String>,
+    /// A name the hosting operator points at 127.0.0.1 and holds a certificate for
+    /// (e.g. local.example.com): the hosted UI dials wss://NAME:PORT. Needs a
+    /// certificate source below. INTERNAL_SERVICE_LOOPBACK_HOST takes precedence.
+    #[structopt(long)]
+    loopback_host: Option<String>,
+    /// Fetch the loopback certificate from URL/loopback.pem and URL/loopback.key at
+    /// start (https only), caching it under the data dir so later starts work offline.
+    /// INTERNAL_SERVICE_LOOPBACK_CERT_URL takes precedence.
+    #[structopt(long)]
+    loopback_cert_url: Option<String>,
+    /// PEM certificate chain for TLS on loopback (with --tls-key). INTERNAL_SERVICE_TLS_CERT.
+    #[structopt(long)]
+    tls_cert: Option<String>,
+    /// PEM private key for TLS on loopback (with --tls-cert). INTERNAL_SERVICE_TLS_KEY.
+    #[structopt(long)]
+    tls_key: Option<String>,
 }
 
 /// Resolve the origin allowlist from env + CLI, or explain what is missing.

--- a/docs/AGENT_README.md
+++ b/docs/AGENT_README.md
@@ -33,6 +33,28 @@ Both flags matter:
   account and message history are gone the next time the agent restarts. Data
   is written to `./internal-service-data` unless `--data-dir` says otherwise.
 
+## Using a hosted Citadel Workspace
+
+When the web app is served from somewhere else (work.avarok.net, say), your
+browser reaches this agent as `wss://local.avarok.net:12345` -- a name the
+operator points at `127.0.0.1` and holds a certificate for. Tell the agent the
+name and where to fetch the certificate:
+
+```bash
+./citadel-agent --bind 127.0.0.1:12345 --backend filesystem \
+  --allowed-origins https://work.avarok.net \
+  --loopback-host local.avarok.net \
+  --loopback-cert-url https://work.avarok.net/agent
+```
+
+The certificate is fetched at start (with `curl`) and cached beside your data,
+so later starts work offline. It is renewed every ninety days on the operator's
+side; you never handle it. The private key it comes with is public by
+construction -- the name resolves to your own machine, so there is no network
+between the browser and the agent to protect -- it exists to make the browser
+willing to open the socket. What protects the socket is `--allowed-origins`
+and the agent refusing any `Host` that is not its own.
+
 ## Windows
 
 ```powershell


### PR DESCRIPTION
Reopens the work from #93, rebased onto current master. That PR was closed
while its base moved; the branch survived and this is it, replayed cleanly (one
commit — the release fix it also carried is already on master).

## Why this is the last code gap for the hosted UI

`work.avarok.net` now serves the Citadel UI, and the page dials
`wss://local.avarok.net:12345`. It is served over HTTPS, so the browser refuses
a plain `ws://` upstream — mixed content. The agent must terminate TLS on
loopback.

citadel-agent#60 provides the primitives in the connector (`Transport`,
`acceptor_from_pem`, `HostPolicy`). **The parent binary does not wire them.**
Measured: `citadel-workspace-internal-service --help` has no `--tls-cert`,
`--tls-key` or `--loopback-host`, and its only TLS mention is the `--dangerous`
skip-verify for the *outbound* protocol connection. So there is currently no
way to run an agent the hosted page can reach.

## What it adds

`--loopback-host NAME` is the name the operator points at 127.0.0.1 and holds a
certificate for; the hosted page dials `wss://NAME:PORT`.

The certificate comes from `--tls-cert`/`--tls-key`, or is fetched from
`--loopback-cert-url` (`URL/loopback.pem` and `URL/loopback.key`, https only) at
start and cached `0600` under the data dir, so later starts work offline and a
renewed certificate replaces the cached one. Env equivalents take precedence, as
for every other flag here.

A name without a certificate source is **refused** rather than run plain.
"I set `--loopback-host` and it silently did nothing" is the failure this
avoids, and it is the same shape as the release that shipped a binary which
listened but could not speak WebSocket.

## Dependency

Pins the connector at citadel-agent#60's branch head. That must merge first,
and this pointer bumped to whatever it merges as.

https://claude.ai/code/session_01CQKcBi2QVjvJBEA8StPfN7