### PR TITLE
fix(kernel): nobody may unseat someone above them, and Owner outranks Admin

### DIFF
--- a/citadel-workspace-server-kernel/src/handlers/domain/server_ops/async_domain_server_ops.rs
+++ b/citadel-workspace-server-kernel/src/handlers/domain/server_ops/async_domain_server_ops.rs
@@ -92,6 +92,48 @@ impl<R: Ratchet + Send + Sync + 'static> AsyncDomainServerOperations<R> {
             Some(user) => user,
             None => return Err(NetworkError::msg("Permission denied: unknown actor")),
         };
+        // The chain of command decides between built-in roles; permission-set
+        // containment decides everything else.
+        //
+        // Containment alone said an Owner may not grant Admin, because Admin
+        // holds the `All` wildcard that `for_role` withholds from Owner. That is
+        // the right answer to "what may this role DO" and the wrong answer to
+        // "whom may this role APPOINT": the Owner runs the workspace, and an
+        // Admin is someone they appoint. `command_authority` is the ladder, and
+        // it returns None for Custom roles precisely so they keep falling
+        // through to containment -- a rank-21 Custom holding nine of the
+        // twenty-seven permissions must not outrank Owner, and containment is
+        // what stops it.
+        if let (Some(mine), Some(granting)) =
+            (actor.role.command_authority(), role.command_authority())
+        {
+            if mine >= granting {
+                return Ok(());
+            }
+            // A vacant seat may be filled; an occupied one may not be taken.
+            //
+            // Without this the Owner role is UNREACHABLE. `UserRole::Owner` is
+            // never assigned anywhere in the kernel's production code -- it is
+            // only ever read -- so the only way a workspace gains an Owner is
+            // this grant, and a workspace begins with an Admin and no Owner. A
+            // strict ladder would therefore have made "Owner" a role nobody
+            // could ever hold, which is not a hierarchy, it is a dead branch.
+            //
+            // Scoped as tightly as it can be: it applies only while the
+            // workspace has NO member holding the role being granted, so it
+            // bootstraps the seat and closes behind itself. An Admin cannot use
+            // it to manufacture a confederate above them once an Owner exists,
+            // which is the lateral escalation that would otherwise be the point
+            // of allowing this at all.
+            if self.workspace_has_no_member_holding(role).await? {
+                return Ok(());
+            }
+            return Err(NetworkError::msg(format!(
+                "Permission denied: {} cannot grant {}, which is above them",
+                actor.role, role
+            )));
+        }
+
         let granting: Vec<Permission> = Permission::for_role(role).into_iter().collect();
         self.ensure_may_grant_permissions(actor_user_id, &granting)
             .await
@@ -136,6 +178,127 @@ impl<R: Ratchet + Send + Sync + 'static> AsyncDomainServerOperations<R> {
             )));
         }
         Ok(())
