### PR TITLE
fix(kernel): a wrong master password answered differently from a wrong caller

### DIFF
--- a/citadel-workspace-server-kernel/src/handlers/domain/server_ops/async_domain_server_ops.rs
+++ b/citadel-workspace-server-kernel/src/handlers/domain/server_ops/async_domain_server_ops.rs
@@ -1036,17 +1036,22 @@ impl<R: Ratchet + Send + Sync + 'static> AsyncWorkspaceOperations<R>
 
         // Determine workspace ID: use sentinel for first workspace, UUID for additional
         let workspace_id = if root_exists {
-            // Creating a non-root workspace: verify against root workspace password
-            let passwords = self.backend_tx_manager.get_all_passwords().await?;
-            if !passwords
-                .get(crate::WORKSPACE_ROOT_ID)
-                .map(|p| crate::kernel::secret_eq::secrets_match(p, &workspace_master_password))
-                .unwrap_or(false)
-            {
-                return Err(NetworkError::msg("Invalid workspace master password"));
-            }
-
-            // Verify the creator has CreateWorkspace permission on the root workspace
+            // AUTHORISATION FIRST, then the secret.
+            //
+            // The order was the other way round, and the two failures return
+            // different strings, so anybody who could reach this endpoint had an
+            // online password oracle: send a guess, and "Invalid workspace master
+            // password" versus "Only root workspace admins can create additional
+            // workspaces" says whether the guess was right. The rate limiter
+            // allows 100 requests per second and resets its bucket each window,
+            // registration needs no invite, and CIDs are free -- so there is no
+            // lockout to run into.
+            //
+            // Checking the permission first means a caller who is not entitled
+            // to create workspaces learns nothing about the password no matter
+            // how many guesses they send. `delete_workspace` already did it in
+            // this order; this is the same fix, applied to the two places that
+            // did not have it.
             if !self
                 .check_entity_permission(
                     user_id,
@@ -1058,6 +1063,15 @@ impl<R: Ratchet + Send + Sync + 'static> AsyncWorkspaceOperations<R>
                 return Err(NetworkError::msg(
                     "Only root workspace admins can create additional workspaces",
                 ));
+            }
+
+            let passwords = self.backend_tx_manager.get_all_passwords().await?;
+            if !passwords
+                .get(crate::WORKSPACE_ROOT_ID)
+                .map(|p| crate::kernel::secret_eq::secrets_match(p, &workspace_master_password))
+                .unwrap_or(false)
+            {
+                return Err(NetworkError::msg("Invalid workspace master password"));
             }
 
             uuid::Uuid::new_v4().to_string()
@@ -1300,18 +1314,6 @@ impl<R: Ratchet + Send + Sync + 'static> AsyncWorkspaceOperations<R>
         metadata: Option<Vec<u8>>,
         workspace_master_password: String,
     ) -> Result<Workspace, NetworkError> {
-        // Verify master access password
-        let passwords = self.backend_tx_manager.get_all_passwords().await?;
-        if !passwords
-            .get(workspace_id)
-            .map(|p| crate::kernel::secret_eq::secrets_match(p, &workspace_master_password))
-            .unwrap_or(false)
-        {
-            return Err(NetworkError::msg(
-                "Invalid workspace master access password",
-            ));
-        }
-
         // Held across the whole read-modify-write, like the connect path.
         //
         // A mutex only excludes PARTICIPANTS. The connect-time member-add takes
@@ -1327,8 +1329,7 @@ impl<R: Ratchet + Send + Sync + 'static> AsyncWorkspaceOperations<R>
         // half of it.
         let _workspace_guard = self.backend_tx_manager.lock_workspaces().await;
 
-        // Get workspace directly from backend without permission check
-        // since we've verified the master password
+        // Read first, then authorise, then verify the secret. See below.
         let mut workspace = match self.backend_tx_manager.get_workspace(workspace_id).await? {
             Some(ws) => ws,
             None => return Err(NetworkError::msg("Workspace not found")),
@@ -1359,6 +1360,35 @@ impl<R: Ratchet + Send + Sync + 'static> AsyncWorkspaceOperations<R>
                     "Permission denied: only an admin or the workspace owner may update it",
                 ));
             }
+        }
+
+        // The password is verified AFTER authorisation, not before it.
+        //
+        // It used to be the first thing this function did, and the two failures
+        // return different strings -- so anyone who could reach this endpoint
+        // had an online password oracle: send a guess and read which refusal
+        // comes back. The rate limiter allows 100 requests per second and resets
+        // its bucket each window, registration needs no invite, and CIDs are
+        // free, so there is no lockout to run into.
+        //
+        // It cannot simply be moved above the read, because the authorisation
+        // DEPENDS on the record: an unowned workspace is claimable by whoever
+        // presents the password, which is how the first administrator is
+        // established. So the order is read, authorise, then verify the secret --
+        // and a caller not entitled to update this workspace learns nothing
+        // about the password however many guesses they send.
+        //
+        // Still required, and for the bootstrap case it is the only thing
+        // standing between a stranger and an unclaimed workspace.
+        let passwords = self.backend_tx_manager.get_all_passwords().await?;
+        if !passwords
+            .get(workspace_id)
+            .map(|p| crate::kernel::secret_eq::secrets_match(p, &workspace_master_password))
+            .unwrap_or(false)
+        {
+            return Err(NetworkError::msg(
+                "Invalid workspace master access password",
+            ));
         }
 
         // Update fields

