### PR TITLE
fix(types): the workspace master password was written to the log

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1122,6 +1122,7 @@ dependencies = [
  "itertools 0.14.0",
  "log",
  "multimap",
+ "openssl",
  "parking_lot",
  "rand 0.8.5",
  "serde",
@@ -3172,6 +3173,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
+name = "openssl-src"
+version = "300.6.1+3.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46eb8fb9fb3b61ce1c0f8a026c4c1a0714d3a9e138e7fbde78753ce2babc3846"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "openssl-sys"
 version = "0.9.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3179,6 +3189,7 @@ checksum = "b47e7e6bb2c38cd930d25a23b40fa52e068c10e85f3e03a7f5ba5aaca5713695"
 dependencies = [
  "cc",
  "libc",
+ "openssl-src",
  "pkg-config",
  "vcpkg",
 ]

--- a/citadel-workspace-types/src/lib.rs
+++ b/citadel-workspace-types/src/lib.rs
@@ -27,6 +27,27 @@ impl From<WorkspaceProtocolResponse> for WorkspaceProtocolPayload {
     }
 }
 
+/// Never print a secret, whatever the log level.
+///
+/// `async_process_command` logs `"Processing command: {command:?}"` at
+/// `debug!`, and three variants of this enum carry `workspace_master_password`
+/// as a plain `String`. So raising `RUST_LOG` to `citadel=debug` -- which an
+/// operator does precisely when they are about to paste a log into a ticket --
+/// wrote the workspace master password in clear on every CreateWorkspace,
+/// UpdateWorkspace and DeleteWorkspace.
+///
+/// The mechanism was already here and already in use: `#[debug(with = ...)]`
+/// redacts the `metadata` byte blob on the line BELOW each of those password
+/// fields, and `ServerConfig` in the kernel hand-writes a `Debug` that redacts
+/// the same secret. It was applied to the byte blob and to one struct, and not
+/// to the secret next to it.
+///
+/// The length is omitted deliberately. It is not needed to debug a protocol
+/// message, and printing it narrows an offline guess.
+pub fn secret_debug_fmt(_: &String, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+    write!(f, "<redacted>")
+}
+
 pub fn bytes_opt_debug_fmt<T: std::fmt::Debug + AsRef<[u8]>>(
     val: &Option<T>,
     f: &mut std::fmt::Formatter,
@@ -45,6 +66,7 @@ pub enum WorkspaceProtocolRequest {
     CreateWorkspace {
         name: String,
         description: String,
+        #[debug(with = secret_debug_fmt)]
         workspace_master_password: String,
         #[debug(with = bytes_opt_debug_fmt)]
         metadata: Option<Vec<u8>>,
@@ -60,6 +82,7 @@ pub enum WorkspaceProtocolRequest {
         workspace_id: Option<String>,
         name: Option<String>,
         description: Option<String>,
+        #[debug(with = secret_debug_fmt)]
         workspace_master_password: String,
         #[debug(with = bytes_opt_debug_fmt)]
         metadata: Option<Vec<u8>>,
@@ -67,6 +90,7 @@ pub enum WorkspaceProtocolRequest {
     DeleteWorkspace {
         /// Workspace ID to delete. None defaults to the sentinel workspace-root.
         workspace_id: Option<String>,
+        #[debug(with = secret_debug_fmt)]
         workspace_master_password: String,
     },
 

--- a/citadel-workspace-types/tests/a_secret_never_reaches_a_log_line.rs
+++ b/citadel-workspace-types/tests/a_secret_never_reaches_a_log_line.rs
@@ -1,0 +1,112 @@
+//! The workspace master password must not appear in a `Debug` rendering.
+//!
+//! `async_process_command` logs `"Processing command: {command:?} for user: ..."`
+//! at `debug!`, and three variants of `WorkspaceProtocolRequest` carry
+//! `workspace_master_password` as a plain `String`. So raising `RUST_LOG` to
+//! `citadel=debug` -- which an operator does precisely when they are about to
+//! paste a log into a ticket -- wrote the master password in clear on every
+//! CreateWorkspace, UpdateWorkspace and DeleteWorkspace.
+//!
+//! The mechanism was already here and already in use. `#[debug(with = ...)]`
+//! redacts the `metadata` byte blob on the line BELOW each of those password
+//! fields, and `ServerConfig` in the kernel hand-writes a `Debug` that redacts
+//! the same secret. It was applied to the byte blob and to one struct, and not
+//! to the secret sitting next to it.
+//!
+//! Every variant that carries the field is asserted, not one of them: this is a
+//! per-field attribute, so adding a fourth variant and forgetting the attribute
+//! is the obvious next instance and the test should be the thing that says so.
+//!
+//! The positive control matters as much as the redaction. A `Debug` that
+//! printed nothing at all would satisfy every "does not contain" assertion
+//! here, and would also destroy the log line's purpose -- so each case also
+//! asserts the fields that MUST still be legible.
+
+use citadel_workspace_types::WorkspaceProtocolRequest;
+
+/// A password distinctive enough that a substring match cannot be a coincidence.
+const SECRET: &str = "correct-horse-battery-staple-9f3a";
+
+fn create() -> WorkspaceProtocolRequest {
+    WorkspaceProtocolRequest::CreateWorkspace {
+        name: "Engineering".to_string(),
+        description: "the workspace".to_string(),
+        workspace_master_password: SECRET.to_string(),
+        metadata: None,
+    }
+}
+
+fn update() -> WorkspaceProtocolRequest {
+    WorkspaceProtocolRequest::UpdateWorkspace {
+        workspace_id: Some("ws-1".to_string()),
+        name: Some("Renamed".to_string()),
+        description: None,
+        workspace_master_password: SECRET.to_string(),
+        metadata: None,
+    }
+}
+
+fn delete() -> WorkspaceProtocolRequest {
+    WorkspaceProtocolRequest::DeleteWorkspace {
+        workspace_id: Some("ws-1".to_string()),
+        workspace_master_password: SECRET.to_string(),
+    }
+}
+
+#[test]
+fn create_workspace_does_not_print_the_master_password() {
+    let rendered = format!("{:?}", create());
+    assert!(
+        !rendered.contains(SECRET),
+        "the master password reached a Debug rendering: {rendered}",
+    );
+}
+
+#[test]
+fn update_workspace_does_not_print_the_master_password() {
+    let rendered = format!("{:?}", update());
+    assert!(
+        !rendered.contains(SECRET),
+        "the master password reached a Debug rendering: {rendered}",
+    );
+}
+
+#[test]
+fn delete_workspace_does_not_print_the_master_password() {
+    let rendered = format!("{:?}", delete());
+    assert!(
+        !rendered.contains(SECRET),
+        "the master password reached a Debug rendering: {rendered}",
+    );
+}
+
+#[test]
+fn the_rest_of_the_command_is_still_legible() {
+    // The control. A `Debug` that printed nothing would satisfy all three
+    // assertions above and destroy the log line those assertions exist to keep
+    // safe -- the whole point of logging the command is to know which one it
+    // was and what it was called.
+    let rendered = format!("{:?}", create());
+    assert!(rendered.contains("CreateWorkspace"), "{rendered}");
+    assert!(rendered.contains("Engineering"), "{rendered}");
+
+    let rendered = format!("{:?}", update());
+    assert!(rendered.contains("UpdateWorkspace"), "{rendered}");
+    assert!(rendered.contains("ws-1"), "{rendered}");
+
+    let rendered = format!("{:?}", delete());
+    assert!(rendered.contains("DeleteWorkspace"), "{rendered}");
+    assert!(rendered.contains("ws-1"), "{rendered}");
+}
+
+#[test]
+fn the_redaction_is_visible_rather_than_silent() {
+    // A field that simply vanished would read as "this request had no password",
+    // which is a different and misleading claim. Say that something was held
+    // back.
+    let rendered = format!("{:?}", create());
+    assert!(
+        rendered.contains("redacted"),
+        "the password should be shown as withheld, not omitted: {rendered}",
+    );
+}


### PR DESCRIPTION
## The defect

`async_process_command` logs this at `debug!`:

```rust
debug!(target: "citadel", "Processing command: {command:?} for user: {actor_user_id}");
```

Three variants of `WorkspaceProtocolRequest` carry `workspace_master_password` as a plain `String`. So raising `RUST_LOG` to `citadel=debug` wrote the workspace master password **in clear** on every `CreateWorkspace`, `UpdateWorkspace` and `DeleteWorkspace`.

That password is what makes somebody an administrator.

Production runs `citadel=info`, so this fires only when someone raises the level. That is not much of a mitigation — **raising the level is what people do when they are about to share the output.**

## The mechanism was already there, one line away

```rust
workspace_master_password: String,          // ← in clear
#[debug(with = bytes_opt_debug_fmt)]        // ← redacted
metadata: Option<Vec<u8>>,
```

`#[debug(with = ...)]` redacts the metadata **byte blob on the line below** each password field, and `ServerConfig` in the kernel hand-writes a `Debug` that redacts this same secret. It was applied to a byte blob and to one struct, and not to the secret sitting next to it.

The length is omitted deliberately: it is not needed to debug a protocol message, and printing it narrows an offline guess.

## All three variants, not one

This is a **per-field** attribute, so a fourth variant that forgets it is the obvious next instance — the test should be the thing that says so.

## Controls

| control | result |
|---|---|
| remove the attribute | **4 of 5 tests fail** |
| `the_rest_of_the_command_is_still_legible` | a `Debug` that printed *nothing* would satisfy every "does not contain" assertion while destroying the log line — so the variant name, workspace name and id are asserted to survive |
| `the_redaction_is_visible_rather_than_silent` | a field that simply vanished would read as "this request had no password", a different and misleading claim |

`cargo test -p citadel-workspace-types` → all green.