+    }
+
+    /// Refuse acting ON someone whose authority the actor does not itself hold.
+    ///
+    /// `ensure_may_grant_role` closed one direction: you cannot hand out
+    /// authority you lack. This is the other, and it was open. Nothing anywhere
+    /// compared the actor against the target's CURRENT role, so the rule was
+    /// "you may not promote above yourself" with no matching "you may not
+    /// demote someone above you".
+    ///
+    /// `Permission::for_role(Banned)` is EMPTY, so the granting check passes
+    /// trivially for every actor: banning is granting nothing. An Owner holds 25
+    /// of the 27 permissions and lacks Admin's `All`, so an Owner could not
+    /// promote anyone to Admin — and could ban or demote an existing one. Three
+    /// paths reached it: `update_workspace_member_role`, `remove_user_from_domain`,
+    /// and `add_user_to_domain` with `role: Banned` at the workspace root.
+    ///
+    /// `ensure_not_last_admin` is not this guard. It refuses only the change
+    /// that empties the admin set; with two Admins present it permits either to
+    /// be removed by anyone who passed the entry gate.
+    ///
+    /// Same comparison as the granting side, pointed at the target's role, so
+    /// the two rules cannot drift: an Admin holds `All` and may act on anyone;
+    /// an actor may act on a peer of equal authority; nobody may act on someone
+    /// holding a permission they lack.
+    ///
+    /// Self-action is exempt. Demoting or removing YOURSELF hands nobody any
+    /// authority, and `ensure_not_last_admin` already refuses the one case that
+    /// matters — the workspace's last administrator standing down.
+    async fn ensure_may_act_on(
+        &self,
+        actor_user_id: &str,
+        target_user_id: &str,
+        action: &str,
+    ) -> Result<(), NetworkError> {
+        if actor_user_id == target_user_id {
+            return Ok(());
+        }
+        let target = match self.backend_tx_manager.get_user(target_user_id).await? {
+            Some(user) => user,
+            // Not a user yet. `add_user_to_domain` mints one, and there is no
+            // standing authority to protect.
+            None => return Ok(()),
+        };
+
+        // Only a MEMBER of this workspace holds authority in it.
+        //
+        // A `User` record can carry `UserRole::Owner` while belonging to no
+        // workspace at all -- roles live on the user, membership lives on the
+        // workspace -- and admitting such a person is not unseating anybody.
+        // Without this, an Admin could not `AddMember` anyone whose stored role
+        // outranked them, so a workspace could never admit its own Owner: the
+        // grant was permitted as a bootstrap and then refused one line later
+        // for acting on the very authority it was about to confer.
+        //
+        // Scoped to membership rather than skipped for AddMember, because
+        // AddMember at the root also WRITES the role: admitting a standing
+        // Owner as a Member is a demotion, and that must still be refused.
+        if !self
+            .is_member_of_domain(target_user_id, crate::WORKSPACE_ROOT_ID)
+            .await?
+        {
+            return Ok(());
+        }
+        let actor = match self.backend_tx_manager.get_user(actor_user_id).await? {
+            Some(user) => user,
+            None => return Err(NetworkError::msg("Permission denied: unknown actor")),
+        };
+
+        // Same ladder as the granting side, so the two rules cannot disagree:
+        // you may unseat someone you could have appointed.
+        if let (Some(mine), Some(theirs)) = (
+            actor.role.command_authority(),
+            target.role.command_authority(),
+        ) {
+            return if mine >= theirs {
+                Ok(())
+            } else {
+                Err(NetworkError::msg(format!(
+                    "Permission denied: {} cannot {action} {}, who is above them",
+                    actor.role, target.role
+                )))
+            };
+        }
+
+        let held = Permission::for_role(&actor.role);
+        if let Some(missing) = Permission::for_role(&target.role)
+            .into_iter()
+            .find(|p| !Permission::has_permission(&held, p))
+        {
+            return Err(NetworkError::msg(format!(
+                "Permission denied: {} cannot {action} {}, who holds {missing:?}",
+                actor.role, target.role
+            )));
+        }
+        Ok(())
+    }
+
+    /// Whether the workspace currently has nobody holding `role`.
+    ///
+    /// The same scan `ensure_not_last_admin` does, asked the other way round,
+    /// and used for one purpose only: letting an administrator fill a VACANT
+    /// seat above their own rank. See `ensure_may_grant_role`.
+    async fn workspace_has_no_member_holding(&self, role: &UserRole) -> Result<bool, NetworkError> {
+        let workspace = match self
+            .backend_tx_manager
+            .get_workspace(crate::WORKSPACE_ROOT_ID)
+            .await?
+        {
+            Some(ws) => ws,
+            // No workspace yet is as vacant as it gets.
+            None => return Ok(true),
+        };
+        for member_id in &workspace.members {
+            if let Some(member) = self.backend_tx_manager.get_user(member_id).await? {
+                if member.role == *role {
+                    return Ok(false);
+                }
+            }
+        }
+        Ok(true)
     }
 
     /// Refuse anything that would leave the workspace with nobody who can
@@ -539,6 +702,13 @@ impl<R: Ratchet + Send + Sync + 'static> AsyncUserManagementOperations<R>
         // they may hand out, and `user_id_to_add` may be the caller.
         self.ensure_may_grant_role(admin_id, &role).await?;
 
+        // `AddMember` is also a role WRITE at the workspace root, so it is the
+        // third door to the same demotion: `role: Banned` on a standing Admin
+        // passes the granting check (Banned grants nothing) and would otherwise
+        // strip them.
+        self.ensure_may_act_on(admin_id, user_id_to_add, "change the role of")
+            .await?;
+
         // If this is the workspace root, use the workspace storage
         // Held across BOTH writes: the membership below and the role at the end.
         //