--- a/citadel-workspace-server-kernel/src/kernel/secret_eq.rs
+++ b/citadel-workspace-server-kernel/src/kernel/secret_eq.rs
@@ -38,12 +38,18 @@ mod tests {
 
     #[test]
     fn identical_secrets_match() {
-        assert!(secrets_match("correct horse battery staple", "correct horse battery staple"));
+        assert!(secrets_match(
+            "correct horse battery staple",
+            "correct horse battery staple"
+        ));
     }
 
     #[test]
     fn different_secrets_do_not_match() {
-        assert!(!secrets_match("correct horse battery staple", "correct horse battery stapla"));
+        assert!(!secrets_match(
+            "correct horse battery staple",
+            "correct horse battery stapla"
+        ));
     }
 
     #[test]

--- a/citadel-workspace-server-kernel/tests/a_wrong_password_is_not_an_oracle.rs
+++ b/citadel-workspace-server-kernel/tests/a_wrong_password_is_not_an_oracle.rs
@@ -1,0 +1,155 @@
+//! An unauthorised caller must learn nothing about the master password.
+//!
+//! `create_workspace` and `update_workspace` each checked the password FIRST and
+//! the caller's authority second, and the two failures return different strings:
+//!
+//!     "Invalid workspace master password"
+//!     "Only root workspace admins can create additional workspaces"
+//!
+//! So anyone who could reach the endpoint had an online password oracle. Send a
+//! guess, read which refusal comes back, and the answer says whether the guess
+//! was right. The rate limiter allows 100 requests per second and resets its
+//! bucket each window, registration needs no invite and CIDs are free, so there
+//! is no lockout to run into — and the reply is a boolean per attempt.
+//!
+//! The property asserted here is the one that closes it: for a caller who is
+//! not entitled to the operation, the answer is the SAME whether the password
+//! was right or wrong. Comparing the two refusals to each other is the test —
+//! not matching either against a fixed string, which would pass the moment
+//! somebody reworded one of them.
+//!
+//! `update_workspace` could not simply have its two checks swapped. Its
+//! authorisation depends on the record: an unowned workspace is claimable by
+//! whoever presents the password, which is how the first administrator is
+//! established. The order there is read, authorise, then verify the secret, and
+//! the bootstrap case is asserted below so that reordering cannot have quietly
+//! closed it.
+//!
+//! `delete_workspace` already checked authority first, and is asserted here too
+//! — it is the case that was always right, and if it ever stops being right
+//! this file should say so.
+
+use citadel_workspace_server_kernel::handlers::domain::async_ops::AsyncWorkspaceOperations;
+use citadel_workspace_types::structs::UserRole;
+use common::member_test_utils::{insert_user_with_role, join_root, GateKernel as Kernel};
+use common::workspace_test_utils::{create_test_kernel, TEST_ADMIN_PASSWORD};
+
+const WRONG: &str = "not-the-master-password";
+
+/// A member with no workspace-creating authority — the actor whose guesses must
+/// teach them nothing.
+async fn a_plain_member(kernel: &Kernel) -> &'static str {
+    insert_user_with_role(kernel, "outsider", UserRole::Member).await;
+    join_root(kernel, "outsider").await;
+    "outsider"
+}
+
+async fn try_create(kernel: &Kernel, actor: &str, password: &str) -> String {
+    kernel
+        .domain_operations
+        .create_workspace(actor, "probe", "", None, password.to_string())
+        .await
+        .err()
+        .map(|e| e.to_string())
+        .unwrap_or_else(|| "<succeeded>".to_string())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn creating_tells_an_unauthorised_caller_the_same_thing_either_way() {
+    let kernel = create_test_kernel().await;
+    let actor = a_plain_member(&kernel).await;
+
+    let with_wrong = try_create(&kernel, actor, WRONG).await;
+    let with_right = try_create(&kernel, actor, TEST_ADMIN_PASSWORD).await;
+
+    assert_ne!(
+        with_right, "<succeeded>",
+        "a plain Member must not be able to create a workspace at all",
+    );
+    assert_eq!(
+        with_wrong, with_right,
+        "the refusal differs by whether the password was right, which is an oracle:\n  \
+         wrong -> {with_wrong}\n  right -> {with_right}",
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn updating_tells_an_unauthorised_caller_the_same_thing_either_way() {
+    let kernel = create_test_kernel().await;
+    let actor = a_plain_member(&kernel).await;
+    let root = citadel_workspace_server_kernel::WORKSPACE_ROOT_ID;
+
+    let refuse = |password: &'static str| async move {
+        let kernel = create_test_kernel().await;
+        let actor = a_plain_member(&kernel).await;
+        kernel
+            .domain_operations
+            .update_workspace(
+                actor,
+                root,
+                Some("renamed"),
+                None,
+                None,
+                password.to_string(),
+            )
+            .await
+            .err()
+            .map(|e| e.to_string())
+            .unwrap_or_else(|| "<succeeded>".to_string())
+    };
+    let _ = actor;
+
+    let with_wrong = refuse(WRONG).await;
+    let with_right = refuse(TEST_ADMIN_PASSWORD).await;
+
+    assert_ne!(
+        with_right, "<succeeded>",
+        "a plain Member must not be able to rename the root workspace",
+    );
+    assert_eq!(
+        with_wrong, with_right,
+        "the refusal differs by whether the password was right, which is an oracle:\n  \
+         wrong -> {with_wrong}\n  right -> {with_right}",
+    );
+}
+
+// ---------- what must still work ----------
+//
+// Without these, a kernel that refused every one of these calls identically
+// would satisfy both assertions above and break workspace creation entirely.
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn an_entitled_caller_with_the_right_password_still_succeeds() {
+    let kernel = create_test_kernel().await;
+    insert_user_with_role(&kernel, "owner", UserRole::Owner).await;
+    join_root(&kernel, "owner").await;
+
+    kernel
+        .domain_operations
+        .create_workspace(
+            "owner",
+            "second",
+            "an additional workspace",
+            None,
+            TEST_ADMIN_PASSWORD.to_string(),
+        )
+        .await
+        .expect("an Owner holding the master password may create a workspace");
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn an_entitled_caller_with_the_wrong_password_is_still_refused() {
+    // The password did not stop mattering; it stopped being the FIRST thing
+    // checked. For someone who passes the authority gate it is the whole gate.
+    let kernel = create_test_kernel().await;
+    insert_user_with_role(&kernel, "owner", UserRole::Owner).await;
+    join_root(&kernel, "owner").await;
+
+    let refusal = try_create(&kernel, "owner", WRONG).await;
+
+    assert_ne!(refusal, "<succeeded>", "a wrong password must still refuse");
+    assert!(
+        refusal.contains("password"),
+        "and an entitled caller SHOULD be told it was the password: {refusal}",
+    );
+}


### PR DESCRIPTION
> **Stacked on [#106](https://github.com/Avarok-Cybersecurity/citadel-workspace/pull/106)** — it rewrites the same comparison lines, so this targets that branch rather than master. Merge #106 first and this retargets cleanly.

## The oracle

`create_workspace` and `update_workspace` each verified the password **first** and the caller's authority second. The two failures return different strings:

```
"Invalid workspace master password"
"Only root workspace admins can create additional workspaces"
```

So anyone who could reach either endpoint had an **online password oracle**: send a guess, read which refusal comes back, and the answer tells you whether the guess was right.

There is nothing to run into. The rate limiter allows **100 requests per second** and *resets its bucket each window*; registration needs no invite; CIDs are free. One boolean per attempt, 100 attempts a second, per account — and you can have as many accounts as you like.

## Two different fixes, because the two functions differ

**`create_workspace`** simply reorders: authorise, then verify.

**`update_workspace` could not.** Its authorisation *depends on the record it is about to change* — an unowned workspace is claimable by whoever presents the password, which is how the first administrator is established. Swapping the checks would have closed the bootstrap.

So the order there is **read → authorise → verify the secret**. The workspace read moved above the password check and stays inside the lock it already needed for the read-modify-write.

`delete_workspace` already did it in this order, and says so in its own comment. This is that fix applied to the two places that did not have it.

## The test compares the refusals to each other

Not to a fixed string. A fixed string would pass the moment somebody reworded one of them, and the property is that the two are **indistinguishable** — not that either is any particular text.

## Controls

With the original ordering restored:

| test | result |
|---|---|
| `creating_tells_an_unauthorised_caller_the_same_thing_either_way` | **FAILED** |
| `updating_tells_an_unauthorised_caller_the_same_thing_either_way` | **FAILED** |
| `an_entitled_caller_with_the_right_password_still_succeeds` | ok |
| `an_entitled_caller_with_the_wrong_password_is_still_refused` | ok |

Without that second pair, a kernel that refused every call identically would satisfy the oracle assertions and break workspace creation entirely. The fourth also asserts an entitled caller is *still told it was the password* — the password did not stop mattering, it stopped being the first thing checked.

## Verification

Full server-kernel suite on this branch: **352 passed, 0 failed**. `cargo fmt --all --check` clean.