@@ -658,6 +828,12 @@ impl<R: Ratchet + Send + Sync + 'static> AsyncUserManagementOperations<R>
             // update_workspace take this lock for.
             let _workspace_guard = self.backend_tx_manager.lock_workspaces().await;
 
+            // Inside the lock, beside the last-admin check, for the same
+            // reason: the target's role is what both read, and a concurrent
+            // promotion between the two would answer from different states.
+            self.ensure_may_act_on(admin_id, user_id_to_remove, "remove")
+                .await?;
+
             self.ensure_not_last_admin(user_id_to_remove, "remove")
                 .await?;
 
@@ -774,6 +950,10 @@ impl<R: Ratchet + Send + Sync + 'static> AsyncUserManagementOperations<R>
         // above could otherwise grant Admin, which carries the ConfigureSystem
         // an Owner is deliberately not granted.
         self.ensure_may_grant_role(actor_user_id, &role).await?;
+
+        // And the other direction: what the target currently holds.
+        self.ensure_may_act_on(actor_user_id, target_user_id, "change the role of")
+            .await?;
 
         // See `write_user_role` — the lock, the last-admin check and the write
         // are one unit, and this was the writer that never took the lock.

--- a/citadel-workspace-server-kernel/tests/no_one_grants_a_role_above_their_own.rs
+++ b/citadel-workspace-server-kernel/tests/no_one_grants_a_role_above_their_own.rs
@@ -106,8 +106,21 @@ async fn a_custom_role_cannot_mint_an_admin_accomplice() {
     );
 }
 
+/// The Owner runs the workspace, and an Admin is someone they appoint.
+///
+/// This asserted the OPPOSITE, on the grounds that `for_role` withholds `All`
+/// and `ConfigureSystem` from Owner so permission containment refuses the
+/// grant. That is a correct reading of the permission sets and the wrong answer
+/// to the question: those sets say what a role may DO, and appointing is about
+/// who a role may MANAGE. `UserRole::command_authority` is that ladder now, and
+/// it puts Owner above Admin.
+///
+/// The `for_role` sets are deliberately unchanged. An Owner still does not hold
+/// `ConfigureSystem` -- a server-level permission -- and still does not hold the
+/// `All` wildcard. Being able to appoint an Admin is not the same as holding
+/// everything that Admin holds.
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn an_owner_cannot_grant_admin() {
+async fn an_owner_may_grant_admin() {
     let kernel = create_test_kernel().await;
     insert_user_with_role(&kernel, "owner", UserRole::Owner).await;
     join_root(&kernel, "owner").await;
@@ -117,8 +130,53 @@ async fn an_owner_cannot_grant_admin() {
     assert!(
         try_set_role_as(&kernel, "owner", "target", UserRole::Admin)
             .await
+            .is_ok(),
+        "the Owner appoints administrators",
+    );
+}
+
+/// An Admin may fill a VACANT Owner seat. This is the bootstrap, and without it
+/// the role is unreachable.
+///
+/// `UserRole::Owner` is never assigned anywhere in the kernel's production code
+/// -- it is only ever read -- so this grant is the only way a workspace gains
+/// an Owner, and a workspace begins with an Admin and no Owner. A strict ladder
+/// would have made "Owner" a role nobody could ever hold.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn an_admin_may_fill_a_vacant_owner_seat() {
+    let kernel = create_test_kernel().await;
+    insert_user_with_role(&kernel, "target", UserRole::Member).await;
+    join_root(&kernel, "target").await;
+    join_root(&kernel, TEST_ADMIN_USER_ID).await;
+
+    assert!(
+        try_set_role_as(&kernel, TEST_ADMIN_USER_ID, "target", UserRole::Owner)
+            .await
+            .is_ok(),
+        "a workspace with no Owner must be able to gain one",
+    );
+}
+
+/// And the seat closes behind itself, which is what makes the ladder a ladder.
+///
+/// This is the assertion the bootstrap above must not cost: once an Owner
+/// exists, an Admin cannot manufacture a second one. That would be a lateral
+/// escalation -- a confederate placed above every other administrator, by an
+/// administrator.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn an_admin_cannot_grant_owner_once_one_exists() {
+    let kernel = create_test_kernel().await;
+    insert_user_with_role(&kernel, "founder", UserRole::Owner).await;
+    join_root(&kernel, "founder").await;
+    insert_user_with_role(&kernel, "target", UserRole::Member).await;
+    join_root(&kernel, "target").await;
+    join_root(&kernel, TEST_ADMIN_USER_ID).await;
+
+    assert!(
+        try_set_role_as(&kernel, TEST_ADMIN_USER_ID, "target", UserRole::Owner)
+            .await
             .is_err(),
-        "Admin carries ConfigureSystem, which for_role withholds from Owner",
+        "an Admin does not mint a peer for the person who appoints them",
     );
 }
 

--- a/citadel-workspace-server-kernel/tests/no_one_unseats_a_role_above_their_own.rs
+++ b/citadel-workspace-server-kernel/tests/no_one_unseats_a_role_above_their_own.rs
@@ -1,0 +1,214 @@
+//! You cannot unseat someone above you in the chain of command.
+//!
+//! `no_one_grants_a_role_above_their_own` closed one direction: you may not
+//! appoint above yourself. This is the other, and it was open. Nothing anywhere
+//! compared the actor against the target's CURRENT role, so the rule was "you
+//! may not promote above yourself" with no matching "you may not demote someone
+//! above you".
+//!
+//! `Permission::for_role(Banned)` is EMPTY, so the granting check passes
+//! trivially for every actor: banning grants nothing. An Admin could therefore
+//! ban, demote or remove the workspace's Owner through any of three doors:
+//!
+//!     update_workspace_member_role(admin, owner, Banned)
+//!     remove_user_from_domain(admin, owner, WORKSPACE_ROOT)
+//!     add_user_to_domain(admin, owner, WORKSPACE_ROOT, Banned)
+//!
+//! `ensure_not_last_admin` is not this guard and never was: it refuses only the
+//! change that empties the admin set. With two administrators present it
+//! permits either to be unseated by anyone who passed the entry gate, which is
+//! exactly the scenario below.
+//!
+//! The ladder is `UserRole::command_authority`, and it puts Owner above Admin:
+//! the Owner runs the workspace and an Admin is someone they appoint. That is
+//! deliberately NOT what permission-set containment says -- `for_role` gives
+//! Admin the `All` wildcard and withholds it from Owner -- because those sets
+//! answer "what may this role do", not "whom may this role manage".
+//!
+//! What must still work is asserted alongside the refusals. A rule that refused
+//! everything would satisfy the refusals on its own, and would also break
+//! ordinary member management: an Owner must still be able to unseat an Admin,
+//! an Admin must still be able to remove a Member, and anyone must still be able
+//! to stand down themselves.
+
+use citadel_workspace_server_kernel::handlers::domain::async_ops::AsyncUserManagementOperations;
+use citadel_workspace_server_kernel::handlers::domain::server_ops::async_domain_server_ops::AsyncDomainServerOperations;
+use citadel_workspace_types::structs::UserRole;
+use common::member_test_utils::{insert_user_with_role, join_root, GateKernel as Kernel};
+use common::workspace_test_utils::{create_test_kernel, TEST_ADMIN_USER_ID};
+
+const ROOT: &str = citadel_workspace_server_kernel::WORKSPACE_ROOT_ID;
+
+async fn try_set_role_as(
+    kernel: &Kernel,
+    actor: &str,
+    target: &str,
+    role: UserRole,
+) -> Result<(), String> {
+    kernel
+        .domain_operations
+        .update_workspace_member_role(actor, target, role, None)
+        .await
+        .map_err(|e| e.to_string())
+}
+
+async fn try_remove_as(kernel: &Kernel, actor: &str, target: &str) -> Result<(), String> {
+    kernel
+        .domain_operations
+        .remove_user_from_domain(actor, target, ROOT)
+        .await
+        .map_err(|e| e.to_string())
+}
+
+async fn try_add_as(
+    kernel: &Kernel,
+    actor: &str,
+    target: &str,
+    role: UserRole,
+) -> Result<(), String> {
+    kernel
+        .domain_operations
+        .add_user_to_domain(actor, target, ROOT, role)
+        .await
+        .map_err(|e| e.to_string())
+}
+
+async fn role_of(kernel: &Kernel, id: &str) -> UserRole {
+    kernel
+        .domain_operations
+        .backend_tx_manager
+        .get_user(id)
+        .await
+        .expect("read user")
+        .expect("user exists")
+        .role
+}
+
+/// An Owner, a standing Admin, and the kernel's own admin — so
+/// `ensure_not_last_admin` has more than one administrator and cannot be the
+/// thing that refuses. Whatever refuses below is this guard.
+async fn owner_and_a_standing_admin() -> std::sync::Arc<Kernel> {
+    let kernel = create_test_kernel().await;
+    insert_user_with_role(&kernel, "owner", UserRole::Owner).await;
+    join_root(&kernel, "owner").await;
+    insert_user_with_role(&kernel, "admin2", UserRole::Admin).await;
+    join_root(&kernel, "admin2").await;
+    join_root(&kernel, TEST_ADMIN_USER_ID).await;
+    kernel
+}
+
+// ---------- the three doors ----------
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn an_admin_cannot_ban_the_owner() {
+    let kernel = owner_and_a_standing_admin().await;
+
+    let outcome = try_set_role_as(&kernel, "admin2", "owner", UserRole::Banned).await;
+    assert!(
+        outcome.is_err(),
+        "Banned grants nothing, so the granting check passes -- this is the only guard: {outcome:?}",
+    );
+    assert_eq!(
+        role_of(&kernel, "owner").await,
+        UserRole::Owner,
+        "a refusal must also leave the role unwritten",
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn an_admin_cannot_demote_the_owner() {
+    let kernel = owner_and_a_standing_admin().await;
+
+    assert!(
+        try_set_role_as(&kernel, "admin2", "owner", UserRole::Member)
+            .await
+            .is_err(),
+        "Member carries less than Admin holds, so only the target's role can refuse this",
+    );
+    assert_eq!(role_of(&kernel, "owner").await, UserRole::Owner);
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn an_admin_cannot_remove_the_owner() {
+    let kernel = owner_and_a_standing_admin().await;
+
+    assert!(
+        try_remove_as(&kernel, "admin2", "owner").await.is_err(),
+        "removal is the same unseating by another door",
+    );
+    assert_eq!(role_of(&kernel, "owner").await, UserRole::Owner);
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn an_admin_cannot_ban_the_owner_through_add_member() {
+    let kernel = owner_and_a_standing_admin().await;
+
+    assert!(
+        try_add_as(&kernel, "admin2", "owner", UserRole::Banned)
+            .await
+            .is_err(),
+        "AddMember is a role write at the root, so it is the third door to the same demotion",
+    );
+    assert_eq!(role_of(&kernel, "owner").await, UserRole::Owner);
+}
+
+// ---------- what must still work ----------
+//
+// Without these, a guard that refused every actor-target pair would pass every
+// assertion above while breaking all of member management.
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn an_owner_may_still_unseat_an_admin() {
+    let kernel = owner_and_a_standing_admin().await;
+
+    assert!(
+        try_set_role_as(&kernel, "owner", "admin2", UserRole::Member)
+            .await
+            .is_ok(),
+        "the Owner appoints administrators, so the Owner may unseat one",
+    );
+    assert_eq!(role_of(&kernel, "admin2").await, UserRole::Member);
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn an_admin_may_still_remove_an_ordinary_member() {
+    let kernel = owner_and_a_standing_admin().await;
+    insert_user_with_role(&kernel, "member", UserRole::Member).await;
+    join_root(&kernel, "member").await;
+
+    assert!(
+        try_remove_as(&kernel, "admin2", "member").await.is_ok(),
+        "ordinary member management must be untouched",
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn an_owner_may_still_act_on_a_peer_owner() {
+    let kernel = owner_and_a_standing_admin().await;
+    insert_user_with_role(&kernel, "owner2", UserRole::Owner).await;
+    join_root(&kernel, "owner2").await;
+
+    assert!(
+        try_set_role_as(&kernel, "owner", "owner2", UserRole::Member)
+            .await
+            .is_ok(),
+        "equal authority is containment, not escalation",
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn an_owner_may_still_stand_down() {
+    let kernel = owner_and_a_standing_admin().await;
+
+    // Self-action hands nobody any authority, and with three administrators
+    // present `ensure_not_last_admin` has nothing to say either. Without this,
+    // the ladder would trap the Owner: nobody outranks them, so nobody else
+    // could ever demote them.
+    assert!(
+        try_set_role_as(&kernel, "owner", "owner", UserRole::Member)
+            .await
+            .is_ok(),
+        "you may always relinquish your own authority",
+    );
+    assert_eq!(role_of(&kernel, "owner").await, UserRole::Member);
+}

--- a/citadel-workspace-server-kernel/tests/removal_takes_the_role_from_an_owner_too.rs
+++ b/citadel-workspace-server-kernel/tests/removal_takes_the_role_from_an_owner_too.rs
@@ -45,12 +45,22 @@ async fn still_administers(kernel: &Kernel, user: &str) -> bool {
         .expect("backend read")
 }
 
-async fn remove(kernel: &Kernel, target: &str) {
+/// Removal, by a named actor.
+///
+/// The actor used to be hard-coded to the seeded Admin. It has to be a
+/// parameter now, because an Admin may no longer unseat an Owner: the Owner
+/// runs the workspace and appoints administrators, so removing one is above an
+/// Admin's authority (see `no_one_unseats_a_role_above_their_own`).
+///
+/// That is a constraint on WHO may remove, and this file is about WHAT removal
+/// does to the role. Naming the actor keeps the two apart instead of letting
+/// the authority rule quietly decide the outcome of a revocation test.
+async fn remove_as(kernel: &Kernel, actor: &str, target: &str) {
     kernel
         .domain_operations
-        .remove_user_from_domain(TEST_ADMIN_USER_ID, target, ROOT)
+        .remove_user_from_domain(actor, target, ROOT)
         .await
-        .expect("an admin may remove a member");
+        .expect("the actor may remove this member");
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
@@ -58,12 +68,18 @@ async fn removing_an_owner_takes_the_role() {
     let kernel = create_test_kernel().await;
     insert_user_with_role(&kernel, "founder", UserRole::Owner).await;
     join_root(&kernel, "founder").await;
+    // A peer Owner does the removing. An Admin cannot reach an Owner any more,
+    // and a peer of equal authority is the narrowest actor that can -- so the
+    // refusal under test below is the ROLE not being dropped, never the caller
+    // being turned away at the door.
+    insert_user_with_role(&kernel, "cofounder", UserRole::Owner).await;
+    join_root(&kernel, "cofounder").await;
     assert!(
         still_administers(&kernel, "founder").await,
         "an Owner administers before removal, or nothing below is being measured",
     );
 
-    remove(&kernel, "founder").await;
+    remove_as(&kernel, "cofounder", "founder").await;
 
     assert_eq!(
         role_of(&kernel, "founder").await,
@@ -84,7 +100,7 @@ async fn removing_an_admin_still_takes_the_role() {
     insert_user_with_role(&kernel, "deputy", UserRole::Admin).await;
     join_root(&kernel, "deputy").await;
 
-    remove(&kernel, "deputy").await;
+    remove_as(&kernel, TEST_ADMIN_USER_ID, "deputy").await;
 
     assert_eq!(role_of(&kernel, "deputy").await, UserRole::Member);
     assert!(!still_administers(&kernel, "deputy").await);
@@ -98,7 +114,7 @@ async fn removing_a_plain_member_leaves_their_role_alone() {
     insert_user_with_role(&kernel, "visitor", UserRole::Guest).await;
     join_root(&kernel, "visitor").await;
 
-    remove(&kernel, "visitor").await;
+    remove_as(&kernel, TEST_ADMIN_USER_ID, "visitor").await;
 
     assert_eq!(role_of(&kernel, "visitor").await, UserRole::Guest);
 }

--- a/citadel-workspace-types/src/structs.rs
+++ b/citadel-workspace-types/src/structs.rs
@@ -187,6 +187,41 @@ impl UserRole {
         }
     }
 
+    /// Where this role sits in the workspace's chain of command.
+    ///
+    /// `Some(n)`, higher outranks lower. `None` for Custom roles, which have no
+    /// place in the ladder — see below.
+    ///
+    /// Deliberately NOT `get_rank`, and deliberately not derived from
+    /// `Permission::for_role`, because all three answer different questions:
+    ///
+    ///   - `get_rank` is a sort order and the scale Custom roles are created on.
+    ///     `ADMIN_RANK` is `u8::MAX` there so no Custom role can be minted above
+    ///     it, which is about namespacing, not authority.
+    ///   - `Permission::for_role` says what a role may DO. Admin holds the `All`
+    ///     wildcard and Owner holds everything except `All` and
+    ///     `ConfigureSystem`, so set containment makes Admin outrank Owner.
+    ///   - this says who a role may MANAGE, and there the Owner is above the
+    ///     Admin: the Owner runs the workspace, and an Admin is someone they
+    ///     appoint.
+    ///
+    /// Custom roles return `None` on purpose. Ranking them here would reopen a
+    /// hole that was closed once already: `create_custom_role` permits ranks
+    /// 21-254, and a Custom role above the editor threshold holds nine of the
+    /// twenty-seven permissions, so a rank-21 Custom would outrank Owner while
+    /// holding a third of its authority. Callers fall back to permission-set
+    /// containment for those, which does track power.
+    pub fn command_authority(&self) -> Option<u8> {
+        match self {
+            UserRole::Owner => Some(4),
+            UserRole::Admin => Some(3),
+            UserRole::Member => Some(2),
+            UserRole::Guest => Some(1),
+            UserRole::Banned => Some(0),
+            UserRole::Custom(_, _) => None,
+        }
+    }
+
     /// Creates a custom user role with a given name and rank.
     pub fn create_custom_role(name: String, rank: u8) -> Option<Self> {
         if rank == ADMIN_RANK


### PR DESCRIPTION
## The hole

`ensure_may_grant_role` closed one direction — you cannot hand out authority you do not hold. **Nothing anywhere compared the actor against the target's *current* role**, so there was no matching "you may not demote someone above you".

`Permission::for_role(Banned)` is **empty**, so the granting check passes trivially for every actor: banning is granting nothing. Three doors reached the same write:

```
update_workspace_member_role(actor, target, Banned)
remove_user_from_domain(actor, target, WORKSPACE_ROOT)
add_user_to_domain(actor, target, WORKSPACE_ROOT, Banned)
```

`ensure_not_last_admin` is **not** this guard — it refuses only the change that empties the admin set, so with two administrators present it permitted either to be unseated by anyone who passed the entry gate.

## The direction: Owner > Admin

Permission-set containment made **Admin outrank Owner**, because `for_role` gives Admin the `All` wildcard and withholds it from Owner. That is a correct reading of the permission sets and the wrong answer to the question — those sets say what a role may **do**; this is about whom a role may **manage**. The Owner runs the workspace; an Admin is someone they appoint.

`UserRole::command_authority` is that ladder, and **both** guards consult it, so "whom you may appoint" and "whom you may unseat" cannot disagree.

It is deliberately not `get_rank` (a sort order whose `ADMIN_RANK = u8::MAX` exists to stop Custom roles being minted above it) and not derived from `for_role`. **Custom roles return `None` on purpose**: `create_custom_role` permits ranks 21–254, so a rank-21 Custom holding 9 of the 27 permissions would outrank Owner while holding a third of its authority. Those fall through to permission containment, which does track power.

## Two corrections found by running it, not reading it

**1. A strict ladder makes the Owner role unreachable.** `UserRole::Owner` is never assigned anywhere in the kernel's production code — only read — so this grant is the only way a workspace gains an Owner, and a workspace begins with an Admin and no Owner. So: an Admin may fill a **vacant** Owner seat, and the seat closes behind itself. Once an Owner exists an Admin cannot mint a second — that is the lateral escalation which would otherwise be the point of allowing it.

**2. The guard protected authority that did not exist.** `ensure_may_act_on` read the target's stored `user.role`, but a `User` record can carry `Owner` while belonging to no workspace — roles live on the user, membership on the workspace. The grant was permitted as a bootstrap and then blocked one line later for acting on the authority it was about to confer. It asks about **membership** now — scoped rather than skipped for AddMember, because AddMember at the root also writes the role: admitting a standing Owner as a Member is a demotion and must still be refused.

## Controls

With the ladder neutered in both guards, **exactly five tests fail** — the four unseating refusals and the grant-once-one-exists refusal — and **every permitted case still passes**.

The first control run was **wrong**, and it is worth recording: without `--no-fail-fast`, cargo stopped after the first failing binary, so the four unseating assertions never ran and the control looked like a single failure.

## Three existing tests changed, none weakened

| test | change | why |
|---|---|---|
| `an_owner_cannot_grant_admin` | → `an_owner_may_grant_admin` | its written rationale *was* the inverted hierarchy |
| `removal_takes_the_role_from_an_owner_too` | helper gained an actor parameter | "who may remove" and "what removal does to the role" are different properties; the authority rule must not silently decide a revocation test |
| `the_last_administrator_cannot_step_down` | unchanged subject | an Owner demoting an Admin is legal again under this ordering |

## Verification

Full server-kernel suite **357 passed, 0 failed**. `cargo fmt --all --check` clean.